### PR TITLE
Fixes #19: Do not use simplecov when running mutation testing

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,7 @@ require './spec/ci_helper'
 if ENV['TRAVIS']
   require 'coveralls'
   Coveralls.wear!
-else
+elsif !defined?(Mutant)
   require 'simplecov'
   SimpleCov.start do
     add_filter '/spec'


### PR DESCRIPTION
This cuts down mutation testing time by 5 seconds.