### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
+-
+
+### Changed
+-
+
+### Removed
+-
+
+
+## [0.3.0] - 2018-03-26
+### Added
 - Add YamlNormalizer::Ext::Nested to generate nested hash from namespaces key-value pairs
 - Add Codeclimate integration https://codeclimate.com/github/Sage/yaml_normalizer/
 
 ### Changed
-- Change flog method to :average, set threshhold to 7.7
+- Change flog method to :average, set threshold to 7.7
 - Reset default_proc before returning to app code
 - Open-source Yaml Normalizer at https://github.com/Sage/yaml_normalizer
 - Publish Yaml Normalizer on https://rubygems.org/gems/yaml_normalizer

--- a/lib/yaml_normalizer/version.rb
+++ b/lib/yaml_normalizer/version.rb
@@ -2,5 +2,5 @@
 
 module YamlNormalizer
   # The current Yaml Normalizer version
-  VERSION = '0.2.2'
+  VERSION = '0.3.0'
 end


### PR DESCRIPTION
## [0.3.0] - 2018-03-26
### Added
- Add YamlNormalizer::Ext::Nested to generate nested hash from namespaces key-value pairs
- Add Codeclimate integration https://codeclimate.com/github/Sage/yaml_normalizer/

### Changed
- Change flog method to :average, set threshold to 7.7
- Reset default_proc before returning to app code
- Open-source Yaml Normalizer at https://github.com/Sage/yaml_normalizer
- Publish Yaml Normalizer on https://rubygems.org/gems/yaml_normalizer
- Specify Ruby version "~> 2.4" in Gemfile
- Use warn instead of $stderr.puts
- Support sorting keys of different types

### Removed
- Remove Coveralls.io integration
