### PR TITLE
[yaml_normalizer] Added sanitizer to control the normalization

### DIFF
--- a/lib/yaml_normalizer/services/normalize.rb
+++ b/lib/yaml_normalizer/services/normalize.rb
@@ -40,7 +40,10 @@ module YamlNormalizer
 
       def normalize!(file)
         file = relative_path_for(file)
-        if stable?(input = read(file), norm = normalize_yaml(input))
+        input = read(file)
+        norm = normalize_yaml(input)
+        norm = sanitize_yaml(input, norm)
+        if stable?(input, norm)
           File.open(file, 'w') { |f| f.write(norm) }
           $stderr.print "[NORMALIZED] #{file}\n"
         else
@@ -52,6 +55,21 @@ module YamlNormalizer
         convert(yaml_a).each_with_index.all? do |a, i|
           a.namespaced.eql?(convert(yaml_b).fetch(i).namespaced)
         end
+      end
+
+      # Psych parser sometimes adds / removes whitespace at the end of the file which causes confising changes in the
+      # files - this sanitization it 
+      def sanitize_yaml(original, processed)
+        new_lines = processed.split("\n")
+        original_lines = original.split("\n")
+        indices = indices_to_correct(original_lines, new_lines)
+        indices.each { |index| new_lines[index] = original_lines[index] } if indices.size > 0
+        new_lines.join("\n") + "\n"
+      end
+
+      def indices_to_correct(original_lines, new_lines)
+        line_diffs = new_lines.each_with_index.select { |l, i| l != original_lines[i] }.map {|n, i| [n, original_lines[i], i]}
+        line_diffs.select {|l, k, i| k.end_with?(':') && l == k + ' '}.map(&:last)
       end
 
       def convert(yaml)

--- a/lib/yaml_normalizer/version.rb
+++ b/lib/yaml_normalizer/version.rb
@@ -2,5 +2,5 @@
 
 module YamlNormalizer
   # The current Yaml Normalizer version
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end

--- a/spec/data/real_life_sample.yml
+++ b/spec/data/real_life_sample.yml
@@ -1,0 +1,14197 @@
+---
+en:
+  SSO:
+    Error:
+      Message: "<p>There has been a problem.</p><p>If you cannot sign in, please email
+        <strong>sagebusinesscloudsupport@sage.com</strong> or call our Customer Service
+        Team on <strong>0845 111 6611 - UK</strong> or <strong>1890 812 811 - Ireland</strong></p>"
+    Password_Change:
+      Button: Continue
+  accounting_premium:
+    promotion_header:
+      button_message: Take the next step
+      message: Good work! Your growing business is ready to take the next step
+    trial_header:
+      button_message: Subscribe Today
+      message: You are currently in a trial
+  accounting_types:
+    accrual: Accrual (Recommended)
+    accrual_plain: Accrual
+    cash: Cash Based
+    description1: The accounting method defines when your business recognizes income
+      and expenses.
+    description2: Your profit, tax liability, and other values on reports are calculated
+      differently based on this selection.
+    help_link_text: Learn more
+    pod_title: Accounting Method
+    suffix:
+      accrual: accrual
+      cash_based: cash_based
+    title: Accounting Type
+  accounts_start_date:
+    non_opening_balance:
+      message: You cannot record entries prior to your Accounts Start Date of %{date}.
+    opening_balance:
+      message: You cannot record entries on or after your Accounts Start Date of %{date}.
+  actions:
+    advanced:
+      apply: Apply
+      bank_account:
+        connect: Connect to Bank
+        download_online: "%{transaction_count} New Transactions"
+        import_statement: Import Statement
+        new: Bank Account
+        reconcile: Reconcile
+        rules: Rules
+      bank_deposit:
+        new: Bank Deposit
+      cheque_register: Cheque Register
+      create: Create
+      create_new: Create New
+      invoicing:
+        add_corrective_invoice: Add Another Corrective Invoice
+        add_purchase_credit_note: Add Another Credit Note
+        add_purchase_invoice: Add Another Invoice
+        add_sales_credit_note: Add Another Credit Note
+        add_sales_estimate: Add Another Estimate
+        add_sales_invoice: Add Another Invoice
+        add_sales_quote: Add Another Quote
+        created_success: Great! %{artefact_type} Created
+        edited_success: Great! %{artefact_type} Edited
+        purchase_corrective_invoice: Corrective Invoice
+        purchase_credit_note: Credit Note
+        purchase_invoice: Invoice
+        sales_corrective_invoice: Corrective Invoice
+        sales_credit_note: Credit Note
+        sales_estimate: Estimate
+        sales_invoice: Invoice
+        sales_quote: Quote
+        settings_message: 'The following settings need to be entered by a user with
+          Full Access to Settings. Please ask your Supervisor or Accountant to enter
+          these: '
+        view_all_credit_notes: View All Credit Notes
+        view_all_estimates: View All Estimates
+        view_all_purchase_corrective_invoices: View All Corrective Invoices
+        view_all_purchase_invoices: View All Invoices
+        view_all_quotes: View All Quotes
+        view_all_sales_corrective_invoices: View All Corrective Invoices
+        view_all_sales_invoices: View All Invoices
+      new: New
+      new_entry: New Entry
+      opening_balances:
+        new: New Opening Balance
+      payment:
+        new: Purchase / Payment
+      quick_entry: New Quick Entry
+      quick_entry_import: Import Quick Entries
+      receipt:
+        new: Sale / Receipt
+      upload: Upload
+    advanced_uk:
+      analysis_type:
+        create: Create Analysis Type
+        delete: Delete Analysis Type
+      customer_opening_balance_entry:
+        new: New Opening Balance
+      journal_code:
+        new: Create Journal Code
+      on_save:
+        confirm_disputed: One or more of the selected items are in dispute. Recording
+          a payment will clear its disputed status.
+        confirm_disputed_and_pay_on_account: You have not allocated the full amount
+          of the receipt/payment and some of the items are disputed. Do you want to
+          save the unallocated amount as a payment on account and clear the disputed
+          status on these records?
+        confirm_pay_on_account: You have not allocated the full amount of the receipt/payment.  Do
+          you want to save the unallocated amount as a payment on account?
+        dialog_title: Confirm
+        edited_analysis: You have edited an analysis category that is in use, this
+          will update any items linked to this analysis type. Would you like to continue?
+        eu_tax_registered: EU VAT registered
+        rest_of_world: outside of the EU
+        vat_cash_mismatch: There is a mismatch between the net/VAT element of the
+          allocated items which may result in inaccuracies on your VAT return. Do
+          you want to save this allocation?
+        vat_cash_poa: To save a payment on account on the VAT Cash Accounting Scheme,
+          you must select the VAT Rate which applies to this receipt/payment.
+        vat_cash_poa_no_tax: VAT is not due on this payment on account as this contact
+          is %{status}.
+      purchase_batch_entry:
+        new: New Quick Entry
+      sales_batch_entry:
+        new: New Quick Entry
+      sales_invoice:
+        tax_inclusive: " [VAT Inclusive]"
+      supplier_opening_balance_entry:
+        new: New Opening Balance
+      tax_return:
+        calculate: Calculate
+        new: Create VAT Return
+        pay: Pay
+        reclaim: Reclaim
+    business_membership:
+      new: Invite User
+    calculate: Calculate
+    cancel: Cancel
+    change: Change
+    clone: Make a copy
+    continue: Continue
+    email: Email
+    export: Export
+    export_detailed: Export Detailed
+    filters: Filters
+    fuji_banking:
+      bank_account:
+        add: Add a new account
+        destroy: Are you sure you wish to delete this bank account?
+        edit: Edit Bank Account
+        manage: Manage Bank Accounts
+        new: New Bank Account
+        new_account_dialog:
+          save_and_connect: Save & Connect Bank
+          save_and_dont_connect: Save
+          title: Add Account
+        pay_into_bank: Pay into Bank
+      bank_transfer:
+        new: Bank Transfer
+      deposits:
+        choose_account: Select Bank Account
+        close: Close
+        select: Select
+      updated_credentials: Credentials updated successfully.
+    fuji_contacts/contact:
+      add_account_name: Add an Account Name
+      add_account_number: Add an Account Number
+      add_bank_transit_number: Add a Transit Number
+      add_bic: Add a BIC/Swift
+      add_iban: Add an IBAN
+      add_institution_number: Add an Institution Number
+      add_sort_code: Add a Sort Code
+      clear: Clear
+      csv: Export to CSV file
+      delete_activity:
+        title: Confirm deletion of Contact Activity
+      delete_address:
+        additional_message: 'This will also delete the following individuals associated
+          with this address: %{namesToDelete}'
+        title: Delete Address
+      delete_contact:
+        message: Are you sure you'd like to delete this contact?
+        title: Delete Contact
+      delete_message: Are you sure you wish to continue?
+      email: Email
+      fr_tax_calculation:
+        options:
+          cash: Payments
+          invoice: Invoices
+        title: VAT is calculated on
+      manage: Manage
+      manage_account_allocation: Account Allocation
+      manage_statement: Manage Statement
+      manage_statements: Statements
+      pdf: Print
+      prompt:
+        none: None
+      recargo:
+        options:
+          disabled: 'No'
+          enabled: 'Yes'
+        title: Equivalence Surcharge
+      send_monthly_statement: Send Monthly Statement
+    fuji_contacts/customer:
+      default_addresses: Statement Addresses/Contacts
+      reports:
+        activity_report:
+          subtitle: Select the date range for your customer activity report
+          title: Activity Report
+        address_list:
+          subtitle: Select the address type(s) to display on this report
+          title: Address List
+        statement_summary:
+          subtitle: Select the date range for your statement summary report
+          title: Statement Summary Report
+        statements_batch:
+          back_button: Back
+          beta_print_limit: "(max %{count} in Beta)"
+          button: Create Statements
+          confirmation_description:
+            one: We'll generate statements for __%{count}__ customer who has more
+              than __%{threshold}__ outstanding. You're owed __%{total_balance} in
+              total__ and the statement date is __%{date}__.
+            other: We'll generate statements for __%{count}__ customers who each have
+              more than __%{threshold}__ outstanding. You're owed __%{total_balance}
+              in total__ and the statement date is __%{date}__.
+          confirmation_email:
+            one: __%{count}__ statement will be emailed.
+            other: __%{count}__ statements will be emailed.
+          confirmation_email_info: __%{count}__ will be emailed to customers.
+          confirmation_print:
+            one: __%{count}__ statement to print & post.
+            other: __%{count}__ statements to print & post.
+          confirmation_print_info: __%{count}__ will be downloadable from the top
+            bar.
+          date: Produce statement as of
+          feedback: Let us know what you think of this feature in the top bar.
+          generate_button: Generate
+          link: Statement Run
+          next_button: Next
+          no_results: As at %{date} there were no customers with an outstanding amount
+            over %{amount}.
+          no_results_description: Based on the previous page's criteria and your customer
+            profile settings; there were no statements to generate.
+          no_results_try_again: Go back and adjust the criteria, or try sending statements
+            another time.
+          popover:
+            body: Send statements to lots of customers in one go. You can choose print
+              or email for each customer in their profile options.
+            button: Got it
+            title: Customer Statements
+          report_in_progress: Please wait until your previous statement run has finished
+            generating before starting a new one.
+          subtitle: 'Generate customer statements for all your customers based on
+            their settings and the following criteria:'
+          threshold_amount: Outstanding amount over
+          title: Customer Statement Run
+          toast_error_message: An unexpected error occurred. Please try again later.
+          toast_error_title: Error generating statements
+          toast_info_message: You can carry on working whilst we're doing this, or
+            even log out and check back later.
+          toast_info_title:
+            one: Generating %{count} statement
+            other: Generating %{count} statements
+          tooltip: Invoices paid after the Statement Date will still be included
+        title: Reports
+      send_monthly_statement: Schedule Monthly Statements
+      statement_delivery_method:
+        statement_delivery_method_email: Sent by email
+        statement_delivery_method_print: By post (PDF Generated)
+      submit: Submit
+    fuji_contacts/supplier:
+      default_addresses: Remittance Addresses
+      new: New Supplier
+      reports:
+        activity_report:
+          subtitle: Select the date range for your supplier activity report
+          title: Activity Report
+        address_list:
+          subtitle: Select the address type(s) to display on this report
+          title: Address List
+        title: Reports
+    fuji_core_accounting/coa_account:
+      new: Create COA Account
+    fuji_core_accounting/coa_templates:
+      edit: Edit Template
+      index:
+        ie: Irish COA Templates
+        uk: UK COA Templates
+        us: US COA Templates
+    fuji_core_accounting/tax_periods:
+      manage_tax_periods: Manage Periods
+      new: Add Period
+    fuji_core_accounting/tax_rates:
+      new: Add Tax Rate
+    fuji_invoicing/purchase_corrective_invoice:
+      clear_dispute: Clear Dispute
+      dispute: Set as Disputed
+      manage_invoice: Manage Corrective Invoice
+    fuji_invoicing/purchase_credit_note:
+      clear_dispute: Clear Dispute
+      dispute: Set as Disputed
+      manage_credit_note: Manage Credit Note
+    fuji_invoicing/purchase_invoice:
+      clear_dispute: Clear Dispute
+      create_corrective_invoice: Create Corrective Invoice
+      create_credit_note: Create Credit Note
+      dispute: Set as Disputed
+      manage_invoice: Manage Invoice
+    fuji_invoicing/sales_corrective_invoice:
+      manage_invoice: Manage Corrective Invoice
+      print_delivery_note: Print Delivery Note
+      refund_dialog:
+        panel:
+          bank_account: Paid from Bank Account
+          reference: Reference (optional)
+          refund_date: Refund Date
+          tax_rate: Tax Rate
+        radio_buttons:
+          refund:
+            text: " - Money is returned to the customer."
+            title: Refund payment
+          unallocate:
+            text: " - Detach the payment from this corrective invoice, and record
+              as a payment on account."
+            title: Unallocate
+        title: 'Amend Customer Receipt: %{paid_amount}'
+      tabs:
+        all: All
+        draft: Draft
+        outstanding: Outstanding
+        overdue: Overdue
+        paid: Paid
+    fuji_invoicing/sales_credit_note:
+      manage_credit_note: Manage Credit Note
+    fuji_invoicing/sales_estimate:
+      create_invoice: Create Invoice
+      decline: Set as Declined
+      manage_quote: Manage Estimate
+      new: New Estimate
+      undecline: Clear Declined
+    fuji_invoicing/sales_invoice:
+      create_corrective_invoice: Create Corrective Invoice
+      create_credit_note: Create Credit Note
+      manage_invoice: Manage Invoice
+      print_delivery_note: Print Delivery Note
+      refund_dialog:
+        panel:
+          bank_account: Paid from Bank Account
+          reference: Reference (optional)
+          refund_date: Refund Date
+          tax_rate: Tax Rate
+        radio_buttons:
+          refund:
+            text: " - Money is returned to the customer."
+            title: Refund payment
+          unallocate:
+            text: " - Detach the payment from this invoice, and record as a payment
+              on account."
+            title: Unallocate
+        title: 'Amend Customer Receipt: %{paid_amount}'
+      tabs:
+        all: All
+        draft: Draft
+        outstanding: Outstanding
+        overdue: Overdue
+        paid: Paid
+    fuji_invoicing/sales_quote:
+      create_invoice: Create Invoice
+      decline: Set as Declined
+      manage_quote: Manage Quote
+      undecline: Clear Declined
+    hide: Hide
+    more: More
+    new_account: New Account
+    new_corrective_invoice_purchase: New Corrective Invoice
+    new_corrective_invoice_sales: New Corrective Invoice
+    new_credit_note_purchase: New Credit Note
+    new_credit_note_sales: New Credit Note
+    new_invoice_purchase: New Invoice
+    new_invoice_sales: New Invoice
+    new_quote_sales: New Quote
+    ok: OK
+    pdf: Print
+    refresh: Refresh
+    remove: Remove
+    reset: Reset
+    save: Save
+    save_add_new: Save & Add New
+    save_artefact_type: Save %{artefact_type}
+    save_as_draft: Save as Draft
+    save_new: Save & New
+    save_pay: Save & Pay Now
+    save_print: Save & Print
+    save_send: Save & Email
+    search: Search
+    send: Send
+    seperator: " | "
+    sop_admin/super:
+      admin:
+        actions: Manage
+        index: Manage tax periods
+        index2:
+          tax_periods:
+            ie: Manage Irish Tax Periods
+            uk: Manage UK Tax Periods
+    sop_settings/user_management:
+      new: Create
+    update: Update
+    user_management:
+      resend_invitation: Resend invitation
+    vat_adjustments: Ajustes del IVA
+    vat_adjustments_button_text: Entendido!
+    vat_adjustments_description_1: Los ajustes no se reflejarán en las transacciones
+      de Sage One.
+    vat_adjustments_description_2: Si aún no te has ocupado de estos ajustes, por
+      ejemplo, no están relacionados con un sistema anterior, debes registrar las
+      entradas de diario manuales para asegurarte de que cualquier aumento o disminución
+      de la obligación de IVA se refleje en tus cuentas.
+    verify: Verify
+    view: view
+    view_all: View All
+    wizard:
+      advanced_uk/quickstart:
+        telephone_help: "<b>Need help?</b><br>Call 0845 1111 6611"
+      fuji_banking/bank_reconciliation:
+        steps:
+          first_step:
+            cancel: Exit Bank Reconciliation
+            next: Reconcile Entries
+          second_step:
+            cancel: Exit Bank Reconciliation
+            finish: Save for Later
+            prev: Change Reconciliation Details
+      mysageone_core/mobile/signup:
+        steps:
+          business_address:
+            finish: Continue
+  activation:
+    resend:
+      message: Would you like to resend the activation email to {{business}}?
+      title: Resend Activation?
+  activemodel:
+    attributes:
+      advanced_uk/quick_start:
+        accounts_start_date: When will you start using Sage Business Cloud Accounting?
+        business_address_registered: The same address is registered with Companies
+          House.
+        business_classification: What does your business do?
+        business_county: County
+        business_name: Business Name
+        business_phone_number: Telephone
+        business_postcode: Postcode
+        business_province: Province
+        business_registered_county: County
+        business_registered_postcode: Postcode
+        business_registered_street_1: Address 1
+        business_registered_street_2: Address 2
+        business_registered_town: Town / City
+        business_start_date: When did your business officially start?
+        business_street_1: Address 1
+        business_street_2: Address 2
+        business_town: Town / City
+        business_type: Type of Business
+        disable_business_start_date: My business hasn't started yet, or I'm not sure
+          of the date.
+        financial_year_end_date: When is the last day of your financial year?
+        flat_rate_scheme: I use the Flat Rate Scheme from HMRC.
+        purchase_tax_calculation_method: Purchases
+        sales_tax_calculation_method: Sales
+        tax_calculation_method: VAT Calculation Method
+        tax_scheme: Tax Scheme
+        vat_number: VAT Number
+        vat_rate: Flat Rate
+      fuji_support/email:
+        send_bcc: Send a copy to myself?
+      sop_authentication/signup:
+        business_name: Business Name
+        business_telephone: Telephone
+        user_email: Email
+        user_first_name: First Name
+        user_last_name: Last Name
+      sop_authentication/signup_full:
+        business_city: City
+        business_country: Country
+        business_county: County
+        business_mobile: Mobile
+        business_name: Business Name
+        business_postcode: Postcode
+        business_street_1: Address 1
+        business_street_2: Address 2
+        business_telephone: Telephone
+        business_website: Website
+        user_email: Email
+        user_first_name: First Name
+        user_last_name: Last Name
+      sop_settings/invitation_signup:
+        user_first_name: First Name
+        user_last_name: Last Name
+    errors:
+      models:
+        fuji_banking/bank_interest_and_charges:
+          attributes:
+            bank_charge_date:
+              before_statement_end_date: must be before the statement end date
+            bank_interest_date:
+              before_statement_end_date: must be before the statement end date
+            bank_interest_earned_date:
+              before_statement_end_date: must be before the statement end date
+            base:
+              cannot_add_transactions_before_accounts_opening_balance: You cannot
+                enter interest or charges dated before the accounts opening balance
+                date
+        fuji_support/email:
+          attributes:
+            message:
+              invalid_message: Contains invalid characters.
+  activerecord:
+    attributes:
+      addresses/models/address:
+        address_type_form_proxy_id: Address Type
+        cc: Cc
+        country_id: Country
+        customer_name: Customer Name
+        delivery_address: Delivery Address
+        end_date: To
+        invoice_address: Invoice Address
+        line_1: Address 1
+        line_2: Address 2
+        line_3: Town/City
+        line_4: County
+        main: Main
+        main_address_name: Main Address
+        message: Message
+        name: Address Name
+        new_address_name: New Address
+        new_contact_name: New Contact
+        postcode: Postcode
+        second_address_name: Address 2
+        start_date: From
+        supplier_name: Supplier Name
+        to: To
+      advanced_uk/address_contact:
+        name: Full Name
+        reference: Reference
+        role: Job Title
+        sort_code: Sort Code
+        supplier_credit_days: Supplier Credit (days)
+        terms_and_conditions: Invoice Terms & Conditions
+      advanced_uk/audit_trail:
+        bank_reconciled: Bank Reconciled
+        by: Created By
+        cr: Credit
+        cr_formatted: Credit
+        created_at: Entry Date
+        date: Trx Date
+        dr: Debit
+        dr_formatted: Debit
+        invoice_number: Invoice Number
+        ledger_account_name: Ledger Account
+        name: Name
+        reference: Ref
+        removed: Deleted
+        tax_reconciled: VAT Reconciled
+        transaction_type: Type
+        who: User
+      advanced_uk/audit_trail_summary:
+        bank_reconciled: Bank Reconciled
+        business_accrual_transaction_id: Trans ID
+        business_cash_based_transaction_id: Trans ID
+        by: Created By
+        created_at: Entry Date
+        date: Trx Date
+        invoice_number: Invoice Number
+        name: Name
+        net: Net
+        reference: Ref
+        removed: Deleted
+        retailer_tax_amount: Recargo
+        tax: VAT
+        tax_reconciled: VAT Reconciled
+        total: Total
+        transaction_type_id: Type
+        who: User
+      advanced_uk/bank_opening_balance:
+        account_number: Account Number
+        amount: Opening Balance
+        bank_account_id: Bank Account
+        base: ''
+        date: Date
+        reference: Reference
+        sort_code: Sort Code
+      advanced_uk/batch:
+        grand_total: Total Amount
+        net_amount: Total Net Amount
+        tax_amount: Total VAT Amount
+      advanced_uk/batch_entry:
+        batch_entry_details: Details
+        batch_entry_ledger_account_id: Ledger Account
+        batch_entry_number: Transaction Number
+        batch_entry_number_prefix: QE-
+        batch_entry_type_id: Type
+        credit_note:
+          abbr_type: QE-Crn
+        credit_note_opening_balance:
+          abbr_type: OB-Crn
+        currency_total: Total
+        currency_total_net_amount: Net
+        currency_total_tax_amount: VAT
+        customer: Customer
+        date: Date
+        details: Details
+        invoice:
+          abbr_type: QE-Inv
+        invoice_opening_balance:
+          abbr_type: OB-Inv
+        is_purchase_for_resale: Resale
+        opening_balance:
+          artefact_number_prefix: OB-
+        reference: Reference
+        tax_rate_id: VAT Rate
+        total: Total
+        total_for_grid: Total
+        total_net_amount: Net
+        total_net_amount_for_grid: Net
+        total_tax_amount: VAT
+        total_tax_amount_for_grid: VAT
+        trade_of_asset: Outside Flat Rate
+      advanced_uk/catalog_item:
+        active: Active
+        adjust:
+          below_reorder_level: This takes your stock below re-order level
+          cost_price: Cost Price
+          date: Date
+          decrease_by: Decrease By
+          decrease_quantity: Decrease Quantity
+          default_reasons:
+            item_damaged: Item damaged
+            item_returned: Item returned
+            item_written_off: Item written off
+            other: Other
+            stock_take: Stock take adjustment
+          delete_disabled_accounts_lockdown_date: You can't delete this Adjustment
+            as it is dated on or before your year-end lock date.
+          delete_disabled_inactive: You can't delete this Adjustment as your stock
+            item is inactive.
+          delete_disabled_negative_stock: You can't delete this Adjustment as it would
+            result in negative stock.
+          increase_by: Increase By
+          increase_quantity: Increase Quantity
+          item: Stock Item
+          new_quantity_in_stock: New Quantity in Stock
+          quantity_in_stock: Quantity in Stock
+          reason: Reason
+          reference: Stock Adjustment
+          stock_below_zero: You can't adjust your stock level below zero
+          subtitle: Increase or decrease your stock levels without buying or selling.
+          subtitle_edit: Make a change to an existing stock adjustment.
+          successful: Stock level adjusted successfully
+          title: Adjust Stock Level
+          title_edit: Edit Adjustment
+          type: Type
+        analysis_type_0_formatted: Analysis Type 1
+        analysis_type_1_formatted: Analysis Type 2
+        analysis_type_2_formatted: Analysis Type 3
+        category: Category
+        category_as_string: Category
+        cost_price: Cost Price
+        create:
+          additional_information: Additional Information
+          as_of_date: As of Date
+          barcode: Barcode
+          category: Category
+          cost_price: Cost Price
+          cost_price_at_date: Cost Price at Date
+          create: New Item
+          default_measurement_unit_copy: We'll set this as your default measurement
+            unit. You can change it in Settings.
+          default_purchase_copy: We'll set this as your default purchase account.
+            You can change it in Settings.
+          errors:
+            messages:
+              item_type: Please select an item type.
+          existing_stock_on_hand: I have existing stock on hand
+          i_buy_this_item: I Buy This Item
+          i_sell_this_item: I Sell This Item
+          inactive: Inactive
+          includes_vat_question: Includes VAT?
+          item: Item
+          item_code: Item Code
+          item_description: Item Description
+          item_information: Item Information
+          item_tracking: Item Tracking
+          location: Location
+          no_category_copy: You can create Categories from the Products & Services
+            list.
+          none: None
+          notes: Notes
+          opening_balance: Opening Balance
+          opening_balance_failed: Item created successfully but there was a problem
+            saving your Opening Balance. Please reenter your Opening Balance via a
+            manual adjustment.
+          please_select: Please select
+          price: Price (%{currency_symbol})
+          price_name: Price Name
+          product:
+            heading: Non-stock
+            info: Quantities are not tracked
+          purchase_account: Purchase Account
+          purchase_description: Purchase Description
+          quantity_on_hand: Quantity on Hand
+          rate: Rate (%{currency_symbol})
+          rate_frequency: Frequency
+          rate_name: Rate Name
+          rates: Rates
+          reorder_level: Reorder Level
+          reorder_quantity: Reorder Quantity
+          sales_account: Sales Account
+          sales_prices: Sales Prices
+          select_type: Select a Type
+          service:
+            heading: Service
+            info: Services you buy and sell
+          stock: Stock
+          stock_item:
+            heading: Stock
+            info: Quantities in and out are tracked
+          subtitle: Create any items that your business buys or sells.
+          successful: Item Created
+          supplier_part_number: Supplier Item Code
+          title: Create an Item
+          unsuccessful: Item not created
+          usual_supplier: Usual Supplier
+          vat_rate: VAT Rate
+          weight: Weight
+        dashboard:
+          items:
+            one: Item
+            other: Items
+        description: Description
+        edit:
+          subtitle: Make changes to this item's details or values
+          title: Edit Item
+        item_code: Code
+        item_code_taken: This code is already taken. Please try another.
+        ledger_account_id: Ledger Account
+        movement:
+          cost_price: Cost Price
+          date: Date
+          details: Details
+          end_date: To
+          movement_number: No.
+          quantity_in: In
+          quantity_out: Out
+          reference: Reference
+          sales_price: Sales Price
+          start_date: From
+          transaction_type: Transaction Type
+          type: Type
+        object_type_formatted: Type
+        period_rate_price: Rate
+        period_rate_price_2: Rate 2
+        period_rate_price_3: Rate 3
+        period_type: Rate Frequency
+        product: Non-stock
+        purchase_ledger_account_id: Purchase Ledger Account
+        purchase_tax_rate_id: Purchase VAT Rate
+        quantity_in_stock: Quantity in Stock
+        reorder_level: Reorder Level
+        reorder_warning: Item is below reorder level
+        sales_price: Sales Price
+        sales_price_2: Sales Price 2
+        sales_price_3: Sales Price 3
+        service: Service
+        stock_item: Stock
+        tax_rate_id: VAT Rate
+        type: Type
+        view:
+          activity: Activity
+          adjust: Adjust Stock Level
+          average_cost: Average Cost
+          barcode: Barcode
+          category: Category
+          cost_price: Cost Price
+          includes_vat: Includes VAT
+          item_code: Item Code
+          item_description: Item Description
+          item_details: Item Details
+          item_information: Item Information
+          last_cost_price: Last Cost Price
+          last_purchase: Last Purchase
+          last_sale: Last Sale
+          location: Location
+          notes: Notes
+          prices: Prices (%{unit})
+          purchase_account: Purchase Account
+          purchase_description: Purchase Description
+          purchases: Purchases
+          quantity_in_stock: Quantity In Stock
+          rates: Rates (%{unit})
+          reorder_level: Reorder Level
+          reorder_quantity: Reorder Quantity
+          sales: Sales
+          sales_account: Sales Account
+          sales_and_purchases: Sales and Purchases
+          sales_price: Sales Price
+          stock_levels: Stock Levels
+          supplier: Supplier
+          supplier_code: Supplier Item Code
+          usual_supplier: Usual Supplier
+          vat_rate: VAT Rate
+          weight: Weight
+      advanced_uk/category:
+        category_name: Category Name
+        name: Name
+        subcategory: Make a sub-category
+      advanced_uk/contact_activity:
+        csv_download: CSV of List
+        date: Date
+        discount_amount: Discount
+        exchange_variance: Variation Change
+        exchange_variance_abbr: Exch. Variance
+        net: Net
+        outstanding_amount: Outstanding
+        pdf_download: PDF of Invoices
+        pdf_email: Email PDF of Invoices
+        pdf_print: Print List
+        reference: Number
+        tax: VAT
+        total_amount: Total
+        type: Type
+        user_reference: Reference
+      advanced_uk/customer_allocation:
+        display: Display
+        left_to_allocate: Left to Allocate
+      advanced_uk/customer_income_payment:
+        bank_account: Paid into Bank Account
+        bank_account_id: Paid into Bank Account
+        contact_balance: This customer has %{value} outstanding.
+        currency_charge: Currency Charges
+        currency_total_amount: Amount Received
+        date: Date Received
+        display: Display
+        exchange_rate: Exchange Rate
+        is_cheque: Paid by cheque
+        left_to_allocate: Left to allocate
+        name: Customer
+        reference: Reference (optional)
+      advanced_uk/customer_opening_balance_entry:
+        exchange_rate: Exchange Rate
+      advanced_uk/customer_refund_payment:
+        bank_account_id: "Paid from \n Bank Account"
+        contact_balance: This customer has %{value} outstanding.
+        currency_charge: Currency Charges
+        currency_total_amount: Amount Refunded
+        date: Date Refunded
+        display: Display
+        left_to_allocate: Left to allocate
+        name: Customer
+        print: Print Remittance
+        reference: Reference (optional)
+        voided_by: Voided payments
+      advanced_uk/data_import:
+        data_import_format_id: CSV Format
+      advanced_uk/datev_export_settings:
+        name: Datev Export Settings
+        next_creditor_number: Creditor Number
+        next_debtor_number: Debtor Number
+      advanced_uk/day_book_entry:
+        contact_name: Name
+        date: Date
+        description: Description
+        ledger_account: Ledger Account
+        net: Net
+        reference: Ref
+        tax: VAT
+        tax_number: Vat No.
+        total: Total
+        transaction_number: Trx No
+        transaction_type: Type
+        vat_rate: VAT Rate
+      advanced_uk/default_settings:
+        customer_credit_days: Days before invoices overdue
+        invoice_purchase_discount_ledger_account: Purchase Discount Ledger Account
+        invoice_purchase_ledger_account: Purchase Ledger Account
+        invoice_sales_discount_ledger_account: Sales Discount Ledger Account
+        invoice_sales_ledger_account: Sales Ledger Account
+        name: Record and Transactions Settings
+        supplier_credit_days: Days before invoices overdue
+      advanced_uk/email_defaults:
+        message: Default Email Message
+      advanced_uk/journal_code:
+        code: Code
+        country_journal_type_id: Journal Type
+        name: Name
+      advanced_uk/journal_opening_balance:
+        date: Date
+      advanced_uk/journal_opening_balance_line:
+        credit: Credit
+        debit: Debit
+        ledger_account_id: Ledger Account
+        line_detail: Details
+      advanced_uk/monthly_statement:
+        cc: Cc
+        day_of_month: Email statements monthly on day
+        email_enabled: Enable Monthly Statement
+        exclude_zero_balances: Exclude zero balances
+        message: Message
+        to: To
+      advanced_uk/nominal_activity:
+        cr: Credit
+        display_name: Ledger Account
+        dr: Debit
+        invoice_number: Invoice Number
+        ledger_account_formatted: Ledger Account
+        running_total: Running Total
+        total: Total
+        transaction_type: Type
+      advanced_uk/other_expense_payment:
+        calculated_total_amount: Total
+        contact_balance: You owe this supplier %{value}.
+        currency_total_amount: Amount Paid
+        date: Date Paid
+        left_to_allocate: Left to record
+        name: Supplier (optional)
+        net_value: Total Net
+        reference: Reference (optional)
+        tax_value: Total VAT
+        voided_by: Voided payments
+      advanced_uk/other_expense_payment/line_items:
+        tax_rate_id: VAT Rate
+      advanced_uk/other_expense_payment_refund:
+        bank_account: Paid into Bank Account
+        bank_account_id: Paid into Bank Account
+        contact_balance: You owe this supplier %{value}.
+        currency_total_amount: Amount Received
+        date: Date Received
+      advanced_uk/other_income_payment:
+        bank_account: Paid into Bank Account
+        bank_account_id: Paid into Bank Account
+        calculated_total_amount: Total
+        contact_balance: This customer has %{value} outstanding.
+        currency_total_amount: Amount Received
+        customer_name: Name
+        date: Date Received
+        is_cheque: Paid by cheque
+        left_to_allocate: Left to record
+        name: Customer (optional)
+        net_value: Total Net
+        reference: Reference (optional)
+        tax_value: Total VAT
+      advanced_uk/other_income_payment/line_items:
+        tax_rate_id: VAT Rate
+      advanced_uk/other_income_payment_refund:
+        bank_account: Paid from Bank Account
+        bank_account_id: Paid from Bank Account
+        contact_balance: You owe this supplier %{value}.
+        currency_total_amount: Amount Paid
+        date: Date Paid
+      advanced_uk/payment:
+        bank_account: Paid from Bank Account
+        bank_account_balance: Balance
+        bank_account_id: Paid from Bank Account
+        contact_balance: Owed
+      advanced_uk/payment_line_item:
+        description: Details
+        is_purchase_for_resale: Resale
+        ledger_account_id: Ledger Account
+        tax_rate_id: VAT Rate
+        total_amount: Total
+        total_net_amount: Net
+        total_tax_amount: VAT Amount
+        trade_of_asset: Outside Flat Rate
+      advanced_uk/payment_on_account:
+        abbr_type: On Acct
+      advanced_uk/payroll_settings:
+        bank_account: Default Payroll Bank Account
+        bank_account_id: Default Payroll Bank Account
+        name: Payroll Integration Settings
+        post_net_wages_to_liability: 'Post Employee Net Wages:'
+      advanced_uk/product:
+        active: Active
+        analysis_type_0_formatted: Analysis Type 1
+        analysis_type_1_formatted: Analysis Type 2
+        analysis_type_2_formatted: Analysis Type 3
+        cost_price: Cost Price
+        description: Description
+        item_code: Code
+        ledger_account: Ledger Account
+        ledger_account_id: Ledger Account
+        purchase_defaults: Purchase Defaults
+        purchase_ledger_account: Purchase Ledger Account
+        purchase_ledger_account_id: Purchase Ledger Account
+        purchase_tax_rate_id: Purchase VAT Rate
+        sales_defaults: Sales Defaults
+        sales_price: Sales Price
+        sales_price_2: Sales Price 2
+        sales_price_3: Sales Price 3
+        tax_rate_id: VAT Rate
+      advanced_uk/product_price:
+        in_use: In Use
+        name: Price Name
+        name_with_message: Price Name* (last entry cannot be deleted/inactive)
+        price: Price
+        price_includes_tax: Includes VAT?
+      advanced_uk/purchase_artefact:
+        artefact_status: Status
+        artefact_status_id: Status
+        contact_name: Supplier
+        contact_reference: Contact Reference
+        corrective: Corrective
+        currency_code: Currency
+        currency_outstanding: Outstanding
+        currency_outstanding_with_sign: Outstanding
+        currency_total_net_amount_with_sign: Net Amount
+        currency_total_tax_amount_with_sign: VAT Amount
+        date: Date
+        due_date: Due Date
+        extra_reference: Supplier Reference
+        main_address_postcode: Postcode
+        main_contact_email: Email
+        main_contact_name: Contact Name
+        main_contact_telephone: Telephone
+        outstanding: Outstanding
+        overdue: Overdue
+        purchase_artefact_currency_total_formatted: Total
+        raised_by_user: Who
+        raised_by_user_id: Created By
+        raised_by_user_initials: User
+        reference: Reference
+        total: Total
+      advanced_uk/purchase_batch/entries:
+        tax_rate_id: VAT Rate
+      advanced_uk/purchase_batch_entry:
+        contact_id: Supplier
+        contact_name: Supplier
+      advanced_uk/purchase_day_book_entry:
+        contact_name: Name
+        contact_name_for_csv: Contact Name
+        contact_reference: Contact Reference
+        date: Date
+        details: Details
+        invoice_no: Invoice No.
+        invoice_number: Invoice Number
+        name: Name
+        net: Net
+        reference: Ref
+        tax: VAT
+        tax_number: VAT Registration No
+        total: Total
+        transaction_number: Trx No
+        transaction_type: Type
+      advanced_uk/purchase_payable_artefact:
+        abbr_type: Type
+        amount_paid: Paid
+        currency_discount: Discount
+        currency_outstanding_with_sign: Outstanding
+        date: Date
+        exchange_rate: Exchange Rate
+        exchange_rate_formatted: Exchange Rate
+        extra_reference: Number
+        max_records_warning: There are more than 1000 unallocated items for this contact
+          - the oldest are listed below. Allocate payments to the items shown, save
+          your changes, and view this page again to work through more.
+        purchase_artefact_currency_total_formatted: Total
+        reference: Reference
+      advanced_uk/sage_pay_vendor:
+        bank_account: Bank A/C
+        bank_account_id: Bank A/C
+        contact_id: Default Customer
+        default_contact: Default Customer
+        default_ledger_account_id: Default Ledger Account
+        default_surcharge_ledger_account_id: Surcharge Ledger Account
+        enable_ecommerce: Ecommerce Enabled?
+        enable_moto: MOTO Payments Enabled?
+        enable_pay_now: Pay Now Payments Enabled?
+        encryption_password: Encryption Password
+        name: Sage Pay Settings
+        password: Password
+        user_name: User Name
+        vendor_name: Vendor Name
+      advanced_uk/sales_artefact:
+        artefact_number_formatted: Number
+        artefact_status_id: Status
+        contact_name: Customer
+        contact_reference: Contact Reference
+        corrective: Corrective
+        currency_code: Currency
+        currency_outstanding: Outstanding
+        currency_outstanding_with_sign: Outstanding
+        currency_total_net_amount_with_sign: Net Amount
+        currency_total_tax_amount_with_sign: VAT Amount
+        date: Date
+        discount: Discount
+        due_date: Due Date
+        issued: Issued
+        main_address_postcode: Postcode
+        main_contact_email: Email
+        main_contact_name: Contact Name
+        main_contact_telephone: Telephone
+        outstanding: Outstanding
+        overdue: Overdue
+        paid: Paid
+        raised_by_user: Who
+        raised_by_user_id: Created By
+        raised_by_user_initials: User
+        reference: Reference
+        sales_artefact_currency_total_formatted: Total
+        total: Total
+      advanced_uk/sales_batch/entries:
+        tax_rate_id: VAT Rate
+      advanced_uk/sales_batch_entry:
+        contact_id: Customer
+        contact_name: Customer
+      advanced_uk/sales_day_book_entry:
+        contact_name: Name
+        contact_name_for_csv: Contact Name
+        contact_reference: Contact Reference
+        date: Date
+        details: Details
+        invoice_number: Invoice Number
+        net: Net
+        reference: Ref
+        retailer_amount: RE
+        tax: VAT
+        tax_number: VAT Registration No
+        total: Total
+        transaction_number: Trx No
+        transaction_type: Type
+      advanced_uk/sales_payable_artefact:
+        abbr_type: Type
+        amount_paid: Paid
+        artefact_number_formatted: Number
+        currency_discount: Discount
+        currency_outstanding_with_sign: Outstanding
+        date: Date
+        exchange_rate: Exchange Rate
+        exchange_rate_formatted: Exchange Rate
+        reference: Reference
+        sales_artefact_currency_total_formatted: Total
+      advanced_uk/service:
+        active: Active
+        analysis_type_0_formatted: Analysis Type 1
+        analysis_type_1_formatted: Analysis Type 2
+        analysis_type_2_formatted: Analysis Type 3
+        description: Description
+        item_code: Code
+        ledger_account: Ledger Account
+        ledger_account_id: Ledger Account
+        period_rate_price: Rate
+        period_rate_price_2: Rate 2
+        period_rate_price_3: Rate 3
+        period_rate_price_includes_tax: Rate Includes VAT
+        period_type: Rate Frequency
+        period_type_id: Rate Frequency
+        tax_rate_id: VAT Rate
+      advanced_uk/service_rate:
+        in_use: In Use
+        name: Rate Name
+        name_with_message: Rate Name (last entry cannot be deleted/inactive)
+        period_type_id: Rate Frequency
+        price: Rate
+        price_includes_tax: Includes VAT?
+      advanced_uk/supplier_allocation:
+        display: Display
+        left_to_allocate: Left to allocate
+      advanced_uk/supplier_expense_payment:
+        bank_account: Paid from Bank Account
+        bank_account_id: Paid from Bank Account
+        contact_balance: You owe this supplier %{value}.
+        currency_charge: Currency Charges
+        currency_total_amount: Amount Paid
+        currency_total_amount_multi_currency: Amount Paid<span data-currency="%{currency_symbol}">&nbsp;</span>
+        date: Date Paid
+        display: Display
+        exchange_rate: Exchange Rate
+        left_to_allocate: Left to allocate
+        name: Supplier
+        payment_type: Method
+        print: Print Remittance Advice
+        reference: Reference (optional)
+        reference_pdf: Reference
+        voided_by: Voided payments
+      advanced_uk/supplier_opening_balance_entry:
+        exchange_rate: Exchange Rate
+      advanced_uk/supplier_refund_payment:
+        bank_account: Paid into Bank Account
+        bank_account_id: "Paid into \n Bank Account"
+        contact_balance: You owe this supplier %{value}.
+        currency_charge: Currency Charges
+        currency_total_amount: Amount Refunded
+        date: Date Refunded
+        display: Display
+        is_cheque: Paid by cheque
+        left_to_allocate: Left to allocate
+        name: Supplier
+        reference: Reference (optional)
+      advanced_uk/tax_return:
+        adjustment_clear_warn: Your adjustments have been cleared
+        from_date: Date From
+        paid_formatted: Paid
+        reference_text: VAT Return
+        return_date: Return Date
+        submitted_date: Submitted Date
+        tax_return_number: Number
+        tax_return_status_id: Status
+        to: to
+        to_date: Date To
+        total_amount: Amount
+      advanced_uk/tax_return_box:
+        calculated_amount: Calculated Figure
+      advanced_uk/tax_return_form_uk:
+        adjustment_amount: Change VAT figure by
+        adjustment_reason: Reason for change
+        box_1: VAT due in this period on <strong>sales</strong> and other outputs
+        box_2: VAT due in this period on <strong>acquisitions</strong> from other
+          <strong>EC Member States</strong>
+        box_3: Total VAT due <strong>(the sum of boxes 1 and 2)</strong>
+        box_4: VAT reclaimed in this period on <strong>purchases</strong> and other
+          inputs (including acquisitions from the EC)
+        box_5: Net VAT to be paid to HMRC or reclaimed by you. <br>(<strong>Difference
+          between boxes 3 and 4</strong>)
+        box_6: Total value of <strong>sales</strong> and all other outputs excluding
+          any VAT. <strong>Include your box 8 figure</strong>
+        box_6_flat: Total value of <strong>sales</strong>, including VAT. <strong>Include
+          your box 8 figure</strong>
+        box_7: Total value of <strong>purchases</strong> and all other inputs excluding
+          any VAT. <strong>Include your box 9 figure</strong>
+        box_8: Total value of all <strong>supplies</strong> of goods and related costs,
+          excluding any VAT, to other <strong>EC Member States</strong>
+        box_9: Total value of all <strong>acquisitions</strong> of goods and related
+          costs, excluding any VAT, from other <strong>EC Member States</strong>
+        company_name: Company Name
+        company_vat: Company VAT No
+        date_changed_info: Please calculate your VAT return again to reflect your
+          changes.
+        date_changed_warn: 'Your dates have changed: '
+        flat_net_vat: Flat scheme VAT
+        flat_rate: Flat Rate (%)
+        flat_rate_difference: "%{difference_key}: £%{difference}"
+        flat_rate_negative: Using a flat rate VAT scheme has cost you
+        flat_rate_notice: 'Note: These figures do not include any adjustments.'
+        flat_rate_positive: Using a flat rate VAT scheme has saved you
+        flat_rate_vat: Based on a flat rate of %{rate}% the actual VAT due is
+        from_date: VAT Period From
+        hmrc_password: HMRC Password
+        hmrc_user: HMRC User ID
+        label_box_1: "[1]"
+        label_box_2: "[2]"
+        label_box_3: "[3]"
+        label_box_4: "[4]"
+        label_box_5: "[5]"
+        label_box_6: "[6]"
+        label_box_7: "[7]"
+        label_box_8: "[8]"
+        label_box_9: "[9]"
+        non_flat_net_vat: Standard scheme VAT
+        non_flat_rate_vat: On a Standard Scheme your VAT due would have been
+        tax_registration_number: 'VAT Registration Number: %{country_code} %{tax_number}'
+        tax_scheme: VAT Scheme
+        tax_submission_frequency_type: VAT Return Frequency
+        to_date: To
+      advanced_uk/vat_expense_payment:
+        bank_account: Bank From
+      advanced_uk/vat_income_payment:
+        bank_account: Bank To
+      business:
+        auxiliary_accounts_visible: Use auxiliary accounts for customers and suppliers
+        business_type: Type of business
+        business_type_city: City/Town
+        business_type_country_id: Country
+        business_type_county: County
+        business_type_postcode: Postcode
+        business_type_street_1: Address 1
+        business_type_street_2: Address 2
+        city: City/Town
+        country: Country
+        county: County
+        name: Business name
+        postcode: Postcode
+        registered_address: Registered Address
+        registered_at_business_address: Same as business address
+        registered_country: Registered Country
+        registered_number: Registration Number
+        street_1: Address 1
+        street_2: Address 2
+      business_membership:
+        business_telephone: Telephone
+        is_owner?: Owner
+        primary: System Manager
+        user_email: Email
+        user_last_logged_in: Last logged in
+      core_accounting/taxes/models/tax_rate:
+        name: Display Name
+        visible: Show this tax rate
+      fuji_banking/bank_account:
+        account_name: Account Name
+        account_number: Account Number
+        account_type: Account Type
+        account_type_id: Account Type
+        balance: Balance
+        bic: BIC/Swift
+        credit_card_last_four_digits: Last 4 digits of your credit card number
+        date: Date
+        iban: IBAN
+        last_reconciled_date: Last Reconciled Date
+        main_address_postcode: Postcode
+        main_contact_email: Email
+        main_contact_name: Contact Name
+        main_contact_telephone: Main Contact Telephone
+        nominal_code_formatted: Ledger Account
+        opening_balance_credit: Credit
+        opening_balance_date: Opening Balance Date
+        opening_balance_debit: Debit
+        payment_type: Default Transaction Method
+        sort_code: Sort Code
+        starting_balance_credit: Credit
+        starting_balance_date: Opening Balance Date
+        starting_balance_debit: Debit
+        starting_balance_source_id: Transfered from
+        user_nominal_code: Ledger Account
+      fuji_banking/bank_activity:
+        category: Type
+      fuji_banking/bank_interest_and_charges:
+        bank_charge_amount: Bank Charge
+        bank_charge_amount_date: Date
+        bank_interest_amount: Interest Charge
+        bank_interest_amount_date: Date
+        bank_interest_earned_amount: Interest Earned
+        bank_interest_earned_amount_date: Date
+      fuji_banking/bank_reconciliation:
+        apply: Apply
+        bank_account_formatted: Bank Account
+        closing_balance: Closing Balance
+        discrepancy: Difference
+        matched_balance: Reconciled Balance
+        previous_balance: Starting Balance
+        previous_balanced: Previous Balance
+        reference: Reference
+        statement_date: Statement Date
+        statement_end_balance: Statement End Balance
+        target_balance: Target Balance
+        total_paid: Total Paid
+        total_received: Total Received
+        user_formatted: Reconciled By
+      fuji_banking/bank_transfer:
+        amount: Amount Transferred
+        date: Date Transferred
+        description: Description
+        destination_id: Paid into Account
+        payment_type_id: Method
+        reference: Reference (optional)
+        source_id: Paid from Account
+      fuji_banking/cheque:
+        amount: Amount
+        contact_name: Name
+        date: Date
+        grand_total: Total
+        number: Cheque Number
+        number_of_cheques: Number of Cheques
+        reference: Ref (Chq No)
+        statuses:
+          manual: Issued Manually
+          printed: Printed
+          saved: Saved
+          voided: Voided
+      fuji_banking/deposit:
+        bank_account_name: Bank Account
+        cash_amount: Cash
+        cash_remaining: Cash in Hand Remaining
+        cheque_amount: Cheques
+        cheque_count: Cheques [%{count}]
+        date: Date
+        destination_bank_account_id: Bank Account
+        reference: Paying in Reference
+        select: Select
+        total_amount: Total
+      fuji_catalogs/product: Product
+      fuji_catalogs/service: Service
+      fuji_contacts/contact:
+        account_balance: O/S Balance
+        account_details: Account Details
+        account_name: Account Name
+        account_number: Account Number
+        add_a: Add a
+        add_account_default: Add a Account Default
+        add_auxillary_reference: Add a Debtor/Creditor Number
+        add_company: Add a Company Name
+        add_currency: Add a Currency
+        add_locale: Add Language
+        add_product_price: Add a Default Price
+        add_purchase_ledger_account_id: Add a Purchase Ledger Account
+        add_reference: Add a Reference
+        add_registered_number: Add a Registration Number
+        add_sales_ledger_account_id: Add a Sales Ledger Account
+        add_tax_number: Add a VAT Number
+        address_name: Address Name
+        address_type: Address Type
+        all: All
+        analysis_type_0_formatted: Analysis Type 1
+        analysis_type_1_formatted: Analysis Type 2
+        analysis_type_2_formatted: Analysis Type 3
+        analysis_types: Analysis Types
+        automatic_statements: Auto-statements
+        automatic_statements_label: Include in Automatic Statement run
+        auxiliary_account: Auxiliary Account
+        average_purchase: Average Purchase
+        average_sale: Average Sale
+        balance: Balance
+        balance_due: Balance Due
+        balance_owed: Balance Owed
+        bank_details: Bank Details
+        bank_transit_number: Transit Number
+        bic: BIC/Swift
+        business_exchange_rate_id: Currency
+        cc_checkbox_label: Copy emails to this person
+        cc_text: Cc'd into emails
+        company: Company / Name
+        contact_name: Contact Name
+        contact_type: Contact Type
+        contact_type_form_proxy_id: Contact Type
+        credit_limit: Credit Limit
+        credit_set: Set Credit Limit <span class='currencySymbol' data-currency='%{currency}'></span><div
+          class='baseCreditLimit'><span data-currency-base='%{baseCurrencyCode}'></span>%{baseValue}</div>
+        credit_terms: Credit Terms
+        credit_terms_days: "%{count} Days"
+        currencies: Currencies
+        currency: Currency
+        currency_average_purchase: Average Purchase
+        currency_average_sale: Average Sale
+        currency_credit_limit: Credit Limit
+        currency_purchases_this_year: Purchases this year
+        currency_purchases_to_date: Purchases to date
+        currency_sales_this_year: Sales this year
+        currency_sales_to_date: Sales to date
+        customer_credit_days: Customer Credit (days)
+        customise_payment_terms: Customise terms
+        customised_credit_terms: Terms and Conditions
+        date: Date
+        default_customer_credit_days: Default Customer Credit (days)
+        default_payment_terms: Use default terms
+        default_supplier_credit_days: Default Supplier Credit (days)
+        discount: Discount
+        edit_name_and_reference: Edit Name & Reference
+        email: Email
+        fax_number: Fax
+        help: View your customer/suppliers details and account activity. You can view
+          or change addresses and contact information from the Addresses tab.
+        iban: IBAN
+        institution_number: Institution Number
+        is_main_address: Main Address <span>- Print on documents produced by Accounting.</span>
+        is_main_contact: Main Contact <span>- Include on emails produced by Accounting.</span>
+        is_preferred_contact: Copy emails <span>to this person.</span>
+        last_payment_value: Last Payment
+        last_purchase_value: Last Purchase
+        last_receipt_value: Last Receipt
+        last_sale_format: DD MMM YYYY
+        last_sale_value: Last Sale
+        locale: Language
+        main_address: Main Address
+        main_address_country: Country
+        main_address_line_1: Address
+        main_address_line_3: Town
+        main_address_postcode: Postcode
+        main_contact_email: Email
+        main_contact_fax_number: Fax
+        main_contact_mobile: Mobile
+        main_contact_name: Contact Name
+        main_contact_telephone: Telephone
+        mobile: Mobile
+        money_in_to_date: Money in to date
+        money_out_to_date: Money out to date
+        name: Name
+        net: Net
+        never: Never
+        new_individual: New Individual
+        no_notes: There are no notes for this contact
+        none: None
+        notes: Notes
+        number: Number
+        oldest_outstanding_invoice_date: Oldest Inv
+        outstanding: Outstanding
+        over_credit_limit: Over credit limit by %{amount}
+        overdue: Overdue
+        overdue_balance: Overdue Balance
+        payment_terms: Payment Terms
+        product_price: Price Default
+        product_price_id: Price Default
+        purchase_ledger_account: Account Default
+        purchase_ledger_account_id: Account Default
+        purchases_this_year: Purchases this year
+        purchases_to_date: Purchases To Date
+        reference: Reference
+        reference_placeholder: e.g. Account Number
+        reference_short: 'Ref:'
+        registered_number: Registration Number
+        retention_expiry_date: Suggested Removal Date
+        role: Role
+        sales_ledger_account: Account Default
+        sales_ledger_account_id: Account Default
+        sales_this_year: Sales this year
+        sales_to_date: Sales to date
+        save_individual: Save
+        sort_code: Sort Code
+        statement_address: Address
+        statement_contact: Contact to send to
+        statement_contact_email_missing: Contact must have an email address within
+          their record
+        statement_delivery_method: Statement Run
+        statement_runs: Statement Runs
+        statements_enabled: Send Statements
+        statements_enabled_label: Send Statements
+        status: Status
+        switch_on_statements: Switch on?
+        tax_number: VAT Number
+        tax_rate_id: VAT Rate
+        taxable: Taxable
+        telephone: Telephone
+        terms_and_conditions: Terms and conditions
+        total: Total
+        type: Type
+        vat: VAT
+        view_currency_in: View currency in
+      fuji_contacts/customer:
+        analysis_type_0_formatted: Analysis Type 1
+        analysis_type_1_formatted: Analysis Type 2
+        analysis_type_2_formatted: Analysis Type 3
+        aux_reference: Debtor Number
+        default_address_id: Statement Address
+        default_contact_id: Statement Email/Contact
+        help: View your customer details and account activity. You can view or change
+          addresses and contact information from the Addresses tab.
+        is_main_address: Main Address <span>- Print on documents produced by Accounting.</span>
+        is_main_contact: Main Contact <span>- Include on emails produced by Accounting.</span>
+        is_preferred_contact: Copy emails <span>to this person.</span>
+      fuji_contacts/dialog:
+        account_details_tab: Account Details
+        address_tab: Contact Address
+        bank_tab: Bank Details
+        contact_tab: Contact Details
+        notes_tab: Notes
+        vat_details: VAT Details
+      fuji_contacts/supplier:
+        analysis_type_0_formatted: Analysis Type 1
+        analysis_type_1_formatted: Analysis Type 2
+        analysis_type_2_formatted: Analysis Type 3
+        aux_reference: Creditor Number
+        default_address_id: Remittance Address
+        default_contact_id: Remittance Email
+        help: View your supplier details and account activity. You can view or change
+          addresses and contact information from the Addresses tab.
+        is_main_address: Main Address <span>- Print on documents produced by Accounting.</span>
+        is_main_contact: Main Contact
+      fuji_core_accounting/business_retention_settings:
+        gdpr:
+          end_of_tax_year: End of Tax Year
+          help_link: https://help.sageone.com/find_by_tag?language=en&locale=uk&service=accounting&tag=setup_gdpr_retention_period
+          help_title: Help me choose
+          info_text: Accounting records are kept for %{num_year} after the end of
+            your tax year in %{month}.
+          month_prompt: Select month
+          reason: Reason
+          reason_tooltip: Why do you need to retain your business data for this period?
+          retention_duration: Retention Period
+          subtitle: Choose how long you need to keep your accounting records. We’ll
+            use this to calculate how long you should keep your contact’s personal
+            data. This is important for complying with data protection laws.
+          title: BUSINESS DATA RETENTION PERIOD
+          year_prompt: Select duration
+          years: year(s)
+      fuji_core_accounting/coa_account:
+        coa_account_id: COA Account
+        coa_country: Country
+        coa_display_name: Display Name
+        coa_name: Name
+        coa_tax_rate: VAT Rate
+        control_name: Control Account
+        display_name: Display Name
+        ledger_account_type_id: Ledger Account Type
+        nominal_code: Nominal Code
+        small_business: Small Business
+        tax_rate_id: VAT Rate
+        ui_visible: UI Visible
+      fuji_core_accounting/coa_structure:
+        display_name: Display Name
+        ledger_account_type_id: Ledger Account Type
+        nominal_code: Nominal Code
+        tax_rate_id: VAT Rate
+        ui_visible: UI Visible
+      fuji_core_accounting/coa_template:
+        create_coa_template: Create Coa template
+        system?: System Template
+      fuji_core_accounting/financial_settings:
+        accounts_start_date: Accounts Start Date
+        bank_charges_ledger_account_id: Bank Charges Ledger Account
+        current_financial_year_start_date: Current financial year from
+        current_next_financial_year_end_date: to
+        exchange_rate_gains_ledger_account_id: Exchange Rate Gains Ledger Account
+        exchange_rate_losses_ledger_account_id: Exchange Rate Losses Ledger Account
+        financial_year_end_date: Year End Date
+        foreign_currency_enabled: Enable Foreign Currency Transactions
+        hmrc_user_id: HMRC User ID
+        live_exchange_rates_enabled: Use Live Exchange Rates
+        lockdown_date: Year End Lockdown
+        next_financial_year_start_date: Next financial year from
+        purchase_tax_calculation: Purchases
+        sales_tax_calculation: Sales
+        tax_calculation:
+          applicability: The VAT Calculation method will apply to future transactions
+            only.
+          cash:
+            label: On payment
+            text: The VAT collected is due when payment is collected.
+          invoice:
+            label: On invoice
+            text: The VAT collected is due from the date of issue of the invoice.
+          title: VAT Calculation
+        tax_number: VAT Number
+        tax_rate: Flat Rate (%)
+        tax_scheme_id: VAT Scheme
+        tax_submission_frequency_type_id: Submission Frequency
+      fuji_core_accounting/financial_settings/business:
+        business_retention_settings: Business retention settings
+      fuji_core_accounting/ledger_account:
+        add_category: Add Ledger Account
+        closing_balance: Closing Balance
+        coa_group_type: Category Group
+        coa_group_type_id: Category Group
+        display_name: Display Name
+        display_name_for_grid: Ledger Name
+        export_accounts: Export Accounts
+        has_bank_scope: Bank
+        has_journals_scope: Journals
+        has_other_payment_scope: Other Payment
+        has_other_receipt_scope: Other Receipt
+        has_purchasing_scope: Purchases - Invoice / Credit, Product / Supplier defaults
+        has_reporting_scope: Reports
+        has_sales_scope: Sales - Invoice / Credit, Product / Services / Customer defaults
+        import_accounts: Import Accounts
+        is_included: Included in Chart
+        is_purchase_for_resale: Purchase for resale
+        ledger_account_formatted: Ledger Account
+        ledger_account_type: Category
+        ledger_account_type_id: Category
+        name: Ledger Name
+        name_for_grid: Ledger Name
+        new_ledger_account: New Ledger Account
+        nominal_code: Nominal Code
+        nominal_code_formatted: Nominal Code
+        opening_balance: Opening Balance
+        tax_rate: VAT Rate
+        tax_rate_id: VAT Rate
+        total_credits_this_period: Total Credits this period
+        total_debits_this_period: Total Debits this period
+        ui_visibility: Visibility
+        ui_visible: Visible?
+      fuji_core_accounting/ledger_entry:
+        bank_activity_reference: Reference
+        bank_reconciled: Reconciled?
+        bank_reconciled_as_checkbox: Reconciled?
+        category: Category
+        cleared: Cleared
+        contact_name: Name
+        cr: Paid
+        date: Date
+        dr: Received
+        reconciled?: Reconciled?
+        recurrence: Recurrence
+      fuji_core_accounting/transaction:
+        void_reference: Reversal of Trx %{reference}
+      fuji_invoicing/corrective_invoice:
+        created_at: " created on %{date} at %{time}."
+      fuji_invoicing/credit_note:
+        abbr_type: Crn
+      fuji_invoicing/invoice:
+        abbr_type: Inv
+      fuji_invoicing/invoice_settings:
+        associate_logo_1: First Associate Logo
+        associate_logo_2: Second Associate Logo
+        batch_number_prefix: Quick Entries
+        company_logo: Company logo
+        corrective_sales_invoice_number_prefix: Sales Corrective Invoice
+        customer_credit_days: Customer Credit (days)
+        estimate_delay_days: Default Days to Expiry
+        estimate_text: Estimate Terms & Conditions
+        insurance_area: Insurance Area
+        insurance_mention: Insurance Mention
+        insurance_mentioned: Insurance Mentioned
+        insurance_type: Insurance Type
+        insurer_id: Insurer
+        late_payment: Late Payment
+        name: Invoice Form Settings
+        next_corrective_number: Next Corrective Invoice Number
+        next_credit_note_number: Next Credit Note Number
+        next_invoice_and_credit_note_number: Next Invoice or Credit Note Number
+        next_invoice_number: Next Invoice Number
+        next_quote_number: Next Estimate/Quote Number
+        prompt_payment: Prompt Payment
+        quote_delay_days: Default Days to Expiry
+        quote_text: Quote Terms & Conditions
+        sales_credit_note_number_prefix: Sales Credit Note
+        sales_estimate_number_prefix: Estimates
+        sales_invoice_number_prefix: Sales Invoice
+        sales_quote_number_prefix: Quotes
+        supplier_credit_days: Supplier Credit (days)
+        terms_and_conditions: Invoice Terms & Conditions
+      fuji_invoicing/logo_and_theme_settings:
+        name: Logo & Theme settings
+      fuji_invoicing/purchase_corrective_credit_note:
+        abbr_type: Cor-Crn
+      fuji_invoicing/purchase_corrective_invoice:
+        abbr_type: Cor-Inv
+        artefact_status_id: Status
+        contact_formatted: Supplier
+        contact_name: Supplier
+        contact_reference: Contact Reference
+        currency_code: Currency
+        currency_outstanding: Outstanding
+        currency_outstanding_with_sign: Outstanding
+        currency_total: Total
+        currency_total_net_amount: Amount Ex VAT
+        currency_total_net_amount_with_sign: Net Amount
+        currency_total_tax_amount: Total VAT
+        currency_total_tax_amount_with_sign: VAT Amount
+        currency_total_with_sign: Total <span data-currency="%{currency_code}"></span>
+        currency_withholding_tax_amount: IRPF
+        date: Invoice Date
+        due_date: Due Date
+        exchange_rate: Exchange Rate
+        extra_reference: Supplier Reference
+        grand_total: Total
+        main_address_postcode: Postcode
+        main_contact_email: Email
+        main_contact_name: Contact Name
+        main_contact_telephone: Telephone
+        name: Supplier
+        notes: Notes
+        outstanding: Outstanding
+        paid: Paid/Allocated
+        purchase_artefact_currency_total_formatted: Total
+        raised_by_user_id: Who
+        raised_by_user_initials: User
+        reference: Reference
+        total: Total
+        total_net_amount: Net Amount
+        total_tax_amount: VAT Amount
+      fuji_invoicing/purchase_credit_note:
+        artefact_status_id: Status
+        contact_formatted: Supplier
+        contact_name: Supplier
+        contact_reference: Contact Reference
+        currency_code: Currency
+        currency_outstanding: Outstanding
+        currency_total: Total
+        currency_total_net_amount: Amount Ex VAT
+        currency_total_tax_amount: Total VAT
+        currency_withholding_tax_amount: IRPF
+        date: Credit Date
+        due_date: Due Date
+        exchange_rate: Exchange Rate
+        extra_reference: Supplier Reference
+        grand_total: Total
+        invoice_outstanding: Invoice Outstanding
+        main_address_postcode: Postcode
+        main_contact_email: Email
+        main_contact_name: Contact Name
+        main_contact_telephone: Telephone
+        name: Supplier
+        notes: Notes
+        outstanding: Outstanding
+        paid: Paid/Allocated
+        raised_by_user_id: Who
+        raised_by_user_initials: User
+        reference: Reference
+        total: Total
+        total_net_amount: Net Amount
+        total_tax_amount: VAT Amount
+      fuji_invoicing/purchase_credit_note/line_items:
+        tax_rate_id: VAT Rate
+      fuji_invoicing/purchase_credit_note_line_item:
+        currency_discount: Discount
+        currency_net_amount: Net Amount
+        currency_tax_amount: VAT Amount
+        currency_total: Total
+        currency_unit_price: Price/Rate
+        description: Description
+        eu_goods_services_type: EU Goods/Services
+        eu_goods_services_type_id: EU Goods/Services
+        is_purchase_for_resale: Resale
+        ledger_account_id: Ledger Account
+        product_code: Item Code
+        quantity: Qty/Hrs
+        tax_amount: VAT Amount
+        tax_rate_id: VAT Rate
+        trade_of_asset: Outside Flat Rate
+        unit_price: Price/Rate
+      fuji_invoicing/purchase_invoice:
+        artefact_status_id: Status
+        contact_formatted: Supplier
+        contact_name: Supplier
+        contact_reference: Contact Reference
+        currency_code: Currency
+        currency_outstanding: Outstanding
+        currency_total: Total
+        currency_total_net_amount: Amount Ex VAT
+        currency_total_tax_amount: Total VAT
+        currency_withholding_tax_amount: IRPF
+        date: Invoice Date
+        due_date: Due Date
+        exchange_rate: Exchange Rate
+        extra_reference: Supplier Reference
+        grand_total: Total
+        main_address_postcode: Postcode
+        main_contact_email: Email
+        main_contact_name: Contact Name
+        main_contact_telephone: Telephone
+        name: Supplier
+        outstanding: Outstanding
+        paid: Paid/Allocated
+        raised_by_user_id: Who
+        raised_by_user_initials: User
+        reference: Reference
+        total: Total
+        total_net_amount: Net Amount
+        total_tax_amount: VAT Amount
+      fuji_invoicing/purchase_invoice/line_items:
+        tax_rate_id: VAT Rate
+      fuji_invoicing/purchase_invoice_line_item:
+        currency_net_amount: Net Amount
+        currency_tax_amount: VAT Amount
+        currency_total: Total
+        currency_unit_price: Price/Rate
+        eu_goods_services_type: EU Goods/Services
+        eu_goods_services_type_id: EU Goods/Services
+        is_purchase_for_resale: Resale
+        ledger_account_id: Ledger Account
+        net_amount: Net Amount
+        product_code: Item Code
+        quantity: Qty/Hrs
+        tax_amount: VAT Amount
+        tax_percentage: VAT (%)
+        tax_rate_id: VAT Rate
+        trade_of_asset: Outside Flat Rate
+        unit_price: Price/Rate
+      fuji_invoicing/purchase_invoice_payment:
+        amount: Amount Paid
+        bank_account_id: Paid From
+      fuji_invoicing/sales_corrective_credit_note:
+        abbr_type: Cor-Crn
+      fuji_invoicing/sales_corrective_invoice:
+        abbr_type: Cor-Inv
+        add_new_delivery_address: Add a delivery address
+        add_new_main_address: Add a main address
+        artefact_number: Corrective Invoice No.
+        artefact_number_formatted: Corrective Invoice No.
+        artefact_status_id: Status
+        carriage_net_amount: Carriage
+        carriage_tax_rate: Carriage VAT Rate
+        carriage_tax_rate_id: Carriage Tax Rate
+        contact_formatted: Customer
+        contact_name: Customer
+        contact_reference: Contact Reference
+        currency_carriage_net_amount: Carriage
+        currency_code: Currency
+        currency_outstanding: Outstanding
+        currency_outstanding_with_sign: Outstanding
+        currency_total: Total
+        currency_total_discount: Discount
+        currency_total_net_amount: Amount Ex VAT
+        currency_total_net_amount_with_sign: Net Amount
+        currency_total_tax_amount: Total VAT
+        currency_total_tax_amount_with_sign: VAT Amount
+        currency_total_with_sign: Total <span data-currency="%{currency_code}"></span>
+        currency_withholding_tax_amount: IRPF
+        custom_delivery_address: Custom
+        date: Invoice Date
+        delivery_address: Delivery Address
+        delivery_address_label: Delivery Address
+        delivery_address_same_as_main: Same as invoice address
+        delivery_address_selector: Delivery Address
+        due_date: Due Date
+        exchange_rate: Exchange Rate
+        grand_total: Total
+        header_note: Delivery/Performance Date
+        invoice_number: Corrective Invoice No.
+        invoice_number_formatted: Corrective Invoice No.
+        issued: Issued
+        main_address: Invoice Address
+        main_address_postcode: Postcode
+        main_contact_email: Email
+        main_contact_name: Contact Name
+        main_contact_telephone: Telephone
+        name: Customer
+        notes: Notes
+        outstanding: Outstanding
+        paid: Paid/Allocated
+        raised_by_user_id: Who
+        raised_by_user_initials: User
+        reference: Reference
+        sales_artefact_currency_total_formatted: Total
+        terms_and_conditions: Terms and Conditions
+        total: Total
+        total_net_amount: Net Amount
+        total_tax_amount: VAT Amount
+      fuji_invoicing/sales_credit_note:
+        add_new_delivery_address: Add a delivery address
+        add_new_main_address: Add a main address
+        artefact_number: Credit Note Number
+        artefact_number_formatted: Credit Note Number
+        artefact_status_id: Status
+        carriage_net_amount: Carriage
+        carriage_tax_rate: Carriage VAT Rate
+        carriage_tax_rate_id: Carriage Tax Rate
+        contact_formatted: Customer
+        contact_name: Customer
+        contact_reference: Contact Reference
+        credit_note_number: Credit Note Number
+        credit_note_number_formatted: Credit Note Number
+        currency_carriage_net_amount: Carriage
+        currency_code: Currency
+        currency_outstanding: Outstanding
+        currency_total: Total
+        currency_total_discount: Discount
+        currency_total_net_amount: Amount Ex VAT
+        currency_total_tax_amount: Total VAT
+        currency_withholding_tax_amount: IRPF
+        custom_delivery_address: Custom
+        date: Credit Date
+        delivery_address: Delivery Address
+        delivery_address_label: Delivery Address
+        delivery_address_same_as_main: Same as invoice address
+        delivery_address_selector: Delivery Address
+        due_date: Due Date
+        exchange_rate: Exchange Rate
+        grand_total: Total
+        invoice_number: Invoice Number
+        invoice_outstanding: Invoice Outstanding
+        issued: Issued
+        main_address: Address
+        main_address_postcode: Postcode
+        main_contact_email: Email
+        main_contact_name: Contact Name
+        main_contact_telephone: Telephone
+        name: Customer
+        outstanding: Outstanding
+        paid: Paid/Allocated
+        raised_by_user_id: Who
+        raised_by_user_initials: User
+        total: Total
+        total_net_amount: Net Amount
+        total_tax_amount: VAT Amount
+        unpaid: Unpaid
+        void: Void
+      fuji_invoicing/sales_credit_note/line_items:
+        tax_rate_id: VAT Rate
+      fuji_invoicing/sales_credit_note_line_item:
+        currency_discount: Discount
+        currency_net_amount: Net Amount
+        currency_tax_amount: VAT Amount
+        currency_total: Total
+        currency_unit_price: Price/Rate
+        description: Description
+        discount_amount: Discount Amount
+        discount_percentage: Discount (%)
+        ec_sales_description: EU Sales Description
+        ec_sales_description_id: EU Sales Description
+        eu_goods_services_type: EU Goods/Services
+        eu_goods_services_type_id: EU Goods/Services
+        ledger_account_id: Ledger Account
+        net_amount: Net Amount
+        product_code: Item Code
+        quantity: Qty/Hrs
+        tax_amount: VAT Amount
+        tax_percentage: VAT (%)
+        tax_rate_id: VAT Rate
+        trade_of_asset: Outside Flat Rate
+        unit_price: Price/Rate
+      fuji_invoicing/sales_estimate:
+        add_new_delivery_address: Add a delivery address
+        add_new_main_address: Add a main address
+        delivery_address: Delivery Address
+        main_address: Invoice Address
+      fuji_invoicing/sales_invoice:
+        add_new_delivery_address: Add a delivery address
+        add_new_main_address: Add a main address
+        artefact_number: Invoice Number
+        artefact_number_formatted: Invoice Number
+        artefact_status_id: Status
+        carriage_net_amount: Carriage
+        carriage_tax_rate: Carriage VAT Rate
+        carriage_tax_rate_id: Carriage Tax Rate
+        contact_formatted: Customer
+        contact_name: Customer
+        contact_reference: Contact Reference
+        created_from_sales_estimate: From Estimate
+        created_from_sales_quote: From Quote
+        currency_carriage_net_amount: Carriage
+        currency_code: Currency
+        currency_outstanding: Outstanding
+        currency_total: Total
+        currency_total_discount: Discount
+        currency_total_net_amount: Amount Ex VAT
+        currency_total_tax_amount: Total VAT
+        currency_total_with_sign: Total <span data-currency="%{currency_code}"></span>
+        currency_withholding_tax_amount: IRPF
+        custom_delivery_address: Custom
+        date: Invoice Date
+        delivery_address: Delivery Address
+        delivery_address_label: Delivery Address
+        delivery_address_same_as_main: Same as invoice address
+        delivery_address_selector: Delivery Address
+        due_date: Due Date
+        exchange_rate: Exchange Rate
+        grand_total: Total
+        header_note: Delivery/Performance Date
+        invoice_number: Invoice Number
+        invoice_number_formatted: Invoice Number
+        issued: Issued
+        main_address: Invoice Address
+        main_address_postcode: Postcode
+        main_contact_email: Email
+        main_contact_name: Contact Name
+        main_contact_telephone: Telephone
+        name: Customer
+        notes: Notes
+        outstanding: Outstanding
+        paid: Paid/Allocated
+        raised_by_user_id: Who
+        raised_by_user_initials: User
+        reference: Reference
+        terms_and_conditions: Terms and Conditions
+        total: Total
+        total_net_amount: Net Amount
+        total_tax_amount: VAT Amount
+      fuji_invoicing/sales_invoice/line_items:
+        ledger_account: Ledger account
+        tax_rate: Tax rate
+        tax_rate_id: VAT Rate
+      fuji_invoicing/sales_invoice_line_item:
+        currency_discount: Discount
+        currency_net_amount: Net Amount
+        currency_tax_amount: VAT Amount
+        currency_total: Total
+        currency_unit_price: Price/Rate
+        description: Description
+        discount_amount: Discount amount
+        discount_percentage: Discount (%)
+        ec_sales_description: EU Sales Description
+        ec_sales_description_id: EU Sales Description
+        eu_goods_services_type: EU Goods/Services
+        eu_goods_services_type_id: EU Goods/Services
+        ledger_account_id: Ledger Account
+        net_amount: Net Amount
+        product_code: Item Code
+        quantity: Qty/Hrs
+        tax_amount: VAT Amount
+        tax_percentage: VAT (%)
+        tax_rate_id: VAT Rate
+        trade_of_asset: Outside Flat Rate
+        unit_price: Price/Rate
+      fuji_invoicing/sales_invoice_payment:
+        amount: Amount Paid
+        bank_account_id: Paid To
+        is_cheque: Tick if Cheque
+        reference: Ref/Chq Number
+      fuji_invoicing/sales_quote:
+        add_new_delivery_address: Add a delivery address
+        add_new_main_address: Add a main address
+        artefact_number: Number
+        artefact_number_formatted: Number
+        contact_formatted: Customer
+        contact_name: Customer
+        currency_carriage_net_amount: Carriage
+        currency_code: Currency
+        currency_outstanding: Outstanding
+        currency_total: Total
+        currency_total_discount: Discount
+        currency_total_net_amount: Amount Ex VAT
+        currency_total_tax_amount: Total VAT
+        currency_withholding_tax_amount: IRPF
+        date: Created
+        delivery_address: Delivery Address
+        due_date: Expires
+        exchange_rate: Exchange Rate
+        formatted_status: Status
+        grand_total: Total
+        invoice_number_formatted: Invoice Number
+        issued: Sent
+        main_address: Invoice Address
+        main_address_postcode: Postcode
+        main_contact_email: Email
+        main_contact_name: Contact Name
+        main_contact_telephone: Telephone
+        name: Customer
+        quote_number_formatted: 'Quote #'
+        quote_status: Status
+        raised_by_user: Created By
+        raised_by_user_id: Created By
+        raised_by_user_initials: Who
+        reference: Reference
+        sales_quote_number: Number
+        terms_and_conditions: Terms and Conditions
+        total: Total
+        total_net_amount: Amount Ex VAT
+        total_tax_amount: Total VAT
+      fuji_invoicing/sales_quote/line_items:
+        tax_rate_id: VAT Rate
+      fuji_invoicing/sales_quote_line_item:
+        currency_discount: Discount
+        currency_net_amount: Net Amount
+        currency_tax_amount: VAT Amount
+        currency_total: Total
+        currency_unit_price: Price/Rate
+        discount_amount: Discount amount
+        discount_percentage: Discount (%)
+        ec_sales_description: EU Sales Description
+        ec_sales_description_id: EU Sales Description
+        eu_goods_services_type: EU Goods/Services
+        eu_goods_services_type_id: EU Goods/Services
+        ledger_account_id: Ledger Account
+        net_amount: Net Amount
+        product_code: Item Code
+        quantity: Qty/Hrs
+        tax_amount: VAT Amount
+        tax_percentage: VAT (%)
+        tax_rate_id: VAT Rate
+        unit_price: Price/Rate
+      fuji_support/recurrence:
+        expiry_date: Recur Until
+      journal_opening_balance_lines:
+        base: Nominal Opening Balance
+        credit: Nominal Opening Balance Credit
+        debit: Nominal Opening Balance Debit
+        ledger_account_id: Nominal Opening Balance Ledger Account
+      prices:
+        name: Price Name
+      rates:
+        name: Rate Name
+      user:
+        business_telephone: Telephone
+        first_name: First Name
+        last_name: Last Name
+        primary: Primary User
+        user_auths: Authentication details
+    errors:
+      messages:
+        analysis_type_category_code_already_exists: You cannot add duplicate codes
+          for an analysis type, please change and try again
+        bic:
+          invalid_format: Invalid Format
+        can_only_use_bank_ledger_account_type_on_bank_types: Only ledger accounts
+          with a category of Bank or Credit Card can be visible in Bank
+        cannot_create_cheque_unless_from_checking_or_savings: You can't save a cheque
+          payment from this bank account. Please select a current or savings account
+          instead.
+        cannot_delete_payment_with_reconciled_bank_payment: This payment cannot be
+          deleted, an associated bank payment has been reconciled.
+        cannot_destroy_batch_entry_if_migrated: You can't delete this quick entry
+          because it was migrated from your old accounting system.
+        cannot_destroy_credit_note_if_restricted: One or more of the selected items
+          is completed and cannot be deleted.  To keep the sequential numbers for
+          credit notes following HMRC rules, complete credit notes must be voided
+          and your access level does not allow you to do this.  Please speak to your
+          Supervisor.
+        cannot_destroy_if_bank_reconciled: You cannot delete bank reconciled transactions.
+        cannot_destroy_if_cheque_transaction: 'This transaction was paid by cheque
+          - please go to the <a href=''/banking/cheque_register#allCheques'' style=''text-decoration:
+          underline;color: white !important;''>Cheque Register</a> to delete it.'
+        cannot_destroy_if_cleared: You cannot delete transactions that have cleared
+          your bank account.
+        cannot_destroy_if_payments: You cannot delete items which have been allocated.
+        cannot_destroy_if_tax_reconciled: You cannot delete VAT reconciled transactions.
+        cannot_destroy_if_transaction_locked: You cannot delete an allocated transaction
+          created from a third-party integration.
+        cannot_destroy_invoice_if_restricted: One or more of the selected items is
+          completed and cannot be deleted.  To keep the sequential numbers for invoices
+          following HMRC rules, complete invoices must be voided and your access level
+          does not allow you to do this.  Please speak to your Supervisor.
+        cannot_destroy_journal_if_cleared: You cannot delete cleared transactions.
+        cannot_destroy_journal_if_migrated: You cannot delete this journal because
+          it was migrated from your old accounting system.
+        cannot_destroy_opening_balance_artefact: You cannot delete Invoices/Credit
+          Notes entered as an opening balance.
+        cannot_destroy_with_allocations: You cannot delete when credit notes or payments
+          on account are allocated.
+        cannot_download_tax_file_if_missing_tax_number: You must enter the GST/HST
+          account number associated with this tax return to download .tax file.
+        cannot_edit_batch_entry_if_migrated: You can’t edit this quick entry because
+          it was migrated from your old accounting system.
+        cannot_edit_if_bank_reconciled: You cannot edit bank reconciled transactions.
+        cannot_edit_if_cleared: You cannot edit transactions that have cleared your
+          bank account.
+        cannot_edit_if_different_scheme: You cannot update items which were created
+          under a different tax scheme.
+        cannot_edit_if_payments: You cannot update items which have been allocated.
+        cannot_edit_if_tax_reconciled: You cannot edit VAT reconciled transactions.
+        cannot_edit_other_schemes_artefact: You cannot edit Invoices/Credit Notes
+          created on a different VAT scheme.
+        cannot_edit_tax_if_tax_reconciled: This entry has been VAT reconciled, and
+          you cannot save changes which would impact on the previously reconciled
+          VAT return.
+        cannot_expose_bank_ledger_account_type_outside_bank: Ledger accounts with
+          a category of Bank or Credit Card can only be visible in Bank
+        cannot_expose_excluded_ledger_account_in_ui: Excluded ledger accounts cannot
+          be shown in the app
+        cannot_expose_this_control_account: This Control Account cannot be visible
+        cannot_overpay: You cannot overpay
+        cannot_raise_credit_note_on_paid: Someone else may have recorded a payment/credit
+          note against this invoice. Please review the outstanding amount on the invoice.
+        cannot_unallocate_if_transaction_locked: Allocations created by third-party
+          integrations cannot be changed.
+        cannot_update_credit_note_if_restricted: Your access level only allows you
+          to edit draft credit notes.  Please speak to your Supervisor.
+        cannot_update_estimate_if_restricted: Your access level only allows you to
+          edit draft estimates.  Please speak to your Supervisor.
+        cannot_update_iban_if_connected_to_bank_feeds: You cannot update the iban
+          if your bank account is connected.
+        cannot_update_if_transaction_locked: You cannot update a transaction created
+          from a third-party integration.
+        cannot_update_invoice_if_restricted: Your access level only allows you to
+          edit draft invoices.  Please speak to your Supervisor.
+        cannot_update_quote_if_restricted: Your access level only allows you to edit
+          draft quotes.  Please speak to your Supervisor.
+        cannot_void_if_tax_reconciled: You cannot void VAT reconciled transactions.
+        cannot_void_opening_balance_artefact: You cannot void Invoices/Credit Notes
+          entered as an opening balance.
+        cannot_void_with_allocations: You cannot void when credit notes or payments
+          on account are allocated.
+        customer_supplier_overseas_opening_balances_no_tax: Opening Balances for EU
+          VAT registered contacts, or those outside of the EU should be recorded as
+          No VAT.
+        customer_supplier_overseas_opening_balances_row_tax: Opening Balances for
+          EU VAT registered contacts, or those outside of the EU should be recorded
+          as zero rated.
+        ensure_credit_or_debit_only: You must enter either a debit or a credit
+        exchange_and_total_not_zero: This field has errors and can not be zero
+        exchange_rate_invalid_for_equal_currencies: The exchange rate must be 1 if
+          the business and contact currencies are the same.
+        field_value_not_valid: The value supplied is not valid for %{field}
+        iban:
+          invalid_check_sum: Invalid check sum
+          too_long: Too long
+          too_short: Too short
+          unknown_country: Invalid format
+        invalid_measurement_unit: Invalid measurement unit - %{measurement_unit}
+        left_to_allocate_higher: This value cannot be higher than the total amount.
+        left_to_record_not_zero: This field must be zero before saving the record.
+        less_than_zero: This field must not be less than zero
+        must_be_less_than_200_characters: Your text must be 200 characters or less.
+        must_be_no_greater_than: Must be no greater than 99999999.
+        must_be_one_of_allowed_tax_rates: 'You must choose one of the following VAT
+          Rates: %{tax_formatted}'
+        must_be_valid_category: Must be a valid category.
+        must_not_exceed_new_outstanding_amount: Must not exceed new outstanding amount.
+        must_not_exceed_outstanding_amount: Must not exceed outstanding amount.
+        no_such_quote_or_estimate: The quote or estimate to be associated cannot be
+          found.
+        nominal_code_must_be_included: Nominal code must be included in chart of accounts
+        not_a_whole_number: must be a whole number
+        opening_balance_attributes_invalid: As an opening balance date is specified,
+          you must enter either a debit or credit
+        opening_balance_attributes_invalid_balance_overdrawn_balance: As an opening
+          balance date is specified, you must enter either a balance or overdrawn
+          balance
+        opening_balance_attributes_invalid_date: You must enter a date for the opening
+          balance, prior to your accounts start date.
+        opening_balance_attributes_invalid_overpaid_balance_balance_due: As an opening
+          balance date is specified, you must enter either an overpaid balance or
+          a balance due
+        payment_artefacts_artefact_contact_invalid: All allocated items must belong
+          to the same contact.
+        payment_artefacts_cannot_overpay: You cannot overpay invoices.
+        payment_artefacts_must_be_present: There must be at least one item allocated.
+        payment_artefacts_status_invalid: You can only pay unpaid or part-paid invoices.
+        payment_on_account_has_been_allocated: Associated payment on account has been
+          allocated so no update is possible
+        payroll_current_liability_control_account_visibility: Payroll Liability accounts
+          can only be visible in Other Payments and Other Receipt
+        payroll_overheads_control_account_visibility: Payroll Overhead accounts can
+          only be visible in Other Payment
+        prohibited_chars: contains invalid characters
+        prohibited_chars_prefix: The prefix of %{artefact} contains invalid characters
+        quantity_in_stock: 'Qty in stock: %{count}<br>You cannot fulfil this invoice
+          as you do not have enough in stock.'
+        quantity_in_stock_info: 'Qty in stock: %{count}'
+        quantity_in_stock_warning: 'Qty in stock: %{count}<br>You''ve entered a quantity
+          that''s higher than your current stock level.'
+        quick_entries_cross_border_vat: You cannot record Quick Entries for Cross
+          Border contacts.  To correctly deal with VAT when recording cross border
+          transactions, you must use the Invoice or Credit Note Option. Delete these
+          lines and resave.
+        required: This field is required
+        retailer_invoice_non_spain_contact: This invoice cannot be edited. Recargo
+          de Equivalencia has been applied, but the contact is not in Spain.  Create
+          a Corrective Invoice to reverse the invoice.
+        sage_pay_unsupported_currency: Your Sage Pay account does not support payments
+          in %{currency_code}.
+        tax_calculation_not_applicable: Tax calculation is not applicable to this
+          buisness.
+        tax_calculation_not_valid: This is not a valid value for the tax calculation.
+        tax_number_invalid: Invalid tax number.
+        tax_rate_not_visible: The tax rate is not marked as visible and therefore
+          is not available for import.
+        transit_and_institution_number_validation: The transit number should be 5
+          digits and the institution number should be 3 digits.
+        unique_field_constraint: "%{field} must be unique"
+        unknown_value_for_column: The value supplied is not valid for %{field}
+        within_financial_year: You cannot report across financial years
+      mixins:
+        invoice_payment:
+          attributes:
+            amount:
+              less_than_outstanding: Invoice total amount cannot be less than the
+                outstanding amount.
+              must_not_be_greater_than_outstanding: Must not be greater than the outstanding
+                amount of the invoice.
+              zero: Cannot be 0.
+      models:
+        addresses/models/address:
+          attributes:
+            base:
+              can_only_have_one_main_contact: You can only have one main contact for
+                an address.
+              cannot_delete_main_address: Unable to delete main address.
+              contact_deleted: The contact for the address has been deleted.
+            is_main_address:
+              must_have_one_main_address: You must have a main address.
+        advanced_uk/address_contact:
+          attributes:
+            base:
+              cannot_delete_main_contact: Unable to delete main contact.
+            is_main_contact:
+              must_have_one_main_contact: You must have one main contact person.
+        advanced_uk/allocation:
+          attributes:
+            base:
+              cannot_delete_allocation: Unable to delete allocation.
+        advanced_uk/analysis_type:
+          attributes:
+            base:
+              cannot_delete_category_in_use: You cannot delete an Analysis Type Category
+                that is in use.
+              cannot_delete_in_use: You cannot delete an Analysis Type that is in
+                use.
+              invalid_analysis_area: One or more of the selected Analysis Areas is
+                invalid for this Analysis Type.
+        advanced_uk/analysis_type_category:
+          attributes:
+            base:
+              cannot_delete_in_use: You cannot delete an Analysis Type Category that
+                is in use.
+        advanced_uk/bank_opening_balance:
+          attributes:
+            base:
+              cannot_destroy_if_bank_reconciled: You cannot delete bank reconciled
+                transactions.
+              cannot_edit_if_bank_reconciled: You cannot edit bank reconciled transactions.
+              credit_and_debit_not_set: Opening Balance is required.
+              credit_and_debit_set: Debit or Credit must be set, but not both.
+        advanced_uk/batch_entry:
+          attributes:
+            ledger_account:
+              home_customer_invalid: is incorrectly selected - please select a non
+                EU/Export ledger account
+              home_supplier_invalid: is incorrectly selected - please select a non
+                EU/Import ledger account
+            tax_rate_id:
+              ledger_account_based: for ledger account %{ledger_account} must be '%{tax_rate}'.
+            total:
+              unbalanced_transaction: must be equal to Net plus VAT.
+            total_tax_amount:
+              cant_record_tax_amount_for_zero_rate: You cannot record VAT Amount if
+                using a VAT Rate with a Zero %.
+            trade_of_asset:
+              invalid_category: Can only be selected for fixed assets
+              not_applicable: Is not valid for your tax system.
+        advanced_uk/catalog_item:
+          attributes:
+            tax_rate_id:
+              ledger_account_based: for ledger account %{ledger_account} must be '%{tax_rate}'.
+        advanced_uk/category:
+          attributes:
+            base:
+              max_level_error: Category must be at most %{max_levels} levels deep.
+              max_subcategory_level_error: The category and its subcategories must
+                be at most %{max_levels} levels deep.
+        advanced_uk/customer_allocation:
+          attributes:
+            left_to_allocate:
+              left_to_allocate_not_zero: Left to allocate must be zero.
+        advanced_uk/customer_income_payment:
+          attributes:
+            base:
+              cannot_allocate_poa_in_payment_that_created_it: You cannot allocate
+                a payment on account from within the customer receipt that originally
+                created the payment on account.
+              cannot_delete_if_payments_allocated: One or more of the selected items
+                are allocated therefore cannot be deleted.
+              cheque_deposited: This cheque has already been deposited.  You must
+                delete the deposit before editing this transaction.
+            left_to_allocate:
+              left_to_allocate_higher: This value cannot be higher than the total
+                amount.
+        advanced_uk/customer_refund_payment:
+          attributes:
+            base:
+              cannot_delete_if_payments_allocated: One or more of the selected items
+                are allocated therefore cannot be deleted.
+              payment_artefacts_cannot_overpay: You cannot overpay credit notes.
+              payment_artefacts_status_invalid: You can only pay unpaid or part-paid
+                credit notes.
+            left_to_allocate:
+              left_to_allocate_not_zero: Left to allocate must be zero.
+            voided_by:
+              present: can't be edited
+        advanced_uk/data_import:
+          attributes:
+            file:
+              size_too_big: is too big (should be at most %{file_size})
+          base:
+            ledger_account_importer:
+              exceeds_line_limit: You can’t import more than 2,000 ledger accounts.
+            unbalanced_exception: The VAT and Net amounts must add up to the Total.
+            unexpected_error: An unexpected error occurred. Please try again later.
+        advanced_uk/default_settings:
+          attributes:
+            credit_ageing_periods:
+              invalid: must be in ascending order
+            debit_ageing_periods:
+              invalid: must be in ascending order
+            prices:
+              too_few: Last price cannot be deleted/inactive
+              too_many: Too many prices
+            rates:
+              too_few: Last rate cannot be deleted/inactive
+              too_many: Too many rates
+          base:
+            unit_of_measure_with_stock_items: You cannot change your default unit
+              of measure as you have entered a weight on one or more of your stock
+              items.
+        advanced_uk/email_verification:
+          attributes:
+            base:
+              max_attempts: You entered an invalid code too many times. The Email
+                Reply Address has been reset.
+            code:
+              one_attempt_remaining: Wrong code entered<br> %{remaining_attempts}
+                attempt remaining.
+              several_attempts_remaining: Wrong code entered<br> %{remaining_attempts}
+                attempts remaining.
+        advanced_uk/financial_year:
+          attributes:
+            end_date:
+              ensure_start_date_before_end_date: can not be prior to start date.
+        advanced_uk/global_tax_return:
+          attributes:
+            base:
+              cannot_delete_migrated: You cannot delete a migrated VAT Return.
+              cannot_delete_submitted: You cannot delete a submitted VAT Return.
+              cannot_record_refund: You cannot record a refund if it is not a final
+                return of current tax year
+              from_date_after_to_date: From date cannot be after to date.
+              multiple_drafts_not_allowed_on_same_dates: You cannot save more than
+                one draft for the same date range.
+              to_date_before_lockdown_date: Your VAT return "To Date" cannot be on
+                or before your <a href="/settings/financial_settings">year end lockdown
+                date</a> of %{lockdown_date}.
+              to_date_before_start_date: Your VAT return "To Date" cannot be before
+                your <a href="/settings/financial_settings">accounts start date</a>
+                of %{start_date}.
+            total_amount:
+              overpayment: must not be greater than outstanding amount.
+        advanced_uk/hosted_artefact_payment_setting:
+          attributes:
+            base:
+              context_type_is_not_valid: This setting can only be configured for Sales
+                Invoices.
+              object_guid_must_match_object_sageone_guid: The object_guid doesn't
+                match a document for this business. Please check the guid is valid.
+        advanced_uk/journal_code:
+          attributes:
+            base:
+              non_deletable_reason_as_has_transactions: Referred by existing transactions.
+              non_deletable_reason_as_reserved: Reserved.
+        advanced_uk/journal_opening_balance_line:
+          attributes:
+            base:
+              ensure_credit_or_debit_only: Must be either a credit or a debit.
+              invalid_ledger_account: The selected ledger account is invalid.
+        advanced_uk/migration_tax_return:
+          attributes:
+            base:
+              from_date_after_to_date: From date cannot be after to date.
+              to_date_before_lockdown_date: Your VAT return "To Date" cannot be on
+                or before your <a href="/settings/financial_settings">year end lockdown
+                date</a> of %{lockdown_date}.
+              to_date_before_start_date: Your VAT return "To Date" cannot be before
+                your <a href="/settings/financial_settings">accounts start date</a>
+                of %{start_date}.
+        advanced_uk/monthly_statement:
+          attributes:
+            base:
+              enable_first: Use Cancel to discard your changes.
+        advanced_uk/other_expense_payment:
+          attributes:
+            base:
+              line_items_must_be_present: There must be at least one line item.
+            contact:
+              cannot_be_foreign_currency_contact: You cannot create an Other Payment
+                for a foreign currency supplier
+            left_to_allocate:
+              left_to_record_not_zero: You still have payments left to record.
+            voided_by:
+              present: can't be edited
+        advanced_uk/other_expense_payment_line_item:
+          attributes:
+            is_purchase_for_resale:
+              invalid_direct_expense: invalid for this ledger account
+            total_amount:
+              total_amount_not_sum_net_tax_amount: This field must be the sum of Net
+                Amount and VAT Amount
+        advanced_uk/other_expense_payment_refund:
+          attributes:
+            base:
+              cheque_deposited: This cheque has already been deposited.  You must
+                delete the deposit before editing this transaction.
+              line_items_must_be_present: There must be at least one line item.
+            left_to_allocate:
+              left_to_record_not_zero: You still have payments left to record.
+        advanced_uk/other_income_payment:
+          attributes:
+            base:
+              cheque_deposited: This cheque has already been deposited. You must delete
+                the deposit before editing this transaction.
+              line_items_must_be_present: There must be at least one line item.
+            contact:
+              cannot_be_foreign_currency_contact: You cannot create an Other Receipt
+                for a foreign currency customer
+            left_to_allocate:
+              left_to_record_not_zero: You still have receipts left to record.
+        advanced_uk/other_income_payment_refund:
+          attributes:
+            base:
+              cheque_deposited: This cheque has already been deposited.  You must
+                delete the deposit before editing this transaction.
+              line_items_must_be_present: There must be at least one line item.
+            left_to_allocate:
+              left_to_record_not_zero: You still have receipts left to record.
+        advanced_uk/payment:
+          attributes:
+            base:
+              cannot_delete_if_for_another_scheme: You cannot delete Payments created
+                on a different VAT scheme.
+              cannot_edit_if_for_another_scheme: You cannot edit Payments created
+                on a different VAT scheme.
+            payment_type_id:
+              is_invalid: is invalid for business.
+        advanced_uk/payment_line_item:
+          attributes:
+            tax_rate_id:
+              ledger_account_based: for ledger account %{ledger_account} must be '%{tax_rate}'.
+            total_amount:
+              total_amount_not_sum_net_tax_amount: This field must be the sum of Net
+                Amount and VAT Amount
+            total_tax_amount:
+              cant_record_tax_amount_for_zero_rate: You cannot record VAT Amount if
+                using a VAT Rate with a Zero %.
+            trade_of_asset:
+              invalid_category: Can only be selected for fixed assets
+              not_applicable: Is not valid for your tax system.
+        advanced_uk/product:
+          attributes:
+            base:
+              at_least_one_price: Must have at least one price.
+              cannot_convert_to_non_stock: Only stock items can be converted to non-stock
+                items.
+              cannot_convert_with_invalid_code: We can't change this item's type as
+                its item code is longer than 30 characters.
+              cannot_convert_with_invalid_code_action: Change your item code and try
+                again.
+              cannot_convert_with_line_items: We can't change this item's type as
+                it has transactions associated with it.
+              cannot_convert_with_negative_cost: We can't change this item's type
+                as it has a negative cost price. Stock items must have a positive
+                cost price.
+              cannot_convert_with_negative_cost_action: Change your cost price and
+                try again.
+              delete_associated_with_invoice: This non-stock item cannot be deleted
+                as it is associated with a transaction.
+        advanced_uk/product_price:
+          attributes:
+            base:
+              cannot_delete_active_items: Active prices cannot be deleted
+              must_have_at_least_one_active_item: At least one price must be active
+        advanced_uk/purchase_batch_entry:
+          attributes:
+            base:
+              no_eu_contact_without_vat_number_allowed: You selected an EU supplier,
+                thus you have to input your USt-ID.
+            contact:
+              cannot_be_foreign_currency_contact: You cannot create Quick Entries
+                for a foreign currency supplier
+            is_purchase_for_resale:
+              invalid_direct_expense: invalid for this ledger account
+        advanced_uk/quick_start:
+          attributes:
+            business_classification:
+              blank: Try another search and choose a match
+        advanced_uk/sage_pay_vendor:
+          attributes:
+            base:
+              connectivity_issues: There was an issue connecting to Sage Pay
+              does_not_have_view_all_access: The Sage Pay user does not have access
+                to view all transactions
+              invalid_credentials: The supplied Vendor Name, User Name and Password
+                combination do not seem to be valid
+              invalid_encryption_password: The supplied Encryption Password does not
+                seem to be valid
+              not_set_up_to_accept_payments: The Sage Pay account is not set up for
+                Payments
+            default_contact:
+              cannot_be_foreign_currency_contact: cannot be a foreign currency customer.
+        advanced_uk/sales_batch_entry:
+          attributes:
+            base:
+              no_eu_contact_without_vat_number_allowed: You selected an EU customer,
+                thus you have to input your USt-ID.
+            contact:
+              cannot_be_foreign_currency_contact: You cannot create Quick Entries
+                for a foreign currency customer
+        advanced_uk/service:
+          attributes:
+            base:
+              at_least_one_price: Must have at least one rate.
+              cannot_convert_service_items: You cannot convert service items.
+              delete_associated_with_invoice: This service cannot be deleted as it
+                is associated with a transaction.
+        advanced_uk/service_rate:
+          attributes:
+            base:
+              cannot_delete_active_items: Active rates cannot be deleted
+              must_have_at_least_one_active_item: At least one rate must be active
+        advanced_uk/stock_attributes:
+          attributes:
+            base:
+              stock_quantity_invalid: Your item "%{item_code}" does not have enough
+                stock available and will take the quantity in stock to %{quantity_in_stock}.
+              stock_quantity_invalid_on_edit: Adjusting the quantity of your item
+                "%{item_code}" will take the quantity in stock to %{quantity_in_stock}.
+              stock_quantity_invalid_on_void: You can't delete this item as it would
+                result in item "%{item_code}" going into negative stock (%{quantity_in_stock}).
+        advanced_uk/stock_item:
+          attributes:
+            base:
+              cannot_convert_to_stock: Only non-stock items can be converted to stock
+                items.
+              cannot_convert_with_adjustments: We can’t change this item’s type as
+                it has stock adjustments associated with it.
+              cannot_convert_with_adjustments_action: Remove the adjustments from
+                the item’s activity and try again.
+              cannot_convert_with_line_items: We can't change this item's type as
+                it has transactions associated with it.
+              delete_associated_with_activity: This stock item cannot be deleted as
+                it is associated with a stock adjustment.
+              delete_associated_with_invoice: This stock item cannot be deleted as
+                it is associated with a transaction.
+              inactive_when_stock_in_hand: You cannot make this item inactive as it
+                has a quantity in stock.
+          measurement_unit:
+            measurement_unit_invalid: Measurement unit must be in the list of measurement
+              units in the business default settings.
+        advanced_uk/supplier_allocation:
+          attributes:
+            left_to_allocate:
+              left_to_allocate_not_zero: Left to allocate must be zero.
+        advanced_uk/supplier_expense_payment:
+          attributes:
+            base:
+              cannot_allocate_poa_in_payment_that_created_it: You cannot allocate
+                a payment on account from within the supplier payment that originally
+                created the payment on account.
+              cannot_delete_if_payments_allocated: One or more of the selected items
+                are allocated therefore cannot be deleted.
+            left_to_allocate:
+              left_to_allocate_higher: This value cannot be higher than the total
+                amount.
+              present: can't be edited
+        advanced_uk/supplier_refund_payment:
+          attributes:
+            base:
+              cheque_deposited: This cheque has already been deposited.  You must
+                delete the deposit before editing this transaction.
+              payment_artefacts_cannot_overpay: You cannot overpay credit notes.
+              payment_artefacts_status_invalid: You can only pay unpaid or part-paid
+                credit notes.
+            left_to_allocate:
+              left_to_allocate_not_zero: Left to allocate must be zero.
+        advanced_uk/tax_return:
+          attributes:
+            base:
+              cannot_delete_migrated: You cannot delete a migrated VAT Return.
+              cannot_delete_submitted: You cannot delete a submitted VAT Return.
+              cannot_record_refund: You cannot record a refund if it is not a final
+                return of current tax year
+              from_date_after_to_date: From date cannot be after to date.
+              multiple_drafts_not_allowed_on_same_dates: You cannot save more than
+                one draft for the same date range.
+              to_date_before_lockdown_date: Your VAT return "To Date" cannot be on
+                or before your <a href="/settings/financial_settings">year end lockdown
+                date</a> of %{lockdown_date}.
+              to_date_before_start_date: Your VAT return "To Date" cannot be before
+                your <a href="/settings/financial_settings">accounts start date</a>
+                of %{start_date}.
+            total_amount:
+              overpayment: must not be greater than outstanding amount.
+        advanced_uk/tax_return_box:
+          attributes:
+            base:
+              cannot_be_changed: You cannot adjust a Submitted VAT Return.
+        advanced_uk/vat_payment:
+          attributes:
+            amount:
+              overpayment: must not be greater than outstanding amount.
+            tax_return_id:
+              not_submitted: Tax Return is not submitted
+        business:
+          attributes:
+            base:
+              invalid_activity: Activity is not valid.
+              invalid_legal_form: Legal form is not valid.
+            business_retention_settings:
+              invalid: are not valid.
+            registered_country_id:
+              must_be_set_for_business_type: 'must be defined when business_type is
+                ''%{business_type}'' (NOTE: attribute registered_country_id is aliased
+                country_of_registration_id in the API)'
+              required_for_registered_number: is required if you have a registered
+                number.
+            registered_number:
+              invalid_format: Invalid Format
+              length_range: Must be between %{min} and %{max} characters in length
+        core_accounting/taxes/models/tax_rate:
+          attributes:
+            base:
+              can_only_edit_name: Can only edit the name of this tax rate.
+              cant_delete_if_in_transactions: This tax rate has been used on at least
+                one transaction or record.
+              cant_delete_system_tax_rates: This is a default tax rate.
+              cant_delete_tax_rates: Cannot delete tax rates.
+              cant_edit_tax_rate: Cannot edit this tax rate.
+            disabled:
+              ensure_cant_reenable: A disabled tax rate can't be enabled
+            sub_tax_rates:
+              cant_be_combined: Cannot define combined rates from other combined rates.
+              cant_be_the_same: Cannot define combined rates with equal tax rates.
+              cant_have_sub_tax_rates_and_percentage: Cannot define a combined tax
+                rate with a percentage. The percentage is calculated from sub tax
+                rates.
+              cant_have_the_same_name: Cannot define sub tax rates with the same name
+                as the combined tax rate.
+        core_accounting/taxes/models/tax_rate_association:
+          attributes:
+            combined_tax_rate:
+              cant_be_equal_to_sub_tax_rate: The combined tax rate and sub tax rate
+                cannot be the same
+        core_accounting/taxes/models/tax_rate_percentage:
+          attributes:
+            end_date:
+              must_be_greater_than_start_date: The end date must be greater than the
+                start date.
+            percentage:
+              cant_have_more_than_one_present: Please end the previous percentage
+                before adding a new one.
+            start_date:
+              must_be_greater_than_previous_end_date: The start date must be greater
+                than a previous end date
+        currencies/models/business_exchange_rate:
+          attributes:
+            base:
+              delete_base_currency: You can not delete your countries currency.
+              delete_with_contact: You can not delete a currency used by a contact.
+            exchange_rate:
+              change_base_currency: You cannot change the exchange rate of your currency.
+              invalid_exchange_rate: is invalid. Please check.
+        fuji_banking/bank_account:
+          attributes:
+            base:
+              cannot_change_type_of_default_bank_accounts: You cannot change the account
+                type of a default bank account.
+              cannot_change_type_when_transactions_exist: You cannot change the account
+                type because this account has transactions allocated to it.
+              cannot_delete_default_bank_accounts: Bank account %{name} is a default
+                account.
+              cannot_record_after_accounts_start_date: You cannot record entries on
+                or after your Accounts Start Date of %{date}.
+              must_have_accounts_start_date: You must add an accounts start date in
+                financial settings before creating a bank account with an opening
+                balance
+              starting_balance_invalid_date_attribute: Opening Balance must have a
+                date.
+              transactions_allocated: You cannot delete a bank account with transactions
+                allocated.
+            opening_balance_credit:
+              invalid_attributes: Opening Balance must have a debit or credit set.
+            opening_balance_date:
+              invalid: Opening Balance must have a date.
+            opening_balance_debit:
+              invalid_attributes: Opening Balance must have a debit or credit set.
+            starting_balance_credit:
+              invalid_attributes: Opening Balance must have a debit or credit set.
+            starting_balance_debit:
+              invalid_attributes: Opening Balance must have a debit or credit set.
+            starting_balance_source_id:
+              account_not_visible_for_payment: You cannot create a starting balance
+                from the Capital Introduced account because it is not visible for
+                Other Payments
+              account_not_visible_for_receipt: You cannot create a starting balance
+                from the Capital Introduced account because it is not visible for
+                Other Receipts
+              missing_bank_account: Invalid bank account
+            user_nominal_code:
+              already_in_use: already in use.
+              invalid_format: Invalid nominal code
+        fuji_banking/bank_activity:
+          attributes:
+            base:
+              not_allowed_to_destroy_currency_charges: Currency charges cannot be
+                deleted directly. Please remove the currency charge from the related
+                %{payment} to perform this action.
+              not_allowed_to_destroy_journals: Journal transactions must be deleted
+                in Journals. You cannot delete transactions that are bank or VAT reconciled,
+                or cleared. Post a reversal in Journals instead.
+        fuji_banking/bank_reconciliation:
+          attributes:
+            base:
+              cannot_change_completed_reconciliation: This Bank Reconciliation has
+                been completed and cannot be modified.
+              existing_reconciliation: This Bank Reconciliation has been previously
+                started and not completed.
+            statement_date:
+              cannot_be_before_latest_transaction: cannot be before the latest reconciled
+                entry which is %{max_date}
+            warning:
+              date_changed_info: Please apply your changes before you continue.
+              date_changed_warn: 'Your Statement Date and/or Statement End Balance
+                has changed: '
+        fuji_banking/bank_transfer:
+          attributes:
+            base:
+              incorrect_source_payload_type: Incorrect source payload type
+              offset_amount_blank: No offset amount specified
+              offset_ledger_account_blank: No ledger account specified
+              source_and_destination_same: You cannot transfer from and to the same
+                bank account.
+        fuji_banking/deposit:
+          attributes:
+            base:
+              cheque_already_deposited: You cannot deposit a cheque that has already
+                been deposited.
+              not_cash_in_hand: You can only deposit from a cash account.
+              total_amount_greater_than_source_account_balance: Total cash and cheques
+                must not be greater than cash in hand account balance.
+        fuji_contacts/contact:
+          attributes:
+            auxiliary_account:
+              cannot_change_auxiliary_account: changes cannot be saved because there
+                are associated transactions in a closed financial year.
+            base:
+              can_only_have_one_main_address: You can only have one main address.
+              cannot_change_contact_type: There are transactions for this contact
+                type, which prevent it from changing type
+              cannot_delete_an_hmrc_contact: You cannot delete an HMRC contact.
+              cannot_duplicate_auxiliary_account: The account code is already being
+                used by another %{contact_type}.
+              contact_must_be_customer_and_or_supplier: Must specify either customer
+                or supplier
+              contact_obfuscated_cant_be_modified: Obfuscated contact can't be modified.
+              credit_notes: This contact cannot be deleted because there are credit
+                notes assigned to it.
+              currency_credit_limit: Must specify a Credit Limit
+              invoices: This contact cannot be deleted because there are invoices
+                assigned to it.
+              main_address_for_vat_number: Main address must have a country to validate
+                VAT number.
+              must_have_a_main_address: You must have a main address.
+              must_have_a_main_contact: You must have a main contact.
+              sales_quotes: This contact cannot be deleted because there are quotes
+                or estimates assigned to it.
+              uncorrected_transactions: There are transactions for this contact which
+                are preventing it from being deleted
+            business_exchange_rate:
+              cannot_change_hmrc: cannot be changed for a HMRC contact.
+              foreign_currency_disabled: Foreign currency not enabled in Foreign Currencies
+              has_transactions: cannot be changed with transactions for contact.
+            company:
+              cannot_change_hmrc: cannot be changed for a HMRC contact.
+              name_and_company_blank: A Contact or Company Name is required.
+            locale:
+              must_be_one_of: 'Locale must be one of: %{supported_locales}'
+            name:
+              name_and_company_blank: A Contact or Company Name is required.
+            purchase_ledger_account:
+              eu_contact:
+                invalid: is incorrectly selected - please select an EU Purchase ledger
+                  account.
+              home_contact:
+                invalid: is incorrectly selected - please select a non EU/Export Purchase
+                  ledger account.
+              row_contact:
+                invalid: is incorrectly selected - please select ledger account for
+                  an overseas supplier.
+            reference:
+              must_be_unique: must be unique.
+            registered_number:
+              invalid_format: Invalid Format
+              length_range: Must be between %{min} and %{max} characters in length
+            sales_ledger_account:
+              eu_contact:
+                invalid: is incorrectly selected - please select an EU Sales ledger
+                  account.
+              home_contact:
+                invalid: is incorrectly selected - please select a non EU/Export Sales
+                  ledger account.
+              row_contact:
+                invalid: is incorrectly selected - please select an export Sales ledger
+                  account.
+            tax_calculation:
+              non_scheme_support_or_retailers_tax_required: Invalid tax calculation
+                method
+            tax_number:
+              explanation:
+                at: U12345678 (9 characters. The first character is always ‘U’)
+                be: 1234567890 (10 characters. Prefix with zero ‘0’ if the customer
+                  provides a 9 digit VAT number)
+                bg: 123456789, 1234567890 (9 or 10 characters)
+                ca: 123456789XX1234 (15 characters)
+                cy: 12345678X (9 characters. The last character must always be a letter)
+                cz: 12345678, 123456789, 1234567890, (8, 9 or 10 characters. If more
+                  than 10 characters are provided delete the first 3 as these are
+                  a tax code)
+                de: 123456789 (9 characters)
+                dk: 12345678 (8 characters)
+                ee: 123456789 (9 characters)
+                es: X12345678, 12345678X, X1234567X, (9 characters. Includes one or
+                  two alphabetical characters (first or last or first and last.))
+                fi: 12345678 (8 characters)
+                fr: 12345678901, X1234567890, 1X123456789, XX123456789, (11 characters.  May
+                  include alphabetical characters (any except O or I) as first or
+                  second or first and second characters.)
+                gb: 123456789 (9 characters)
+                gr: 123456789 (9 characters)
+                hr: 12345678901 (11 characters)
+                hu: 12345678 (8 characters)
+                ie: 1234567X, 1X23456X, 1234567XX, (8 or 9 characters. Includes one
+                  or two alphabetical characters (last, or second and last, or last
+                  2))
+                it: 12345678901 (11 characters)
+                lt: 123456789, 123456789012, (9 or 12 characters)
+                lu: 12345678 (8 characters)
+                lv: 12345678901 (11 characters)
+                mc: 12345678901, X1234567890, 1X123456789, XX123456789, (11 characters.  May
+                  include alphabetical characters (any except O or I) as first or
+                  second or first and second characters.)
+                mt: 12345678 (8 characters)
+                nl: 123456789B01 (12 characters. The tenth character is always B)
+                pl: 1234567890 (10 characters)
+                pt: 123456789 (9 characters)
+                ro: 12, 123, 1234, 12345, 123456, 1234567, 12345678, 123456789, 1234567890,
+                  (from 2 to 10 characters)
+                se: 123456789012 (12 characters)
+                si: 12345678 (8 characters)
+                sk: 1234567890 (10 characters)
+              format_explanation:
+                at: Format must match 'U12345678 (9 characters. The first character
+                  is always ‘U’)' for country Austria.
+                be: Format must match '1234567890 (10 characters. Prefix with zero
+                  ‘0’ if the customer provides a 9 digit VAT number)' for country
+                  Belgium.
+                bg: Format must match '123456789, 1234567890 (9 or 10 characters)'
+                  for country Bulgaria.
+                ca: Format must match '123456789XX1234 (15 characters)' for country
+                  Canada.
+                cy: Format must match '12345678X (9 characters. The last character
+                  must always be a letter)' for country Cyprus.
+                cz: Format must match '12345678, 123456789, 1234567890, (8, 9 or 10
+                  characters. If more than 10 characters are provided delete the first
+                  3 as these are a tax code)' for country Czech Republic.
+                de: Format must match '123456789 (9 characters)' for country Germany.
+                dk: Format must match '12345678 (8 characters)' for country Denmark.
+                ee: Format must match '123456789 (9 characters)' for country Estonia.
+                es: Format must match 'X12345678, 12345678X, X1234567X, (9 characters.
+                  Includes one or two alphabetical characters (first or last or first
+                  and last.))' for country Spain.
+                fi: Format must match '12345678 (8 characters)' for country Finland.
+                fr: Format must match '12345678901, X1234567890, 1X123456789, XX123456789,
+                  (11 characters.  May include alphabetical characters (any except
+                  O or I) as first or second or first and second characters.)' for
+                  country France.
+                gb: Format must match '123456789 (9 characters)' for country United
+                  Kingdom.
+                gr: Format must match '123456789 (9 characters)' for country Greece.
+                hr: Format must match '12345678901 (11 characters)' for country Croatia.
+                hu: Format must match '12345678 (8 characters)' for country Hungary.
+                ie: Format must match '1234567X, 1X23456X, 1234567XX, (8 or 9 characters.
+                  Includes one or two alphabetical characters (last, or second and
+                  last, or last 2))' for country Ireland.
+                it: Format must match '12345678901 (11 characters)' for country Italy.
+                lt: Format must match '123456789, 123456789012, (9 or 12 characters)'
+                  for country Lithuania.
+                lu: Format must match '12345678 (8 characters)' for country Luxembourg.
+                lv: Format must match '12345678901 (11 characters)' for country Latvia.
+                mc: Format must match '12345678901, X1234567890, 1X123456789, XX123456789,
+                  (11 characters.  May include alphabetical characters (any except
+                  O or I) as first or second or first and second characters.)' for
+                  country Monaco.
+                mt: Format must match '12345678 (8 characters)' for country Malta.
+                nl: Format must match '123456789B01 (12 characters. The tenth character
+                  is always B)' for country Netherlands.
+                pl: Format must match '1234567890 (10 characters)' for country Poland.
+                pt: Format must match '123456789 (9 characters)' for country Portugal.
+                ro: Format must match '12, 123, 1234, 12345, 123456, 1234567, 12345678,
+                  123456789, 1234567890, (from 2 to 10 characters)' for country Romania.
+                se: Format must match '123456789012 (12 characters)' for country Sweden.
+                si: Format must match '12345678 (8 characters)' for country Slovenia.
+                sk: Format must match '1234567890 (10 characters)' for country Slovakia.
+              invalid_format: Format must match '%{explanation}' for country %{country}.
+              must_be_blank: must be blank for countries outside the European Union
+        fuji_contacts/customer:
+          attributes:
+            aux_reference:
+              cannot_be_changed: Debtor number cannot be changed
+        fuji_contacts/supplier:
+          attributes:
+            aux_reference:
+              cannot_be_changed: Creditor number cannot be changed
+          insurer:
+            cannot_be_deleted: A supplier that is an insurer cannot be deleted
+        fuji_core_accounting/coa_account:
+          attributes:
+            base:
+              existing_ledger_accounts: There are existing ledger accounts associated
+                with this account
+              existing_structures: There are existing COA structures associated with
+                this account
+        fuji_core_accounting/coa_template:
+          attributes:
+            base:
+              used_by_businesses: This template is currently in use by one or more
+                businesses
+        fuji_core_accounting/financial_settings:
+          attributes:
+            accounts_start_date:
+              must_be_after_opening_balances_date: must be after all opening balance
+                dates
+              must_be_on_or_before_accounting_object_dates: must be on or before any
+                transactions entered
+              must_be_set_when_opening_balances: must be set when opening balances
+                already exist
+            base:
+              invalid_exchange_rate_delete: You cannot delete exchange rates in use
+              no_vat_number_entered: 'The following settings need to be entered by
+                a user with Full Access to Settings. Please ask your Supervisor or
+                Accountant to enter these: VAT Number'
+              unallocated_credit_notes: You cannot change scheme as you have unallocated
+                Credit Notes
+              unallocated_payments_on_account: You cannot change scheme until you
+                have allocated outstanding payments on account and then ran a VAT
+                return to pick up these allocations
+              unsubmitted_vat_transactions: You must submit a VAT return before changing
+                tax scheme
+              void_future_transactions: Before changing tax scheme you must void any
+                future dated transactions
+            current_financial_year_end_date:
+              can_not_be_changed: can not be changed
+            current_financial_year_start_date:
+              can_not_be_changed: can not be changed
+              no_transactions_allowed_before: no transactions can exist before the
+                first financial year
+            foreign_currency_enabled:
+              cannot_enable: cannot be enabled
+              must_not_have_multi_currency_transactions: cannot be disabled when you
+                have multi currency transactions
+            lockdown_date:
+              must_not_be_before_current_end_date: must not be before current financial
+                year end date
+              must_not_be_before_current_start_date: cannot be earlier than the day
+                before the start of your current financial year
+              must_not_be_in_the_future: must not be in the future
+            next_financial_year_start_date:
+              can_not_be_changed: can not be changed
+              must_be_contiguous: financial years must be contiguous
+            purchase_tax_calculation:
+              not_applicable: not applicable for this business and tax scheme
+              not_taxable: cannot be set for non taxable businesses
+            sales_tax_calculation:
+              not_applicable: not applicable for this business and tax scheme
+              not_taxable: cannot be set for non taxable businesses
+            tax_scheme_id:
+              existing_documents: cannot be changed because there are existing invoice
+                drafts, quotes, or estimates.
+        fuji_core_accounting/ledger_account:
+          attributes:
+            base:
+              cannot_include_deleted_bank: You cannot include a ledger account which
+                belongs to a deleted bank account.
+              combined_2_exclude_ledger_message: Default ledger accounts must be included
+                in your Chart of Accounts. Remember, you may have an account set as
+                default within a customer, supplier, product or service record. Change
+                default accounts at Settings > Record and Transactions Settings and
+                in the relevant record.
+              combined_3_exclude_ledger_message: Default ledger accounts and ledger
+                accounts with transactions must be included in your Chart of Accounts.
+                Remember, you may have an account set as default within a customer,
+                supplier, product or service record. Change default accounts at Settings
+                > Record and Transactions Settings and in the relevant record.
+              has_transactions: Ledger accounts with transactions must be included
+                in your Chart of Accounts.
+              is_control_account: You cannot change the category of a control account.
+              is_default_setting: Default ledger accounts must be included in your
+                Chart of Accounts. Change default accounts at Settings > Record and
+                Transactions Settings.
+              is_not_direct_expense: You can only set "Purchase for resale" for ledger
+                accounts with a direct expense category
+              is_record_default: You cannot remove a ledger account that is set as
+                a default account on a customer, supplier, product or service record. Change
+                default accounts at Settings > Record and Transactions Settings.
+              other_expense_visibility: The default other payment ledger must always
+                be visible. Change default accounts at Settings > Record and Transactions
+                Settings.
+              other_incomes_visibility: The default other receipt ledger must always
+                be visible. Change default accounts at Settings > Record and Transactions
+                Settings.
+              purchases_visibility: The default purchase ledger must always be visible.
+                Change default accounts at Settings > Record and Transactions Settings.
+              sales_visibility: The default sales ledger must always be visible. Change
+                default accounts at Settings > Record and Transactions Settings.
+            control_name:
+              cannot_be_modified: You cannot remove or edit a control name once set.
+              invalid_control_name: This control name is not valid.
+            is_included:
+              is_control_account: You cannot exclude a control account.
+            is_purchase_for_resale:
+              invalid_direct_expense: invalid for this ledger account
+            ledger_account_type_id:
+              cannot_be_modified: You cannot change the category of a bank ledger
+                account.
+              is_control_account: You cannot change the category of a control account.
+              is_invalid: is invalid for business.
+            name:
+              is_control_account: You cannot change the name of a control account.
+            nominal_code:
+              belongs_to_classification: The nominal code must begin with %{count}
+            scope:
+              cannot_modify_bank: You cannot change bank visibility on a bank ledger
+                account.
+            tax_rate:
+              must_be_exempt: Tax rate must be exempt for this ledger.
+              wrong_country: Tax rate must be for the same country as the registered
+                country of the business.
+            trade_of_asset:
+              invalid_category: Can only be selected for fixed assets
+              not_applicable: Is not valid for your tax system.
+        fuji_invoicing/artefact:
+          attributes:
+            base:
+              cannot_discount_sale_of_asset: You cannot apply a discount to the sale
+                of an asset.
+              catalog_item_must_be_active: You cannot create or update a %{type} with
+                an inactive Product or Service.
+              line_items_must_be_present: There must be at least one line item.
+              quantity_and_unit_price_both_negative: Quantity and price cannot both
+                be negative.
+              stock_item_must_have_positive_quantity: Stock item quantity must be
+                greater than 0.
+              stock_item_must_have_positive_value: Stock items can not have a negative
+                value.
+            carriage_tax_rate:
+              eu_tax_invoices_can_only_use_zero_rate: You can only use 'Zero Rated'
+                for EU Tax Registered Customers
+            contact:
+              hmrc_forbidden: must not be an HMRC contact
+        fuji_invoicing/artefact_line_item:
+          attributes:
+            catalog_item:
+              must_be_active: You cannot create a %{type} with an inactive Product
+                or Service.
+            currency_tax_amount:
+              cant_record_tax_amount_for_zero_rate: You cannot record VAT Amount if
+                using a VAT Rate with a Zero %.
+            eu_goods_services_type_id:
+              blank: Please select the EU Goods/Services on each item line.
+            tax_amount:
+              tax_on_non_taxable_business: You cannot add tax, your business is not
+                registered for tax
+            tax_rate_id:
+              ledger_account_based: for ledger account %{ledger_account} must be '%{tax_rate}'.
+            tax_rate_percentage:
+              is_zero: You entered a tax amount but tax rate is zero. Please fix one
+                of them.
+            trade_of_asset:
+              invalid_category: Can only be selected for fixed assets
+              not_applicable: Is not valid for your tax system.
+        fuji_invoicing/corrective_invoice:
+          attributes:
+            base:
+              balance_cannot_be_greater_than_original_outstanding: A Credit Total
+                must not be greater than the outstanding amount of the invoice.
+        fuji_invoicing/credit_note:
+          attributes:
+            base:
+              can_only_release_drafts: You can only release draft credit notes.
+              invoice_must_be_outstanding: You cannot create a Credit Note from an
+                Invoice without an outstanding amount.
+              must_not_be_zero_when_created_from_invoice: You cannot create a Credit
+                Note from an Invoice with a 0.00 value.
+            total:
+              must_not_be_greater_than_outstanding: Must not be greater than the outstanding
+                amount of the invoice.
+        fuji_invoicing/invoice:
+          attributes:
+            base:
+              can_only_release_drafts: You can only release draft invoices.
+              delivery_address_not_filled: Delivery Address is required.
+              invoice_address_not_filled: Invoice Address is required.
+        fuji_invoicing/invoice_settings:
+          attributes:
+            default_delivery_address:
+              invalid_value: Invalid Value
+            document_headers:
+              length: "%{item} heading must be between 1 and 30 characters long"
+              presence: You must supply a heading for %{item}
+            line_item_headers:
+              length: "%{item} heading must be between 1 and 30 characters long"
+              presence: You must supply a heading for %{item}
+            next_credit_note_number:
+              already_taken: is already taken
+            next_invoice_number:
+              already_taken: is already taken
+            next_quote_number:
+              already_taken: is already taken
+            payment_bank_account:
+              cannot_receive_invoice_payment: cannot receive invoice payment
+        fuji_invoicing/purchase_artefact:
+          attributes:
+            currency_total_tax_amount:
+              eu_tax_invoices_can_only_record_zero_amount: You can not record VAT
+                amount for EU Tax Registered Suppliers
+        fuji_invoicing/purchase_artefact_line_item:
+          attributes:
+            currency_tax_amount:
+              eu_tax_invoices_can_only_record_zero_amount: You can not record VAT
+                amount for EU Tax Registered Suppliers
+              rest_of_world:
+                must_be_zero: must be zero for Suppliers outside the EU
+            ledger_account:
+              eu_supplier:
+                invalid: is incorrectly selected - please select an EU ledger account
+              home_supplier:
+                invalid: is incorrectly selected - please select a non EU/Import ledger
+                  account
+              row_supplier:
+                invalid: is incorrectly selected - please select an Import ledger
+                  account
+            tax_rate:
+              rest_of_world_must_be_zero: must be zero for goods and related services
+        fuji_invoicing/purchase_corrective_invoice:
+          attributes:
+            base:
+              cannot_edit_voided_invoice: You cannot edit corrective invoices which
+                have already been voided.
+              cannot_save_already_voided: Corrective invoice already voided.
+              cannot_void_already_voided: Corrective invoice already voided.
+              date_after_due_date: Corrective invoice date cannot be after due date.
+              edit_has_allocations: You must unallocate refunds/payments before editing
+                this corrective invoice.
+              edit_has_payments: You cannot edit corrective invoices where you have
+                recorded a payment.
+              unable_to_copy_artefact: Unable to copy this corrective invoice as a
+                ledger account it uses is no longer available in purchases. Please
+                check the ledger accounts used on the invoice in your chart of accounts
+                to ensure it is available in purchases.
+              void_has_payments: You cannot void corrective invoices where you have
+                recorded a payment.
+        fuji_invoicing/purchase_credit_note:
+          attributes:
+            base:
+              cannot_delete_already_voided: You cannot delete a voided credit note.
+              cannot_edit_migrated_credit_note: You can’t edit this credit note because
+                it was migrated from your old accounting system.
+              cannot_edit_voided_credit_note: You cannot edit credit notes which have
+                already been voided.
+              cannot_save_already_voided: Credit note already voided.
+              cannot_void_already_voided: Credit note already voided.
+              destroy_has_payments: You cannot delete credit note where you have recorded
+                a refund.
+              edit_has_allocations: You must unallocate refunds before editing this
+                credit note.
+              no_eu_contact_without_vat_number_allowed: You selected an EU supplier,
+                thus you have to input your USt-ID.
+              total_must_not_be_negative: Credit note total cannot be negative.
+              unable_to_copy_artefact: Unable to copy this credit note as a ledger
+                account it uses is no longer available in purchases. Please check
+                the ledger accounts used on the credit note in your chart of accounts
+                to ensure it is available in purchases.
+        fuji_invoicing/purchase_credit_note_line_item:
+          attributes:
+            base:
+              asset_purchase_not_service: Credit note line cannot be both an Asset
+                and a Service. Please review the goods / services selection.
+        fuji_invoicing/purchase_invoice:
+          attributes:
+            base:
+              cannot_destroy_already_voided: You cannot delete a voided invoice.
+              cannot_edit_legacy_migrated_invoice: This opening balance invoice cannot
+                be edited, as it was created in your previous Accounts service.
+              cannot_edit_migrated_invoice: You can't edit this invoice because it
+                was migrated from your old accounting system.
+              cannot_edit_voided_invoice: You cannot edit voided invoices.
+              cannot_save_already_voided: Invoice already voided.
+              cannot_void_already_voided: Invoice already voided.
+              date_after_due_date: Invoice date cannot be after due date.
+              destroy_has_payments: You cannot delete invoices where you have recorded
+                a payment.
+              edit_has_allocations: You must unallocate credit notes or payments before
+                editing this invoice.
+              edit_has_credit_notes: You must void any credit notes before editing
+                this invoice.
+              edit_has_payments: You cannot edit invoices where you have recorded
+                a payment.
+              no_eu_contact_without_vat_number_allowed: You selected an EU supplier,
+                thus you have to input your USt-ID.
+              total_must_not_be_negative: Invoice total cannot be negative.
+              unable_to_copy_artefact: Unable to copy this invoice as a ledger account
+                it uses is no longer available in purchases. Please review your chart
+                of accounts.
+              void_has_payments: You cannot void invoices where you have recorded
+                a payment.
+            currency_total_tax_amount:
+              eu_tax_invoices_can_only_record_zero_amount: You can not record VAT
+                amount for EU Tax Registered Suppliers
+        fuji_invoicing/purchase_invoice_line_item:
+          attributes:
+            base:
+              asset_purchase_not_service: Invoice line cannot be both an Asset and
+                a Service. Please review the goods / services selection.
+            is_purchase_for_resale:
+              invalid_direct_expense: invalid for this ledger account
+        fuji_invoicing/purchase_invoice_payment:
+          attributes:
+            base:
+              invoice_is_voided: Invoice is voided.
+        fuji_invoicing/purchase_line_item:
+          attributes:
+            currency_tax_amount:
+              eu_tax_invoices_can_only_record_zero_amount: You can not record VAT
+                amount for EU Tax Registered Suppliers
+              rest_of_world_must_be_zero: must be zero for Suppliers outside the EU
+            ledger_account:
+              eu_supplier_invalid: is incorrectly selected - please select an EU ledger
+                account
+              home_supplier_invalid: is incorrectly selected - please select a non
+                EU/Import ledger account
+              row_supplier_invalid: is incorrectly selected - please select an Import
+                ledger account
+              contact_invalid_for_scopes: is incorrectly selected - you can't use 
+                this ledger account for this supplier.
+            tax_rate:
+              rest_of_world_must_be_zero: must be zero for goods and related services
+        fuji_invoicing/sales_artefact:
+          attributes:
+            base:
+              artefact_number_must_be_unique: Artefact number must be unique
+              both_artefact_number_fields_must_be_present: Both artefact_number and
+                artefact_number_prefix must be present or blank
+        fuji_invoicing/sales_corrective_invoice:
+          attributes:
+            base:
+              cannot_edit_voided_invoice: You cannot edit corrective invoices which
+                have already been voided.
+              cannot_save_already_voided: Corrective invoice already voided.
+              cannot_void_already_voided: Corrective invoice already voided.
+              date_after_due_date: Corrective invoice date cannot be after due date.
+              edit_has_allocations: You must unallocate refunds/payments before editing
+                this corrective invoice.
+              edit_has_credit_notes: You must void any credit notes before editing
+                this corrective invoice.
+              edit_has_payments: You cannot edit corrective invoices where you have
+                recorded a payment.
+              unable_to_copy_artefact: Unable to copy this corrective invoice as a
+                ledger account it uses is no longer available in sales. Please check
+                the ledger accounts used on the invoice in your chart of accounts
+                to ensure it is available in sales.
+              void_has_payments: You cannot void corrective invoices where you have
+                recorded a payment.
+        fuji_invoicing/sales_credit_note:
+          attributes:
+            base:
+              cannot_edit_issued_credit_note: You cannot edit credit notes which have
+                already been issued.
+              cannot_edit_migrated_credit_note: You can’t edit this credit note because
+                it was migrated from your old accounting system.
+              cannot_edit_voided_credit_note: You cannot edit credit notes which have
+                already been voided.
+              cannot_save_already_voided: Credit note already voided.
+              cannot_void_already_voided: Credit note already voided.
+              edit_has_allocations: You must unallocate refunds before editing this
+                credit note.
+              no_eu_contact_without_vat_number_allowed: You selected an EU customer,
+                thus you have to input your USt-ID.
+              total_must_not_be_negative: Credit note total cannot be negative.
+              unable_to_copy_artefact: Unable to copy this credit note as a ledger
+                account it uses is no longer available in sales. Please check the
+                ledger accounts used on the credit note in your chart of accounts
+                to ensure it is available in sales.
+        fuji_invoicing/sales_estimate:
+          attributes:
+            base:
+              no_eu_contact_without_vat_number_allowed: You selected an EU customer,
+                thus you have to input your USt-ID.
+              total_must_not_be_negative: Sales Estimate unit price cannot be negative.
+              unable_to_copy_artefact: Unable to copy this estimate as a ledger account
+                it uses is no longer available in sales. Please check the ledger accounts
+                used on the estimate in your chart of accounts to ensure it is available
+                in sales.
+        fuji_invoicing/sales_invoice:
+          attributes:
+            base:
+              cannot_edit_issued_invoice: You cannot edit issued invoices.
+              cannot_edit_legacy_migrated_invoice: This opening balance invoice cannot
+                be edited, as it was created in your previous Accounts service
+              cannot_edit_migrated_invoice: You can’t edit this invoice because it
+                was migrated from your old accounting system.
+              cannot_edit_voided_invoice: You cannot edit invoices which have already
+                been voided.
+              cannot_save_already_voided: Invoice already voided.
+              cannot_void_already_voided: Invoice already voided.
+              date_after_due_date: Invoice date cannot be after due date.
+              edit_has_allocations: You must unallocate credit notes or receipts before
+                editing this invoice.
+              edit_has_credit_notes: You must void any credit notes before editing
+                this invoice.
+              edit_has_payments: You cannot edit invoices where you have recorded
+                a payment.
+              no_eu_contact_without_vat_number_allowed: You selected an EU customer,
+                thus you have to input your USt-ID.
+              tax_on_non_taxable_business: You cannot add tax, your business is not
+                registered for tax
+              total_must_not_be_negative: Invoice total cannot be negative.
+              unable_to_copy_artefact: Unable to copy this invoice as a ledger account
+                it uses is no longer available in sales. Please check the ledger accounts
+                used on the invoice in your chart of accounts to ensure it is available
+                in sales.
+              void_has_payments: You cannot void invoices where you have recorded
+                a payment.
+        fuji_invoicing/sales_invoice_payment:
+          attributes:
+            base:
+              cheque_deposited: This cheque has already been deposited into a bank
+                account. Delete the deposit before editing this transaction.
+              invoice_is_voided: Invoice is voided.
+        fuji_invoicing/sales_line_item:
+          attributes:
+            base:
+              product_xor_service: Cannot assign both product and service
+            ledger_account:
+              eu_customer_invalid: is incorrectly selected - please select an EU ledger
+                account.
+              home_customer_invalid: is incorrectly selected - please select a non
+                EU/Export ledger account.
+              row_customer_invalid: is incorrectly selected - please select an Export
+                ledger account.
+              contact_invalid_for_scopes: is incorrectly selected - you can't use 
+                this ledger account for this customer.
+            tax_rate:
+              eu_tax_invoices_can_only_use_zero_rate: You can only use 'Zero Rated'
+                for EU Tax Registered Customers.
+              rest_of_world_must_use_zero_rate: must be 'Zero Rated' for Customers
+                outside the EU.
+        fuji_invoicing/sales_quote:
+          attributes:
+            base:
+              no_eu_contact_without_vat_number_allowed: You selected an EU customer,
+                thus you have to input your USt-ID.
+              total_must_not_be_negative: Sales Quote unit price cannot be negative.
+              unable_to_copy_artefact: Unable to copy this quote as a ledger account
+                it uses is no longer available in sales. Please check the ledger accounts
+                used on the quote in your chart of accounts to ensure it is available
+                in sales.
+        inventory/models/stock_movement:
+          attributes:
+            base:
+              catalog_item_inactive_delete: You cannot delete this item as it contains
+                one or more stock items that are marked as inactive.
+              catalog_item_must_be_active: One or more items are marked as inactive.
+                You cannot make changes to inactive items.
+              date_before_accounts_start: The adjustment date must be later than the
+                accounts start date of %{date}. Change the adjustment date or the
+                accounts start date and try again.
+              date_before_accounts_start_compact: The date must be later than the
+                accounts start date of %{date}.
+              date_before_lockdown_date: The adjustment date must be later than the
+                year-end lock date of %{date}. Change the adjustment date or <a href="%{help_url}/find_by_tag?language=%{help_language}&locale=%{help_locale}&service=accounts_extra&tag=extra_financial_year_end"
+                target="_">change the year-end lock down date</a> and try again.
+              date_before_lockdown_date_compact: The date must be later than the year-end
+                lock date of %{date}.
+              original_date_before_lockdown_date: You can't edit this Adjustment as
+                it's dated %{original_date} which is on or before the year end lock
+                date of %{date}. <a href="%{help_url}/find_by_tag?language=%{help_language}&locale=%{help_locale}&service=accounts_extra&tag=extra_financial_year_end"
+                target="_">Change the year-end lock down date</a> and try again.
+        user:
+          attributes:
+            base:
+              activated_user_cannot_be_deleted: You cannot delete activated users.  Please
+                set their access permissions to 'No Access'.
+            email:
+              email_cannot_be_changed: Email cannot be changed
+            user_auths:
+              invalid: are invalid.
+    models:
+      advanced_uk/analysis_type: Analysis Type
+      advanced_uk/bank_opening_balance: Bank Opening Balance
+      advanced_uk/bank_opening_balance_batch: Bank Account Opening Balances
+      advanced_uk/bank_payment: Bank Payment
+      advanced_uk/bank_receipt: Bank Receipt
+      advanced_uk/cashflow_forecast: Cash Flow Forecast
+      advanced_uk/catalog_item:
+        one: Product/Service
+        other: Products/Services
+      advanced_uk/category:
+        one: Category
+        other: Categories
+      advanced_uk/customer_allocation: Customer Allocation
+      advanced_uk/customer_income_payment: Customer Receipt
+      advanced_uk/customer_opening_balance_batch: Customer Opening Balance
+      advanced_uk/customer_opening_balance_entry: Customer Opening Balance
+      advanced_uk/customer_refund_payment: Customer Refund
+      advanced_uk/journal_code: Journal Code
+      advanced_uk/journal_opening_balance: Nominal Opening Balance
+      advanced_uk/journal_opening_balance_line: Nominal Opening Balance Line
+      advanced_uk/other_expense_payment: Other Payment
+      advanced_uk/other_expense_payment_refund: Other Receipt
+      advanced_uk/other_income_payment: Other Receipt
+      advanced_uk/other_income_payment_refund: Other Payment
+      advanced_uk/product:
+        one: Non-stock
+        other: Non-stock
+      advanced_uk/purchase_artefact: Purchase Item
+      advanced_uk/purchase_batch: Purchase Batch
+      advanced_uk/purchase_batch_entry: Purchase Quick Entry
+      advanced_uk/sales_artefact: Sales Item
+      advanced_uk/sales_batch: Sales Batch
+      advanced_uk/sales_batch_entry: Sales Quick Entry
+      advanced_uk/service:
+        one: Service
+        other: Services
+      advanced_uk/stock_item:
+        one: Stock
+        other: Stock
+      advanced_uk/supplier_allocation: Supplier Allocation
+      advanced_uk/supplier_expense_payment: Supplier Payment
+      advanced_uk/supplier_opening_balance_batch: Supplier Opening Balance
+      advanced_uk/supplier_opening_balance_entry: Supplier Opening Balance
+      advanced_uk/supplier_refund_payment: Supplier Refund
+      advanced_uk/tax_return: VAT Return
+      advanced_uk/vat_expense_payment: VAT Payment
+      advanced_uk/vat_income_payment: VAT Reclaim
+      business_membership: User
+      fuji_banking/bank_account: Bank Account
+      fuji_banking/bank_activity: Bank Activity
+      fuji_banking/bank_transfer: Bank Transfer
+      fuji_contacts/contact:
+        one: Contact
+        other: Contacts
+        sar_request:
+          contact:
+            account_details:
+              title: Account Details
+              vat_number: VAT Number
+            addresses:
+              delivery_address:
+                title: Delivery Address
+              main_address:
+                title: Main Address
+              title: Address(es)
+            bank_details:
+              account_name: Account Name
+              account_number: Account Number
+              bic_swift: BIC/Swift
+              iban: IBAN
+              sort_code: Sort Code
+              title: Bank Details
+            contacts:
+              title: Contact(s)
+            email: Email
+            fax: Fax
+            main_contact:
+              title: Main Contact
+            mobile: Mobile
+            notes:
+              title: Notes
+            role: Role
+            telephone: Telephone
+          file:
+            csv:
+              filename: contact_sar_request.csv
+            pdf:
+              filename: contact_sar_request.pdf
+          generated_by: Generated by Sage Business Cloud Accounting
+          personal_data_header: Personal Data
+      fuji_contacts/customer:
+        one: Customer
+        other: Customers
+      fuji_contacts/supplier:
+        one: Supplier
+        other: Suppliers
+      fuji_contacts/vendor:
+        one: Vendor
+        other: Vendors
+      fuji_core_accounting/financial_settings: Financial Settings
+      fuji_core_accounting/ledger_account: Ledger Account
+      fuji_invoicing/credit_note: Credit Note
+      fuji_invoicing/invoice_settings: Invoice Settings
+      fuji_invoicing/purchase_corrective_invoice: Purchase Corrective Invoice
+      fuji_invoicing/purchase_credit_note: Purchase Credit Note
+      fuji_invoicing/purchase_invoice: Purchase Invoice
+      fuji_invoicing/purchase_invoice_payment: Purchase Invoice Payment
+      fuji_invoicing/sales_corrective_invoice: Sales Corrective Invoice
+      fuji_invoicing/sales_credit_note: Sales Credit Note
+      fuji_invoicing/sales_estimate: Estimate
+      fuji_invoicing/sales_invoice: Sales Invoice
+      fuji_invoicing/sales_invoice_payment: Sales Invoice Receipt
+      fuji_invoicing/sales_quote: Quote
+      inventory/adjustment_in: Adjustment In
+      inventory/adjustment_out: Adjustment Out
+      inventory/purchase_corrective_credit_note: Goods In
+      inventory/purchase_corrective_invoice: Goods In
+      inventory/purchase_credit_note: Goods In
+      inventory/purchase_invoice: Goods In
+      inventory/sales_corrective_credit_note: Goods Out
+      inventory/sales_corrective_invoice: Goods Out
+      inventory/sales_credit_note: Goods Out
+      inventory/sales_invoice: Goods Out
+      mysageone_core/jwt_reseller: Reseller
+      mysageone_core/message_recipient: message
+    warnings:
+      messages:
+        adding_credit_note_to_disputed_invoice: The original invoice is in dispute.  Applying
+          a credit note to this invoice will clear its disputed status.
+        adding_payment_to_disputed_invoice: This invoice is currently disputed.  Recording
+          a payment on this invoice will clear its disputed status.
+        adding_refund_to_disputed_credit_note: This credit note is currently disputed.  Recording
+          a refund on this credit note will clear its disputed status.
+        bank_account_multiple_opening_balances: This balance includes itemised entries.
+        declined_estimate: This estimate has been declined. Any changes will result
+          in the declined status being removed.
+        declined_quote: This quote has been declined. Any changes will result in the
+          declined status being removed.
+        payment_bank_and_tax_reconciled: This entry or a previous version of it has
+          been bank / VAT reconciled.  You can make limited changes only.
+        payment_bank_reconciled: Part or all of this entry has been bank reconciled.  You
+          can make limited changes only.
+        payment_cannot_be_edited: You can’t edit this transaction as it has an associated
+          payment or refund.
+        payment_cleared: Part or all of this entry has cleared your bank account.  You
+          can make limited changes only.
+        payment_cleared_and_tax_reconciled: This entry or a previous version of it
+          has cleared your bank account / been VAT reconciled.  You can make limited
+          changes only.
+        payment_tax_reconciled: This entry or a previous version of it has been VAT
+          reconciled.  You can make limited changes only.
+        sage_pay_no_surcharge_ledger_selected: If no Surcharge Ledger Account is selected
+          then the Ledger Account of the transaction itself will be applied to the
+          surcharge.
+        tax_return_require_after_scheme_change: You need to produce a VAT Return to
+          cover the outstanding transactions that became due when the business changed
+          to be Not Registered
+      multi_user:
+        limited_access: There may be limited access to one or more areas of the application.
+        no_access: No summary information to display for your access level.
+        read_only: Your access level is set to Read Only, and you cannot make changes
+          or enter data.
+  address:
+    dialog:
+      custom: Custom
+      delivery_address_same_as_main: Same as invoice address
+      help_tag:
+        custom: Use a custom address.
+        delivery_address_same_as_main: Use main invoice address.
+        no_address: There is no delivery address for this invoice.
+      no_address: No Address
+      title: Set %{edited_object}
+    formats:
+      artefact_templates: |-
+        <span class='street_1'>%{street_1}</span>, <span class='street_2'>%{street_2}</span>
+        <span class='city'>%{city}</span>, <span class='county'>%{county}</span>, <span class='postcode'>%{postcode}</span>
+        <span class='country_name'>%{country_name}</span>
+      blankcity: |-
+        %{street_1}
+        %{street_2}
+        %{county}
+        %{postcode}
+        %{country_name}
+      blankcity_no_country: |-
+        %{street_1}
+        %{street_2}
+        %{county}
+        %{postcode}
+      blankcity_non_na: |-
+        %{street_1}
+        %{street_2}
+        %{county} %{postcode}
+        %{country_name}
+      blankcity_non_na_no_country: |-
+        %{street_1}
+        %{street_2}
+        %{county} %{postcode}
+      default: |-
+        %{street_1}
+        %{street_2}
+        %{city}
+        %{county}
+        %{postcode}
+        %{country_name}
+      default_eu: |-
+        %{street_1}
+        %{street_2}
+        %{county}
+        %{postcode} %{city}
+        %{country_name}
+      default_eu_no_country: |-
+        %{street_1}
+        %{street_2}
+        %{county}
+        %{postcode} %{city}
+      default_eu_no_county: |-
+        %{street_1}
+        %{street_2}
+        %{postcode} %{city}
+        %{country_name}
+      default_eu_no_county_simplified: |-
+        %{street_1}
+        %{city}
+        %{postcode}
+        %{country_name}
+      default_na: |-
+        %{street_1}
+        %{street_2}
+        %{city} %{county} %{postcode}
+        %{country_name}
+      default_na_no_country: |-
+        %{street_1}
+        %{street_2}
+        %{city} %{county} %{postcode}
+      default_na_simplified: |-
+        %{street_1}
+        %{city}
+        %{county}
+        %{postcode}
+        %{country_name}
+      default_no_country: |-
+        %{street_1}
+        %{street_2}
+        %{city}
+        %{county}
+        %{postcode}
+      default_simplified: |-
+        %{street_1}
+        %{city}
+        %{postcode}
+        %{country_name}
+      delimiter: "\n"
+      one_line: "%{street_1}, %{street_2}, %{city}, %{county}, %{postcode}, %{country_name}"
+      one_line_eu: "%{street_1}, %{street_2}, %{city}, %{county}, %{postcode}, %{country_name}"
+      one_line_eu_no_country: "%{street_1}, %{street_2}, %{city}, %{county}, %{postcode}"
+      one_line_na: "%{street_1}, %{street_2}, %{city}, %{county}, %{postcode}, %{country_name}"
+      one_line_na_no_country: "%{street_1}, %{street_2}, %{city}, %{county}, %{postcode}"
+      one_line_no_country: "%{street_1}, %{street_2}, %{city}, %{county}, %{postcode}"
+      one_line_non_na: "%{street_1}, %{street_2}, %{city}, %{county}, %{postcode},
+        %{country_name}"
+      one_line_non_na_no_country: "%{street_1}, %{street_2}, %{city}, %{county}, %{postcode}"
+  allocations:
+    dialog:
+      artefact_total: Total
+      artefact_total_multi_currency: Total<span data-currency="%{currency_code}">&nbsp;</span>
+      description: A detailed breakdown of payments and allocations.
+      description_multi_currency: A detailed breakdown of payments and allocations
+        in %{currency_code}.
+      outstanding: Outstanding
+      outstanding_multi_currency: Outstanding <span data-currency="%{currency_code}">&nbsp;</span>
+      title: Payments and Allocations
+      total_paid: Paid/Allocated
+      total_paid_multi_currency: Paid/Allocated <span data-currency="%{currency_code}">&nbsp;</span>
+    report:
+      headers:
+        allocated_amount: Amount
+        date: Date
+        discount_amount: Discount
+        reference: Reference
+        refund: Refund
+        type: Type
+      rows:
+        allocation_type: Allocation - %{type}
+        total: Total Paid/Allocated
+  analysis_types:
+    headers:
+      areas: Active Areas for this Analysis Type
+      categories: Categories for this Analysis Type
+    labels:
+      analysis_type: Analysis Type
+      analysis_type_category: Analysis Category
+    pod:
+      title: Analysis
+    prompt: None
+    prompt_all: All
+  api:
+    errors:
+      destination_bank_account: Destination must be for a valid bank account
+      filter_dates_required: From and To dates are required
+      filter_dates_to_before_from: From Date must be before the To Date.
+      gone:
+        data_code: Gone
+        message: The requested resource is no longer available
+      inaccessible_field: This field cannot be modified by this API
+      invalid_date: invalid_date
+      invalid_dates: Invalid dates.
+      record_not_found:
+        data_code: RecordNotFound
+        message: Record not found
+      runtime_error:
+        data_code: RuntimeError
+        message: Value was not allowed
+      source_bank_account: Source must be for a valid bank account
+      unprocessable_entity:
+        data_code: UnprocessableEntity
+        message: This entity cannot be modified by this API
+      validation_errors:
+        line_items:
+          message: There must be at least one line item.
+  app:
+    accept: Accept
+    azure:
+      user_not_recognised: We haven't recognised your Azure account. Please complete
+        the sign up form to create a new account.
+      user_recognised: We have recognised your account. Please login to your account.
+    change_password: Change Password
+    cobrands:
+      current_image: 'Co-Brand Logo:'
+      manage: Manage Co-Brands
+      upload_new: Upload New
+    coming_soon_dialog:
+      close: Go back
+      message_1: This feature is still in development,
+      message_2: it will be ready when we publicly release the application.
+      title: Feature coming soon
+    connect_provider:
+      link: Connect with %{provider}
+      message:
+        success: You have successfully linked up your %{provider} account.
+      providers:
+        azure: Azure
+        facebook: Facebook
+        google: Google
+        sageid: SageID
+      sage: Provide a username and password
+      sage_intro: Want to create a Sage Login?
+    cost_per_month: Cost per month
+    cost_this_month: Cost this month
+    decline: Decline
+    email_not_verified_error: To verify your email address, please click the link
+      in the email we sent when you signed up. Need some help or can't find the email?
+      Just give us a call on 0845 111 6611.
+    errors:
+      cannot_access_restricted_area: You do not have access to this option.  If you
+        require access, please contact your Supervisor.
+      impersonation_access_denied: You do not have access to the selected area.
+    facebook:
+      missing_email: To sign up or sign in with Facebook, you must allow permission
+        to your email address
+      user_not_recognised: We haven't recognised your Facebook account. Please complete
+        the sign up form to create a new account.
+      user_recognised: We have recognised your account. Please login to your account.
+    google:
+      user_not_recognised: We haven't recognised your Google account. Please complete
+        the sign up form to create a new account.
+      user_recognised: We have recognised your account. Please login to your account.
+    help: Help
+    home_screen:
+      icons:
+        accounts_extra: Accounting
+    jwt_resellers:
+      header:
+        enabled: Enabled
+        endpoint: Endpoint
+        environment: Environment
+        token: Token
+      manage: Manage Resellers
+      messages:
+        blurb_html: This page is available until %{expiry_date}. After this date,
+          this information will not be available. You should store this information
+          in a secure way. <strong>DO NOT</strong> check this information into source
+          control.
+        confirm_disable: Are you sure you wish to deny this third party provider access?
+        confirm_enable: Are you sure you wish to allow this third party provider to
+          have access?
+        disable: Disable
+        disabled: Production endpoint disabled
+        disabled_html: This customer is currently not allowed to use the production
+          endpoint. Which means <strong>login and automatic provisioning</strong>
+          to any of the services is <strong>disabled</strong>.
+        enable: Enable
+        enabled: Production endpoint enabled
+        enabled_html: This customer is currently allowed to use the production endpoint.  Which
+          means <strong>login and automatic provisioning</strong> to any of the services
+          is <strong>enabled</strong>.
+        page_title: Reseller integration details
+        production: 'Once you''ve checked the validity of your token you can integrate
+          with the production endpoint. To integrate with the production endpoint
+          you must use the following details:'
+        production_disabled:
+          text: Please contact us to enable this endpoint.
+          title: Production endpoint not enabled.
+        readme_html: Read the <a href='%{url}'>documentation</a>.
+        resend:
+          action: Resend invitation
+          confirmation: Are you sure you wish to resend an invitation to %{name}?  Any
+            previously issued invitations will be invalid.
+        signatory_html: 'Your signatory is: <strong>%{signatory}</strong>'
+        steps: Steps to integrate
+        test: 'To check the validity of your token we recommend integrating with the
+          test endpoint. You must use the following details:'
+        title: 'Important:'
+    live_chat: Chat
+    mailer:
+      user_invitation:
+        from: example_from@sageone.com
+        subject: "%{user} invites you to use Sage Business Cloud Accounting"
+    manage_services: Manage Services
+    mysageone: My Sage One
+    name: Sage Business Cloud
+    names:
+      accounts_extra: Accounting
+    oauth:
+      review_permissions: Review Permissions
+    oauth_actions:
+      allow: Allow
+      deny: Deny
+    oauth_authorize_1: " would like to request access to your Sage Business Cloud
+      Accounting data."
+    oauth_authorize_2: 'If you would like more information please contact them at '
+    oauth_authorize_access: 'Access:'
+    oauth_authorize_business: 'Business:'
+    oauth_authorize_link: Application URL
+    oauth_scopes:
+      full_access: Full
+      readonly: Read only
+    one: One
+    password_change_success: Password changed successfully
+    roles:
+      custom: Custom
+      full_access: Full Access
+      no_access: No Access
+      owner: Owner
+      read_only: Read Only
+      restricted_access: Restricted Access
+    sage: Sage
+    service: Service
+    service_names:
+      accounting: Accounting
+      micro: Accounting Start
+      micro_invoicing: Accounting
+      service_uid:
+        accounting: Accounting
+        accounts_extra: Accounting
+        micro: Accounting Start
+        micro_invoicing: Accounting Start
+        sage_one: Accounting Standard
+        sage_one_basics: Invoicing
+    subscription_cost_summary: Subscription Cost Summary
+    superadmin: Super Admin
+    title: Accounting
+    title_html: <span class="logo-sage">Sage</span> <span class="logo-one">One</span>
+    total_cost_per_month: Total cost per month
+    total_cost_this_month: Total cost this month
+    user_invitation:
+      accept:
+        message:
+          success: Invitation accepted.
+        signin_with: Sign in With
+        title: Accept Invitation
+      resend:
+        alert:
+          text: 'The invitation has not been accepted yet. Click the following button
+            to resend the invitation email:'
+          title: 'Invitation '
+        message:
+          success: Invitation email has been resent.
+      title: Your Invitation to %{app_title}
+    user_management_create_user: Invite User
+  artefact_form_options:
+    draft_purchases_credit_note: Draft Credit Notes do not update your Accounts
+    draft_purchases_invoice: Draft Invoices do not update your Accounts
+    draft_sales_credit_note: Draft Credit Notes do not update your Accounts
+    draft_sales_invoice: Draft and Pro Forma Invoices do not update your Accounts
+    notes_textarea_title: Notes
+    save_as: 'Save as:'
+    save_as_draft: Save as draft
+  artefact_line_item:
+    tax: VAT
+  artefact_template_121:
+    net_amount: Net Amount
+    retailer: RE
+    tax: Tax
+    tax_type: Type of tax
+    total: Total
+  artefact_template_18:
+    address:
+      deliver_to: Delivery Address
+    line_items:
+      amount: Total
+      code: Item Code
+    reference: Reference / PO Number
+    sales_credit_note:
+      address:
+        invoice_to: Main Address
+    sales_estimate:
+      address:
+        invoice_to: Main Address
+    sales_invoice:
+      address:
+        invoice_to: Main Address
+    sales_quote:
+      address:
+        invoice_to: Main Address
+  artefact_template_21:
+    net_amount: Net Amount
+    retailer: RE
+    tax: Tax
+    tax_type: Type of tax
+    total: Total
+  artefact_template_9:
+    address:
+      deliver_to: Delivery Address
+    line_items:
+      amount: Total
+      code: Item Code
+    reference: Reference / PO Number
+    sales_credit_note:
+      address:
+        invoice_to: Main Address
+    sales_estimate:
+      address:
+        invoice_to: Main Address
+    sales_invoice:
+      address:
+        invoice_to: Main Address
+    sales_quote:
+      address:
+        invoice_to: Main Address
+  artefact_templates:
+    account: Account
+    address:
+      deliver_to: Deliver To
+      invoice_to: To
+    amount_due: Amount Due
+    amount_paid: Amount Paid
+    attn: Attn
+    bic: 'BIC:'
+    carriage: Carriage
+    contact_details:
+      email: Email
+      main_name: Name
+      mobile: Mobile
+      telephone: Telephone
+      title: Contact Details
+    corrective_invoice:
+      title: Corrective Invoice
+    customer: Customer
+    customer_reference: Customer Code
+    delivery_note:
+      title: Delivery Note
+    discount: Discount
+    draft:
+      title: Draft Invoice
+    due_date: Due by
+    email: Email
+    exchange_rate: Exchange rate
+    for: For
+    iban: 'IBAN:'
+    line_item_headers:
+      description:
+        label: Description
+        value: Description
+      discount:
+        label: Discount
+        value: Discount
+      quantity:
+        label: Quantity or Hours
+        value: Qty/Hrs
+      unit_price:
+        label: Price or Rate
+        value: Price/Rate
+    line_items:
+      amount: Amount
+      code: Code
+      cost: Cost
+      description: Description
+      discount: Discount
+      item: Item
+      net_amount: Net Amt
+      picked: Picked
+      quantity: Qty/Hrs
+      tax: VAT
+      total: Total
+      unit_price: Price/Rate
+    mobile: Mobile
+    net_amount: Net Amount
+    not_tax_invoice: This is not a VAT Invoice
+    note: Note
+    notes: Notes
+    pro_forma:
+      title: Pro Forma Invoice
+    reference: Reference
+    registration:
+      address: Registered Address
+      country: Registered in
+      number: No.
+      tax_registration_number: VAT Registration Number
+    remittance_advice:
+      title: Remittance Advice
+    retailer_tax_total: Recargo de equivalencia
+    sage_pay:
+      pay_now_button: Pay Now
+      pay_now_multi_currency_text: Pay Now option will take payment of outstanding
+        value in %{base_currency}. Total outstanding for this invoice %{base_outstanding}
+      pay_now_text: <p>We accept online payments. It's a fast, secure and very easy
+        way to pay.<br />Simply click the "Pay Now" button to pay this invoice using
+        your credit or debit card.</p>
+    sales_corrective_invoice:
+      address:
+        invoice_to: Invoice To
+      artefact_number: Corrective Invoice Number
+      date: Invoice Date
+      delivery_date: Date
+      details: Details
+      due_date: Due Date
+      original_date: Original Date
+      original_number: Original Invoice Number
+      reason: Reason for Correction
+      title: Sales Corrective Invoice
+      total: Total
+    sales_credit_note:
+      address:
+        invoice_to: Credit Note To
+      artefact_number: Credit Note Number
+      date: Credit Note Date
+      due_date: Credit Date
+      title: Sales Credit Note
+      total: Total
+    sales_estimate:
+      address:
+        invoice_to: Issued To
+      artefact_number: Number
+      date: Issue Date
+      delivery_date: Date
+      due_date: Expiry Date
+      title: Sales Estimate
+      total: Total
+    sales_invoice:
+      address:
+        invoice_to: Invoice To
+      artefact_number: Invoice Number
+      date: Invoice Date
+      delivery_date: Date
+      delivery_performance_date: Delivery/Performance Date
+      due_date: Due Date
+      title: Sales Invoice
+      total: Total
+    sales_quote:
+      address:
+        invoice_to: Issued To
+      artefact_number: Number
+      date: Issue Date
+      delivery_date: Date
+      due_date: Expiry Date
+      title: Sales Quote
+      total: Total
+    signature:
+      date: Date
+      name: Name
+      received: Received By
+      signed: Signed
+    sort_code: Sort Code
+    statement:
+      title: Statement
+    tax_amount: VAT Amount
+    telephone: Telephone
+    terms_and_conditions: Terms and Conditions
+    vat_number: VAT Number
+    website: Website
+    witholding_tax_rate: IRPF
+    your_tax_number: Your VAT Number
+  artefacts:
+    artefact_due_date:
+      one: Due in 1 day
+      other: Due in %{count} days
+      zero_days: Due today
+    artefact_overdue:
+      css_class: overdue
+      label: Overdue
+      one: 1 day <span class='overdue'>overdue</span>
+      other: "%{count} days <span class='overdue'>overdue</span>"
+    confirm:
+      buttons:
+        continue_editing: Continue Editing
+        dismiss: Don’t show again
+        save: Save
+    feedback: We'd love your feedback
+    show:
+      credit_note_address: Credit Note Address
+      delivery_address: Delivery Address
+      due_date: Due Date
+      header_note: Delivery/Performance Date
+      invoice_address: Invoice Address
+      issued: " - Issued"
+      not_issued: " - Not Issued"
+      pdf_generation: " (Generating PDF...)"
+      quote_address: Address
+      reference: Reference
+      sending_email: " (Sending Email...)"
+      supplier_name: Supplier
+      supplier_reference: Supplier Reference
+  attachments:
+    errors:
+      file_could_not_be_deleted: File could not be deleted
+      file_count_exceeded: Maximum files for business exceeded. Only %{limit} allowed.
+      invalid_file_size: The file is too big. Try uploading a file %{limit} or less.
+      invalid_storage_limit: Maximum file storage limit of %{limit} exceeded.
+      reached_artefact_limit: Maximum of %{limit} files per artefact reached.
+  attributes:
+    address_type_form_proxy_id: Address Type
+    cc: Cc
+    country_id: Country
+    customer_name: Customer Name
+    end_date: To
+    is_main_contact: Main Contact
+    line_1: Address 1
+    line_2: Address 2
+    line_3: Town/City
+    line_4: County
+    main: Main
+    main_address_name: Main Address
+    message: Message
+    name: Address Name
+    new_address_name: New Address
+    new_contact_name: New Contact
+    notes: Notes
+    postcode: Postcode
+    reference: Reference
+    second_address_name: Address 2
+    start_date: From
+    supplier_name: Supplier Name
+    to: To
+    valid_for_period_formatted: Valid for Period?
+  audits:
+    mysageone_core/messages:
+      destroy: "%{authenticated_user} has deleted message '%{entity}'"
+    sop_admin/users:
+      resend_email_verification: Admin resent activation email.
+  bank_account_card:
+    balance: Balance
+    bank_balance: Bank Balance
+    cancel_bank_account_connection: Cancel Connection
+    connect_your_bank: Connect Bank
+    connect_your_bank_hint: A secure bank connection that reduces data entry by up
+      to 80%
+    delete_account: Delete
+    disconnect_bank: Disconnect bank account
+    edit_signin_info: Edit sign in info
+    failed_to_connect: Connection Failed...
+    imported: imported
+    imported_transactions:
+      one: Imported Transaction
+      other: Imported Transactions
+      zero: Import
+    last_refresh: 'Refresh: %{when}'
+    last_transaction: 'Last entry: %{when}'
+    last_transaction_never: 'Last entry: never'
+    manage_account: Manage account
+    move_label: Move
+    new_transactions: new transactions
+    no_transactions_imported: No transactions imported
+    pending_to_connect: Connection Pending...
+    refresh_account: Refresh account
+    stripe_view_dashboard: View Dashboard
+    transactions:
+      one: Transaction
+      other: Transactions
+      zero: No transactions
+  bank_activity:
+    grid_filter:
+      transaction_type:
+        prompt: All
+  bank_feed:
+    connected_with:
+      bankdrive: Sage Bank Feeds
+      bankin: Bankin
+      barclays: Barclays
+      hbci: HBCI
+      message: Connected with %{provider}
+      yodlee: Yodlee
+    errors:
+      bank_reconciliation_already_started: A bank reconciliation is already in progress
+        for this bank account.
+      bank_transfer_creation_failed: Bank transfer creation failed.
+      business_does_not_exist: Business does not exist
+      create_transaction_failed: There was a problem in processing this transaction,
+        please try again.
+      customer_income_payment_creation_failed: Customer payment on account could not
+        be created.
+      customer_receipt_creation_failed: Customer receipt could not be created.
+      customer_refund_creation_failed: Customer refund could not be created.
+      inaccessible_account_type: Inaccessible account type
+      incomes_not_specified: Incomes not specified
+      invalid_transaction_type: Invalid transaction type
+      ledger_entry_clearing_failed: Ledger entry clearing failed.
+      match_transaction_failed: There was a problem in processing this transaction,
+        please try again.
+      other_expense_payment_creation_failed: Other payment creation failed.
+      other_income_payment_creation_failed: Other receipt creation failed.
+      supplier_expense_payment_creation_failed: Supplier payment on account could
+        not be created.
+      supplier_payment_creation_failed: Supplier payment could not be created.
+      supplier_refund_creation_failed: Supplier refund could not be created.
+      tax_return_payment_creation_failed: VAT Payment could not be created.
+    messages:
+      cleared_entries_reconciled: New cleared entries have automatically been marked
+        as reconciled and included in your Reconciled Balance.
+      customer_income_payment_created_successfully: Customer payment on account created
+        successfully.
+      customer_receipt_created_successfully: Customer receipt created successfully.
+      customer_refund_created_successfully: Customer refund created successfully.
+      expense_transaction_created_successfully: Other payment created successfully.
+      income_transaction_created_successfully: Other receipt created successfully.
+      ledger_entries_cleared: Ledger Entries cleared
+      ledger_entry_already_corrected: Transaction could not be matched, please refresh
+        and try again.
+      ledger_entry_cleared: Ledger Entry cleared
+      other_expense_payment_created_successfully: Other payment created successfully.
+      other_income_payment_created_successfully: Other receipt created successfully.
+      supplier_expense_payment_created_successfully: Supplier payment on account created
+        successfully.
+      supplier_payment_created_successfully: Supplier payment created successfully.
+      supplier_refund_created_successfully: Supplier refund created successfully.
+      tax_return_payment_created_successfully: VAT Payment created successfully.
+      transaction_matched_successfully: This transaction has been successfully processed.
+      transfers_in_created_successfully: Bank transfer created successfully.
+      transfers_out_created_successfully: Bank transfer created successfully.
+    unlink:
+      button: Disconnect Bank Account
+  banking_cloud:
+    error_confirm:
+      cancel_button: Cancel Request
+      confirm_button: Close
+      description: Please give your bank a call.
+      description_bank_name: Please contact %{bank_name} for help.
+      questions: Check out
+      questions_link: " sageone.com/support"
+      questions_link_href: http://sageone.com/support
+      questions_title: Any questions?
+      sorry_message: Sorry, we seem to be having some trouble setting up your connection.
+      title: Unable to Connect
+    error_message:
+      cancel_button: Cancel Connection
+      description: Sorry, we seem to be having some trouble setting up the connection
+        with your bank. Please give your bank a call.
+      description_bank_name: Sorry, we seem to be having some trouble setting up the
+        connection with your bank. Please contact %{bank_name} for help.
+      title: Unable to Connect
+    indirect_downloading:
+      message: It can take up to 30 minutes to download transactions from your bank
+        for the first time.
+      title: We're downloading your transactions
+    pending_confirm:
+      cancel_button: Cancel Connection
+      confirm_button: Wait for Successful Connection
+      description_cancel: If you cancel your connection request, you can set up a
+        fresh connection at any time.
+      description_cancel_title: Changed your mind?
+      direct:
+        description: |
+          Remember to follow the instructions from your bank below.
+          %{direct_text}
+        no_direct_text: You'll be able to see your bank data coming through within
+          a couple of days. If it's been longer, contact your bank for help, or try
+          cancelling the connection and setting it up again.
+      form:
+        description: |
+          Remember to download your personalised form, and follow the instructions written on it.
+          Once the connection is activated your bank transactions will be available.
+          You’ll then see your transactions flowing in - job done!
+        download_link: Download the Form
+      questions: Check out
+      questions_link: " sageone.com/support"
+      questions_link_href: http://sageone.com/support
+      questions_title: Any questions?
+      title: Setting up Connection
+      web:
+        description: |
+          Remember to <a class='UILink carbon-link__anchor' href='%{direct_text}' target='_blank'>visit your Bank’s Website</a>,
+          and follow the instructions.
+          <br />Once the connection is activated your bank transactions will be available.
+        no_direct_text: You'll be able to see your bank data coming through within
+          a couple of days. If it's been longer, contact your bank for help, or try
+          cancelling the connection and setting it up again.
+    pending_message:
+      cancel_button: Cancel Connection
+      direct:
+        description_span_1: Remember to follow the instructions from your bank. %{direct_text}
+        no_direct_text: You'll be able to see your bank data coming through within
+          a couple of days. If it's been longer, contact your bank for help, or try
+          cancelling the connection and setting it up again.
+      form:
+        description_span_1: 'Remember to '
+        description_span_2: ", and follow the instructions written on it. Once the
+          connection is activated your bank transactions will be available."
+        download_link: download your personalised form
+      title: Setting up Connection
+      web:
+        description_span_1: |
+          Remember to <a class='UILink carbon-link__anchor' href='%{direct_text}' target='_blank'>visit your Bank’s Website</a>,
+          and follow the instructions. Once the connection is activated your bank transactions will be available.
+        no_direct_text: You'll be able to see your bank data coming through within
+          a couple of days. If it's been longer, contact your bank for help, or try
+          cancelling the connection and setting it up again.
+  bulk_destroy:
+    messages:
+      migrated: You can't delete one or more of the selected items because it was
+        migrated from your old accounting system.
+      payments_allocated:
+        credit_note: One or more of the selected items are paid, part-paid or already
+          voided and cannot be deleted.
+        invoice: One or more of the selected items are paid, part-paid or already
+          voided and cannot be deleted.
+        purchase_artefact: One or more of the selected items are paid, part-paid or
+          already voided and cannot be deleted.
+        sales_artefact: One or more of the selected items are paid, part-paid or already
+          voided and cannot be deleted.
+      tax_reconciled: One or more of the selected items are VAT reconciled and cannot
+        be deleted.
+      warning:
+        credit_note: 'One or more of the selected items is completed and cannot be
+          deleted. In order to keep the sequential numbers for credit notes following
+          HMRC rules they will be voided instead. If you wish to void the selected
+          item(s), enter a reason below:'
+        invoice: 'One or more of the selected items is completed and cannot be deleted.
+          In order to keep the sequential numbers for invoices following HMRC rules
+          they will be voided instead. If you wish to void the selected item(s), enter
+          a reason below:'
+        purchase_artefact: 'One or more of the selected items is completed and cannot
+          be deleted. In order to keep the sequential numbers for invoices or credit
+          notes following HMRC rules they will be voided instead. If you wish to void
+          the selected item(s), enter a reason below:'
+        sales_artefact: 'One or more of the selected items is completed and cannot
+          be deleted. In order to keep the sequential numbers for invoices or credit
+          notes following HMRC rules they will be voided instead. If you wish to void
+          the selected item(s), enter a reason below:'
+      warning_allocated_credit_note: Deleting an allocated credit note will set the
+        associated invoice as unpaid.
+      warning_draft:
+        credit_note: One or more of the selected items has a Draft status. Draft credit
+          notes will be fully deleted and won't be retained after deletion.
+        purchase_artefact: One or more of the selected items has a Draft status. Draft
+          invoices or credit notes will be fully deleted and won't be retained after
+          deletion.
+        purchases_invoice: One or more of the selected items has a Draft status. Draft
+          invoices will be fully deleted and won't be retained after deletion.
+        sales_artefact: One or more of the selected items has a Draft or Pro Forma
+          status. Draft or Pro Forma invoices or credit notes will be fully deleted
+          and won't be retained after deletion.
+        sales_invoice: One or more of the selected items has a Draft or Pro Forma
+          status. Draft or Pro Forma invoices will be fully deleted and won't be retained
+          after deletion.
+      warning_no_access:
+        default: Your access level does not allow you to void invoices or credit notes,
+          please speak to your Supervisor.
+        sales:
+          quote: Your access level does not allow you to delete sales quotes or estimates,
+            please speak to your Supervisor.
+    titles:
+      access_denied: Access Denied
+      migrated:
+        credit_note: Delete Purchase Credit Note
+        invoice: Delete Purchase Invoice
+        purchase_artefact: Delete Purchase Item
+      payments_allocated_or_voided:
+        credit_note: Payments allocated or voided
+        invoice: Payments allocated or voided
+        purchase_artefact: Payments allocated or voided
+        sales_artefact: Payments allocated or voided
+      tax_reconciled: VAT Reconciled
+  bulk_pay_or_allocate:
+    messages:
+      payments_allocated_or_voided:
+        credit_note: One or more of the selected items are already voided, fully allocated
+          or draft.
+        purchase_artefact: One or more of the selected items are already voided, fully
+          allocated or draft.
+        purchases_invoice: One or more of the selected items are already voided, fully
+          allocated or draft.
+        sales_artefact: One or more of the selected items are already voided, fully
+          allocated, draft or pro forma.
+        sales_invoice: One or more of the selected items are already voided, fully
+          allocated, draft or pro forma.
+    titles:
+      more: More
+      pay_or_allocate: Pay or Allocate
+      payments_allocated_or_voided:
+        credit_note: Payments allocated or voided
+        invoice: Payments allocated or voided
+        purchase_artefact: Payments allocated or voided
+        sales_artefact: Payments allocated or voided
+  bulk_remove_cleared:
+    messages:
+      success: Cleared status has been removed for %{number_cleared} transaction(s).
+    titles:
+      more: More
+      remove_cleared_status: Remove Cleared Status
+  bulk_void:
+    messages:
+      migrated: You can't void one or more of the selected items because it was migrated
+        from your old accounting system.
+    titles:
+      migrated:
+        credit_note: Void Sales Credit Note
+        invoice: Void Sales Invoice
+        sales_artefact: Void Sales Item
+  business_membership:
+    formatted: "%{user} of %{business}"
+  business_membership_admin:
+    customer_list:
+      title: Customer List
+  business_type:
+    description:
+      limited: we're registered at Companies House
+      partner: it's me and my business partner(s)
+      sole: I work for myself
+    name:
+      limited: Limited Company/LLP
+      partner: Partnership
+      sole: Sole Trader or Small Business
+  change_password: Change Password
+  checkbox:
+    advanced_uk/product:
+      label: Sales Price Includes VAT
+    advanced_uk/service:
+      label: Rate Includes VAT
+  cheque_printing:
+    cheque_stub:
+      amount_label: 'Cheque Amount:'
+      continue_message: List continues on the next page...
+      date_label: 'Date:'
+      payee_label: 'To:'
+      reference_label: 'Reference:'
+      stub_title: ''
+      stub_title_label: Cheque Payment
+      summary_label: 'Continued:'
+      summary_value: Cheque to %{payee} on %{date}
+      table_headers:
+        amount_paid: Amount Paid
+        amount_refunded: Amount Refunded
+        balance: Remaining Balance
+        credit_amount: Credit Amount
+        credit_date: Credit Date
+        credit_number: Credit Number
+        details: Details
+        discount: Discount Taken
+        invoice_amount: Invoice Amount
+        invoice_date: Invoice Date
+        invoice_number: Invoice Number
+        tax_rate: Tax Rate
+    delete_dialog:
+      content_line1: "- If the cheque was linked to an invoice, the invoice will show
+        as ‘unpaid’ again."
+      content_line2: "- You can re-use the same cheque number for a new payment if
+        you like."
+      content_title: What else happens when I delete a cheque?
+      save: Delete Cheque
+      title: Delete Cheque
+      warning: Are you sure you’d like to permanently delete this cheque, and the
+        transaction it’s linked to?
+    dummy:
+      amount: XXXXXXXXX
+      amount_with_currency: XXXXXXXXXX
+      date: XXXXXXXXX
+      date_format: XXXXXXXXX
+      payee: XXXXXXXXXXXXXXXXXXXXX
+      payee_with_address: XXXXXXXXXXXXXXX<br>XXXXXXXXXXXXXXX<br>XXXXXXXXXXXXXXX<br>XXXXXXXXXXXXXXX
+      text_amount: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+      text_amount_no_currency: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    edit_dialog:
+      cancel: Cancel
+      cheque_number: Cheque Number
+      save: Save
+      title: Edit Cheque Number
+    errors:
+      delete_void: Void payments can't be deleted
+    issue_dialog:
+      cheque_number: Cheque Number (optional)
+      enter: If you don’t want to print a cheque, but still want to issue it to a
+        payee, enter your cheque number below (for example, if you write your cheques
+        manually).
+      optional: optional
+      save: Issue Manually
+      title: Issue Cheque Manually
+    number_label: |
+      **Cheque Number**
+      (optional)
+    presenter:
+      address_line3: "%{line_3} %{line_4} %{postcode}<br>"
+      text_amount: "%{amount_dollars} Pounds and %{amount_cents}/100"
+      text_amount_no_currency: "%{whole_amount} and %{rational_amount}/100"
+    print_dialog:
+      cheque_number: Cheque Number
+      enter: When you’ve successfully printed, enter the pre-printed cheque number
+        below.
+      print: Print Cheque
+      print_for: Print your cheque for **%{amount}** to **%{payee}**.
+      save: All Done!
+      title: Print a Cheque
+    register:
+      actions:
+        balance: Bank Balance
+        bank: Bank Account
+        delete:
+          title: Delete
+        issue:
+          title: Issue Manually
+          tooltip: Issue manual cheque
+        paper: Cheque Paper
+        print:
+          title: Print Cheque
+          tooltip: Print cheque
+        settings: Settings
+        void:
+          title: Void
+      alert_delete_one_cheque: Please select only one cheque to delete at a time.
+      alert_delete_voided_cheque: This cheque has already been voided, and cannot
+        be deleted.
+      alert_issue_one_cheque: Please select only one cheque to issue manually.
+      alert_print_one_cheque: Please select only one cheque to print at a time.
+      alert_print_voided_cheque: Voided cheques can’t be printed.
+      alert_void_one_cheque: Please select only one cheque to void at a time.
+      alert_void_saved_cheque: You can only void cheques that have already been printed/issued
+        manually. Please print the cheque or issue the cheque manually, then void
+        it.
+      alert_void_voided_cheque: This cheque has already been voided.
+      delete_cheque_success: The cheque has been deleted successfully.
+      headers:
+        amount: Amount
+        bank: Bank Account
+        date: Trx Date
+        name: Name
+        number: Cheque Number
+        printed: Date Printed/Issued
+        status: Status
+        type: Type
+        voided: Date Voided
+      identical_number_validation_error: The cheque number entered is identical to
+        the saved number.
+      payment_types:
+        customer_refund: Customer Refund
+        other_expense: Other Payment
+        supplier_expense: Bill Payment
+      sage_cheque: Sage Cheque Paper
+      set_cheque_number_success: The cheque number has been successfully updated.
+      status:
+        manual: Issued Manually
+        printed: Printed
+        saved: Saved
+        voided: Voided
+      tabs:
+        all: All Cheques
+        print: Cheques to Print (%{total})
+      void_cheque_success: The cheque has been successfully voided.
+      void_date_validation_error: The void date must be on or after the transaction
+        date %{start_date}.
+    settings:
+      buy:
+        help_content: Checks are printed in the language chosen in each vendor's profile
+          in the Contacts section.
+        help_title: Print in your Vendor's Language
+        hours: Monday - Friday, 8am - 8pm GMT
+        link: https://www.sagechecks.com/estore/Sage+One/All+Versions+-+Sage+One/SL-MP98/prod1620237_prd.p?_requestid=69534
+        phone: Call 1-800-617-3224
+        url: "**Buy Compatible Cheques**"
+      enable:
+        browser: as your web browser to make printing easier.
+        description: We'll show the Cheque Register under the Banking section, and
+          ask if you'd like to print a cheque when you create payments.
+        label: Enable Cheque Printing
+        latest: and using the latest version of
+        recommend: We recommend installing the latest version of
+        title: Enable Cheque Printing
+      external_links:
+        adobe:
+          name: Adobe Reader
+          url: https://get.adobe.com/reader/
+        chrome:
+          name: Google Chrome
+          url: https://www.google.com/chrome/browser/desktop/
+      setup:
+        button: Print Setup
+        description: Run a test print to help line your printer up perfectly with
+          your cheque paper.
+        title: Print Setup
+      template:
+        description: Select the type of cheque stock you purchased, so we know exactly
+          where to print the details.
+        description_1: We'll print your cheques to line up exactly with this cheque
+          stock.
+        labels:
+          :1: "**Sage Cheque Paper**  \n(SLMP98)"
+          :2: QuickBooks Voucher
+        title: Choose your Cheque Paper
+        title_1: Cheque Paper
+    setup_dialog:
+      adjust:
+        left:
+          minus: Further left
+          plus: Further right
+        line_up: To line up, the printed numbers need to be...
+        measure: Using the square grid printed on **Test Cheque 1**, measure the distance
+          between where the printed numbers are now, and their correct location on
+          the pre-printed cheque paper.
+        squares: squares
+        top:
+          minus: Higher up
+          plus: Lower down
+      adjust_help:
+        read: Read about
+        title: Need some help?
+        topic: aligning your printer for cheque printing.
+      all_done: All Done!
+      back: Back
+      confirm:
+        done:
+          long: the numbers are now in the right place.
+          long_1: the numbers are in the right place.
+          short: 'Yes'
+        hold_up: Place **Test Cheque %{number}** on top of a sheet of pre-printed
+          cheque paper, and hold them up to the light.
+        line_up: Do the printed numbers line up with your cheque paper now?
+        line_up_1: Do the printed numbers line up with your cheque paper?
+        more:
+          long: I'll try again, measuring from **Test Cheque 1**.
+          long_1: I need to adjust where the numbers are printed.
+          short: 'No'
+      continue: Continue
+      done:
+        choose: Select **Cheques to Print** on the **Cheque Register**.
+        ready: You’re now ready to print cheques!
+      intro:
+        browser: as your web browser.
+        install: Install the latest version of
+        read_more: Read more
+        scaling: Make sure your system doesn't add margins or adjust scaling when
+          you print, for example, in Google Chrome, make sure 'Fit to page' is not
+          checked.
+        set_up: To set up your printer, print **Test Cheque 1** on a sheet of blank
+          Letter sized paper.
+        to_print: To print cheques directly on pre-printed cheque paper...
+        use: and use
+      print: Print Test Cheque %{number}
+      reprint:
+        make_sure: To make sure your adjustments worked, print **Test Cheque %{number}**.
+      test_cheque: Test Cheque
+      title: Cheque Printing Setup
+    test_cheque:
+      amount: 218615.37
+      instructions:
+        continue: Try again, measuring from <strong>Test Cheque 1</strong>.
+        continue_1: Using the square grid above, measure the distance between where
+          the printed numbers are now, and their correct location on the pre-printed
+          cheque paper. Enter your adjustments as required.
+        done: 'Yes'
+        main: Place this page on top of a sheet of pre-printed cheque paper, and hold
+          them up to the light.
+        more: 'No'
+        prompt: Do the printed numbers line up with your cheque paper now?
+        prompt_1: Do the printed numbers line up with your cheque paper?
+        ready: You're ready to print cheques!
+        title: Verify your Adjustments
+        title_1: Measure for Alignment
+      payee: VOID Payee VOID
+      payee_with_address: VOID Payee VOID<br>1001 Test Drive<br>Suite 111<br>Atlanta
+        GA 30363<br>United States
+      text_amount: Two Hundred Eighteen Thousand Six Hundred Fifteen Dollars and 37/100
+      text_amount_no_currency: Two Hundred Eighteen Thousand Six Hundred Fifteen and
+        37/100
+      title: Test Cheque
+    transaction_dialog:
+      create: How would you like to create your cheque?
+      message_content: To print from Accounting, remember to choose a supplier. Or,
+        continue without a supplier and write your cheque.
+      message_title: Want to print your cheque?
+      method: You chose 'Cheque' as the payment method for this transaction.
+      radio:
+        later: "**I'll print this cheque later** - I'll go to the Cheque Register
+          in Banking when I'm ready."
+        manual: "**I'll write out a cheque manually** - and enter a cheque number."
+        now: "**I'll print this cheque right now** - take me to the Cheque Register."
+      save_text: Confirm
+      title: Pay by Cheque
+    transaction_fields:
+      optional: " (optional)"
+      vendor: Vendor
+    unable_delete_dialog:
+      line1: This cheque can’t be deleted because the payment has been reconciled.
+      line2: You could enter another transaction to compensate for this cheque’s value
+        if you need to.
+      save: Got it!
+      title: Unable to delete cheque
+    unable_void_dialog:
+      line1: This cheque can’t be voided because the payment has been reconciled.
+      line2: You could enter another transaction to compensate for this cheque’s value
+        if you need to.
+      save: Got it!
+      title: Unable to void cheque
+    void_dialog:
+      content_line1: "- It will still be listed in the Cheque Register, but marked
+        as voided."
+      content_line2: "- We’ll reverse the original transaction - this will show up
+        in your Audit Trail report."
+      content_line3: "- If you still want to make the payment, you can enter a new
+        one."
+      content_title: What happens when I permanently void a cheque?
+      date_label: Date Cheque Voided
+      enter: If you printed a cheque but you don’t want to issue it to a payee, you
+        can permanently void it.
+      link_text: Read more about this
+      message: This cheque was created in a previous month, but voiding the cheque
+        will affect your reports on the date entered here. To avoid this, change the
+        date to the same month that the cheque was created.
+      message_title: Voiding cheques across financial periods
+      save: Void Cheque
+      title: Void Cheque
+  coa:
+    exclude: Exclude
+    include: Include
+  confirm:
+    buttons:
+      include_future_vat_return: Include on Future VAT Return
+      keep_prices: Keep Current Prices
+      replace: Replace
+      transfer: Transfer
+      update_prices: Update Prices
+    messages:
+      advanced_uk/catalog_item:
+        bulk_destroy:
+          error: The selected items could not be deleted as one or more of them are
+            in use
+          one: Are you sure you wish to delete this Product or Service?
+          other: Are you sure you wish to delete these Product and Services?
+        convert:
+          allow: allow
+          cancel: Cancel
+          change_type: Change type
+          confirm:
+            one: Convert Item
+            other: Convert %{no_of_items} Items
+          info: Converting items to %{item_type} will %{allow} you to track quantities
+            in and out.
+          not_allow: not allow
+          one: Are you sure you want to change this item to %{item_type}?
+          other: Are you sure you want to convert %{no_of_items} items to %{item_type}?
+          success:
+            one: Item successfully converted to %{item_type}!
+            other: "%{no_of_items} items successfully converted to %{item_type}!"
+        delete:
+          error: We were unable to delete this Item
+          question: Are you sure you wish to delete this Item?
+          success: Item has been deleted
+        type:
+          non-stock: Non-stock
+          stock: Stock
+        update:
+          error: We were unable to update this Item
+          success: Item updated successfully
+      advanced_uk/category:
+        bulk_destroy:
+          one: |-
+            Are you sure you want to delete this category?
+
+            Deleting this category will remove the category from any products and services associated with it.
+          other: |-
+            Are you sure you want to delete these categories?
+
+            Deleting these categories will remove the category from any products and services associated with them.
+      advanced_uk/transactions:
+        include_transaction_on:
+          future_vat_return: The next time you run a VAT return, we’ll remind you
+            about this transaction. <br><strong>Are you sure you’d like to continue?</strong>
+      copy_clashing_note_confirmation_for_estimate: Do you want to transfer the Notes
+        from this Estimate to the Sales Invoice, or replace them with the Default
+        Notes?
+      copy_clashing_note_confirmation_for_quote: Do you want to transfer the Notes
+        from this Quote to the Sales Invoice, or replace them with the Default Notes?
+      copy_note_confirmation_for_estimate: Do you want to transfer the Notes from
+        this Estimate to the Sales Invoice?
+      copy_note_confirmation_for_quote: Do you want to transfer the Notes from this
+        Quote to the Sales Invoice?
+      default_prices: The default product price for %{customer} is <strong>%{price_name}</strong>.
+        Do you want to update this invoice to use %{customer}'s default product prices,
+        or keep the prices currently listed?
+      fuji_banking/bank_activity:
+        bulk_destroy:
+          one: Are you sure you wish to delete this Bank Activity?
+          other: Are you sure you wish to delete these Bank Activities?
+      fuji_contacts/contact:
+        bulk_destroy:
+          one: Are you sure you wish to delete this Contact?
+          other: Are you sure you wish to delete these Contacts?
+      fuji_contacts/customer:
+        bulk_destroy:
+          one: Are you sure you wish to delete this Customer?
+          other: Are you sure you wish to delete these Customers?
+      fuji_contacts/supplier:
+        bulk_destroy:
+          one: Are you sure you wish to delete this %{model}?
+          other: Are you sure you wish to delete these %{model}?
+      fuji_invoicing/sales_quote:
+        bulk_destroy:
+          one: Are you sure you wish to delete this Quote or Estimate?
+          other: Are you sure you wish to delete these Quotes or Estimates?
+      include_future_vat_return:
+        success: Transaction updated successfully
+      inventory/models/stock_movement:
+        bulk_destroy:
+          adj_in: Your quantity in stock and average cost price will be updated.
+          adj_out: Your quantity in stock will be updated.
+          error_lockdown_date:
+            one: You can't delete this Adjustment as the date must be later than the
+              year-end lock date of %{date}. <a href="%{help_url}/find_by_tag?language=%{help_language}&locale=%{help_locale}&service=accounts_extra&tag=extra_financial_year_end"
+              target="_">Change the year-end lock down date</a> and try again.
+            other: You can't delete one or more Adjustments as the date must be later
+              than the year-end lock date of %{date}. <a href="%{help_url}/find_by_tag?language=%{help_language}&locale=%{help_locale}&service=accounts_extra&tag=extra_financial_year_end"
+              target="_">Change the year-end lock down date</a> and try again.
+          error_negative_stock:
+            one: You can't delete this Adjustment as it would result in negative stock.
+            other: You can't delete one or more Adjustments as it would result in
+              negative stock.
+          error_non_adjustments:
+            one: You can't delete this item, only Adjustments can be deleted.
+            other: You can't delete one or more items, only Adjustments can be deleted.
+          error_stock_item_inactive:
+            one: You can't delete this item as your stock item is inactive.
+            other: You can't delete one or more items as your stock item is inactive.
+          one: Are you sure you wish to delete this Adjustment?
+          other: Are you sure you wish to delete these Adjustments?
+        delete:
+          error: We were unable to delete this Adjustment.
+          error_non_adjustments: The selected item could not be deleted, only Adjustments
+            can be deleted.
+          question:
+            adj_in: |-
+              Are you sure you want to delete this Adjustment?
+
+              Your quantity in stock and average cost price will be updated.
+            adj_out: |-
+              Are you sure you want to delete this Adjustment?
+
+              Your quantity in stock will be updated.
+          success: Adjustment has been deleted!
+      multi_currency:
+        convert: Convert
+        convert_values: Would you like us to convert all your entered values into
+          the currency for the contact or leave them as entered?
+        keep_current: Keep Current Rate
+        leave: Leave
+        use_latest: Use Latest Rate
+        use_new_rate: The latest exchange rate for this contacts currency does not
+          match your current entered rate, would you like to use the latest value
+          or keep the current one?
+    titles:
+      advanced_uk/catalog_item:
+        bulk_destroy:
+          one: Delete?
+          other: Delete?
+        convert: Change to %{item_type}
+        delete: Delete?
+      advanced_uk/category:
+        bulk_destroy:
+          one: Delete Category?
+          other: Delete Categories?
+      advanced_uk/transactions:
+        include_transaction_on:
+          future_vat_return: Include Transaction on Future VAT Return
+      copy_clashing_note_confirmation_for_estimate: Create Sales Invoice from Estimate
+      copy_clashing_note_confirmation_for_quote: Create Sales Invoice from Quote
+      copy_note_confirmation_for_estimate: Create Sales Invoice from Estimate
+      copy_note_confirmation_for_quote: Create Sales Invoice from Quote
+      default_prices: Update Invoice Prices?
+      fuji_banking/bank_activity:
+        bulk_destroy:
+          one: Delete Bank Activity?
+          other: Delete Bank Activities?
+      fuji_contacts/contact:
+        bulk_destroy:
+          one: Delete Contact?
+          other: Delete Contacts?
+      fuji_contacts/customer:
+        bulk_destroy:
+          one: Delete Customer?
+          other: Delete Customers?
+      fuji_contacts/supplier:
+        bulk_destroy:
+          one: Delete %{model}?
+          other: Delete %{model}?
+      fuji_invoicing/sales_quote:
+        bulk_destroy:
+          one: Delete Quote/Estimate?
+          other: Delete Quotes/Estimates?
+      inventory/models/stock_movement:
+        bulk_destroy:
+          one: Delete Adjustment?
+          other: Delete Adjustments?
+        delete:
+          adj_in: Delete Adjustment In?
+          adj_out: Delete Adjustment Out?
+      please_select: Please select
+  confirm_dialogs:
+    duplicate_artefacts:
+      cancel: Review
+      message_for_purchase: One or more of these entries have the same date, reference
+        and supplier as previously entered transactions. Click Save Anyway to continue,
+        or Review to check the entries.
+      message_for_sales: One or more of these entries have the same date, reference
+        and customer as previously entered transactions. Click Save Anyway to continue,
+        or Review to check the entries.
+      ok: Save Anyway
+      title: Warning
+  contact_activity:
+    contacts:
+      bank_details:
+        aba_routing: ABA/Routing Number
+        account_no: Account Number
+        account_no_validation: Account number must be between 5 and 12 digits
+        bic: BIC/SWIFT
+        institution_no: Institution Number
+        institution_no_validation: Institution number must be 3 digits
+        transit_no: Bank Transit Number
+        transit_no_validation: Transit number must be 5 digits
+        withholding_tax_rate: Default IRPF Rate
+      dialog:
+        account_default: Account Default
+        address_1: Delivery Address
+        address_2: Invoice Address
+        address_one: Address 1
+        aux_reference:
+          customer: Debtor Number
+          supplier: Creditor Number
+        auxiliary_account: Account code
+        bank_details: BANK DETAILS
+        business_name: Business Name
+        business_no: Business Number
+        city: City
+        contact_name: Contact Name
+        contact_type:
+          customer: customer
+          supplier: supplier
+        country_group:
+          display_name:
+            ALL: Other
+            CA: Canada
+            EU: Europe
+            GBIE: UK & Ireland
+            US: US
+        country_select: Select a country
+        county: County
+        day:
+          one: day
+          other: days
+        default_contact_name: Main Contact
+        default_price: Price Default
+        defaults: Defaults
+        delivery_address_same_as_main: Same as Invoice address
+        fixed_assets: |-
+          I buy fixed assets
+           from this supplier
+        fixed_assets_help: If you'll buy items for your business that you'll keep
+          for more than a financial year, check this option.
+        invoice_details_tab: Account Details
+        invoice_tab: Invoice Details
+        language: Language
+        ledger_accounts:
+          no_accounts_found: No ledger accounts found. Please check your Chart of
+            Accounts.
+        notes: Notes
+        payment_tab: Payment Details
+        payment_terms: PAYMENT TERMS
+        postal_code: Postal Code
+        postcode: Postcode
+        province: Province
+        province_select: Select a province
+        province_state: Province / State
+        recargo_checkbox_label: Invoice with Equivalence Surcharge
+        reference: Reference
+        set_credit_limit: Set Credit Limit (%{currency_symbol})
+        set_credit_terms: Set Credit Terms
+        state: State
+        state_select: Select a state
+        tax_calculation:
+          single_choice:
+            title: Invoice with Equivalence Surcharge
+        tax_rate_id: Tax Rate
+        taxable_help: Sole trader or small businesses are usually not taxable.
+        title: Create a new %{type}
+        town_city: Town / City
+        update_contact_record: Update Contact Record
+        vat_warning:
+          button:
+            cancel: Continue Editing Address
+            save: Save Changes
+          client_type:
+            customers: customer
+            suppliers: supplier
+          message: To make sure VAT is calculated correctly, after saving your changes,
+            enter a new VAT Number in the Options tab.
+          title: Enter a New VAT Number
+          warning: This %{client_type} currently has a VAT Number for %{old_country},
+            but you’re changing their main address to be in %{new_country}.
+        zipcode: ZIP Code
+      placeholders:
+        business_name: Company or Person
+        notes: Any additional information about this contact that you would like to
+          store.
+        reference: e.g. Account Number
+        registered_number: e.g. 12/345/67890
+        terms_and_conditions: Terms & Conditions
+    customer:
+      placeholders:
+        aux_reference: '10000'
+    grid_filter:
+      currency: Currency
+      outstanding: Show Outstanding Only
+      type:
+        show_all: All
+    supplier:
+      placeholders:
+        aux_reference: '70000'
+  contacts:
+    dialog:
+      address: Address
+      address_0: Main Address
+      address_1: Delivery Address
+      addresses: Addresses
+      contact_details: Contact Details
+      contacts: Contacts
+      defaults: Defaults
+      defaults_info: 'When I create a new invoice or credit note for this contact:'
+      notes: Notes
+      tax_calculation:
+        multiple_choice:
+          options:
+            cash: Payments
+            invoice: Invoice
+          title: VAT is calculated on
+    payment_terms:
+      days_credit: days credit
+    show:
+      add_client_notes: Add notes
+      address: Address
+      address_0: Main Address
+      address_1: Delivery Address
+      addresses: Addresses
+      contact_details: Contact Details
+      contacts: Contacts
+      defaults: Defaults
+      main_address_with_no_contacts: Add a new contact to make this your main address.
+      notes: Notes
+      set_main_address: Set main address
+      set_main_contact: Set main contact
+  core_accounting:
+    taxes:
+      decimal_places: '2'
+      default:
+        de_lower_name: Lower Rate
+        de_no_tax_name: No Tax
+        de_standard_name: Standard
+        de_zero_name: Zero Rated
+        es_exempt_name: Exempt
+        es_lower_1_name: Lower 1
+        es_lower_1_re_name: Lower 1 RE
+        es_lower_2_name: Lower 2
+        es_lower_2_re_name: Lower 2 RE
+        es_no_tax_name: No VAT
+        es_standard_name: Standard
+        es_standard_re_name: Standard RE
+        exempt_name: Exempt
+        fr_dom_exempt_name: DOM Exempt
+        fr_dom_lower_1_name: DOM
+        fr_dom_lower_2_name: DOM
+        fr_exempt_name: Exempt
+        fr_lower_1_name: Rate
+        fr_lower_2_name: Rate
+        fr_lower_3_name: Rate
+        fr_lower_4_name: Rate
+        fr_no_tax_name: No Tax
+        fr_standard_name: Rate
+        lower_name: Lower Rate
+        no_tax_name: No VAT
+        standard_name: Standard
+        zero_name: Zero Rated
+      short:
+        de_lower_name: Lower
+        de_no_tax_name: No Tax
+        de_standard_name: Standard
+        de_zero_name: Zero
+        es_exempt_name: Exempt
+        es_lower_1_name: Lower 1
+        es_lower_1_re_name: RE
+        es_lower_2_name: Lower 2
+        es_lower_2_re_name: RE
+        es_no_tax_name: No VAT
+        es_standard_name: Standard
+        es_standard_re_name: RE
+        exempt_name: Exempt
+        fr_dom_exempt_name: DOM Exempt
+        fr_dom_lower_1_name: DOM
+        fr_dom_lower_2_name: DOM
+        fr_exempt_name: Exempt
+        fr_lower_1_name: Rate
+        fr_lower_2_name: Rate
+        fr_lower_3_name: Rate
+        fr_lower_4_name: Rate
+        fr_no_tax_name: No Tax
+        fr_standard_name: Rate
+        lower_name: Lower
+        no_tax_name: No VAT
+        standard_name: Standard
+        zero_name: Zero
+      tax_rate_for: 'Tax rate for:'
+      tax_with_percentage: "%{tax_name} %{tax_percentage}%"
+  correction:
+    reference: Correction of %{reference}
+    void_reference: "%{reference}V"
+  corrective_invoices:
+    details: Details
+    help:
+      details: Explain the correction
+      reason: Select a reason
+    original_date: Original Date
+    reason: Reason for Correction
+  corrective_reason_codes:
+    administrative_judgement: Administrative judgement
+    discount_rebate: Discounts or rebates
+    fees_charged: Fees charged
+    fees_withheld: Fees withheld
+    invoice_date: Invoice date
+    invoice_number: Invoice number
+    invoice_prefix: Invoice prefix
+    invoice_type: Invoice type
+    issue_date: Issue date
+    issuer_address: Issuer address
+    issuer_name: Issuer name
+    issuer_tax_id: Issuer tax ID
+    legal_terms: Legal terms
+    packages_returned: Packages returned
+    receiver_address: Receiver address
+    receiver_name: Recipient name
+    receiver_tax_id: Recipient tax ID
+    statement_details: Statement details
+    tax_percentage: Tax percentage
+    tax_rate: Tax rate
+    taxable_amount: Taxable amount
+    unpaid_fees: Unpaid fees
+  counties_gb:
+    aberdeenshire: Aberdeenshire
+    angus: Angus
+    argyll: Argyll
+    avon: Avon
+    ayrshire: Ayrshire
+    banffshire: Banffshire
+    bedfordshire: Bedfordshire
+    berkshire: Berkshire
+    berwickshire: Berwickshire
+    buckinghamshire: Buckinghamshire
+    caithness: Caithness
+    cambridgeshire: Cambridgeshire
+    cheshire: Cheshire
+    clackmannanshire: Clackmannanshire
+    cleveland: Cleveland
+    clwyd: Clwyd
+    cornwall: Cornwall
+    county_antrim: County Antrim
+    county_armagh: County Armagh
+    county_down: County Down
+    county_durham: County Durham
+    county_fermanagh: County Fermanagh
+    county_londonderry: County Londonderry
+    county_tyrone: County Tyrone
+    cumbria: Cumbria
+    derbyshire: Derbyshire
+    devon: Devon
+    dorset: Dorset
+    dumfriesshire: Dumfriesshire
+    dunbartonshire: Dunbartonshire
+    dyfed: Dyfed
+    east_lothian: East Lothian
+    east_sussex: East Sussex
+    essex: Essex
+    fife: Fife
+    gloucestershire: Gloucestershire
+    gwent: Gwent
+    gwynedd: Gwynedd
+    hampshire: Hampshire
+    herefordshire: Herefordshire
+    hertfordshire: Hertfordshire
+    inverness-shire: Inverness-Shire
+    isle_of_lewis: Isle of Lewis
+    isle_of_skye: Isle of Skye
+    isle_of_wight: Isle of Wight
+    kent: Kent
+    kincardineshire: Kincardineshire
+    kirkcudbrightshire: Kirkcudbrightshire
+    lanarkshire: Lanarkshire
+    lancashire: Lancashire
+    leicestershire: Leicestershire
+    lincolnshire: Lincolnshire
+    london: London
+    merseyside: Merseyside
+    mid_glamorgan: Mid Glamorgan
+    middlesex: Middlesex
+    midlothian: Midlothian
+    morayshire: Morayshire
+    norfolk: Norfolk
+    north_humberside: North Humberside
+    north_yorkshire: North Yorkshire
+    northamptonshire: Northamptonshire
+    northumberland: Northumberland
+    nottinghamshire: Nottinghamshire
+    orkney: Orkney
+    oxfordshire: Oxfordshire
+    peeblesshire: Peeblesshire
+    perthshire: Perthshire
+    powys: Powys
+    renfrewshire: Renfrewshire
+    rosssShire: Ross-Shire
+    roxburghshire: Roxburghshire
+    rutland: Rutland
+    selkirkshire: Selkirkshire
+    shropshire: Shropshire
+    somerset: Somerset
+    south_glamorgan: South Glamorgan
+    south_humberside: South Humberside
+    south_yorkshire: South Yorkshire
+    staffordshire: Staffordshire
+    stirlingshire: Stirlingshire
+    suffolk: Suffolk
+    surrey: Surrey
+    sutherland: Sutherland
+    tyne_and_wear: Tyne and Wear
+    warwickshire: Warwickshire
+    west_glamorgan: West Glamorgan
+    west_lothian: West Lothian
+    west_midlands: West Midlands
+    west_sussex: West Sussex
+    west_yorkshire: West Yorkshire
+    wigtownshire: Wigtownshire
+    wiltshire: Wiltshire
+    worcestershire: Worcestershire
+  counties_ie:
+    carlow: Carlow
+    cavan: Cavan
+    clare: Clare
+    cork: Cork
+    donegal: Donegal
+    dublin: Dublin
+    galway: Galway
+    kerry: Kerry
+    kildare: Kildare
+    kilkenny: Kilkenny
+    laois: Laois
+    leitrim: Leitrim
+    limerick: Limerick
+    longford: Longford
+    louth: Louth
+    mayo: Mayo
+    meath: Meath
+    monaghan: Monaghan
+    offaly: Offaly
+    roscommon: Roscommon
+    sligo: Sligo
+    tipperary: Tipperary
+    waterford: Waterford
+    westmeath: Westmeath
+    wexford: Wexford
+    wicklow: Wicklow
+  credit_notes_general:
+    credit_note_already_issued:
+      message_text: If you make any changes, make sure you inform your customer and
+        provide an updated copy.
+      message_title: Credit note already issued
+    eu_no_vat:
+      supplier:
+        message_title: This supplier has an address in the EU, but their VAT number
+          hasn't been entered.
+        show_message_text: This supplier has an address in the EU, but their VAT number
+          hasn't been entered.
+    eu_tax_registration:
+      customer:
+        message_text: The credit note address has been fixed and the VAT Rate has
+          been set to zero (0). Please review the EU Goods/Services and EC Sales Descriptions.
+        message_title: This customer is registered for tax in the EU.
+        show_message_text: This customer is registered for tax in the EU.
+      supplier:
+        message_text: This credit note will be treated as an EC Purchase and VAT will
+          be charged under the Reverse Charge mechanism. Please review the EU Goods/Services
+          and EC Sales Descriptions.
+        message_title: This supplier is registered for VAT in the EU.
+        show_message_text: This supplier is registered for VAT in the EU.
+    row:
+      customer:
+        message_text: The credit note address has been fixed and the VAT Rate has
+          been set to zero (0).
+        message_title: This customer is outside the EU.
+        show_message_text: This customer is outside the EU.
+      supplier:
+        message_text: This credit note will be charged under the Reverse Charge mechanism.
+        message_title: This supplier is outside the EU.
+        show_message_text: This supplier is outside the EU.
+  currency_symbols:
+    cad: "$"
+    eur: "€"
+    gbp: "£"
+    usd: "$"
+  data_management:
+    description: Reset or restore your data.
+    reset_data:
+      action: Reset my Data
+      confirm_action: Reset Data
+      confirm_consequence: All your data will be reset and you'll need to start afresh.
+      confirm_email: 'Please enter your email address to confirm this:'
+      confirm_title: Reset Data
+      description: Reset all your __%{service}__ data for __%{business}__, and start
+        afresh.
+      success: Data Reset has completed.
+      title: Reset Data
+    restore_data:
+      action: Restore my Data
+      can_restore_message: |-
+        You can restore your data as it was on %{date}.
+        You'll lose any data since this time, and this can't be undone.
+      cant_restore_message: You have no previously deleted data to restore.
+      confirm_action: Restore Data
+      confirm_consequence: |-
+        You can restore your data as it was on %{date}.
+        You'll lose any data since this time, and this can't be undone.
+      confirm_email: 'Please enter your email address to confirm this:'
+      confirm_title: Restore Data
+      description: If you've previously deleted your data, you can restore it.
+      success: Data Restore has completed.
+      success_message: You have restored your data as it was on %{date}.
+      title: Restore Data
+    title: Data Management
+  date:
+    formats:
+      default_2_year: "%d/%m/%y"
+      journals_long: "%d %b %Y"
+      short_da_mo_long_yr: "%d %b %Y"
+      short_with_year: "%d %b %y"
+      tax_return: "%d/%m/%y"
+    time_ago: "%{time} ago"
+  datetime:
+    date_words:
+      x_years:
+        one: 1 year
+        other: "%{count} years"
+    distance_in_words:
+      about_x_hours:
+        one: 1 hour
+        other: "%{count} hours"
+      about_x_years:
+        one: 1 year
+        other: "%{count} years"
+  default:
+    advanced_uk/address_contact:
+      add_contact: Add Address Contact
+      default_contact_name: Contact
+      main_contact_name: Main Contact
+      new_contact_name: New Contact
+  default_accounts:
+    cash_in_hand:
+      account_name: Cash
+      ledger_name: Cash in Hand
+    current:
+      account_name: Bank Account
+      ledger_name: Cash at Bank
+  defaults:
+    advanced_uk/analysis_type:
+      group:
+        type_1:
+          name: Customer Group
+        type_2:
+          name: Supplier Group
+        type_3:
+          name: Product Group
+      transaction:
+        type_1:
+          name: Department
+        type_2:
+          name: Cost Centre
+        type_3:
+          name: Project
+    advanced_uk/ec_sales_description:
+      exempt: This supply is exempt from VAT
+      names:
+        exempt: Exempt
+        outside_scope_of_vat: Outside Scope of VAT
+        standard: Standard/Lower
+        zero: Zero
+      outside_scope_of_vat: This supply is outside the scope of VAT
+      standard: This supply is an intra-community supply
+      zero: This is a Zero rated EC Supply
+    advanced_uk/journal_opening_balance:
+      description: Opening Balance
+      details: "(Opening Balance)"
+    advanced_uk/sage_pay/request_form:
+      billing_address_1: "[Add Address Line 1]"
+      billing_city: "[Add City]"
+      billing_firstnames: "[Add Firstnames]"
+      billing_post_code: Add
+      billing_surname: "[Add Surname]"
+      delivery_address_1: "[Add Address Line 1]"
+      delivery_city: "[Add City]"
+      delivery_firstnames: "[Add Firstnames]"
+      delivery_post_code: Add
+      delivery_surname: "[Add Surname]"
+      description:
+        moto: MOTO payment for sales invoice %{artefact_number_formatted}
+        pay_now: Pay Invoice
+        payment_moto: MOTO payment for existing Payment
+    advanced_uk/transaction_types:
+      customer_opening_balance: Customer Opening Balance
+      supplier_opening_balance: Supplier Opening Balance
+    core_accounting/taxes:
+      exempt_tax_name: Non-taxable
+      no_tax_name: Without tax
+    fuji_core_accounting/financial_settings:
+      tax_contacts:
+        customer:
+          name: HMRC Reclaimed
+          reference: HMRC Rec
+        supplier:
+          name: HMRC Payments
+          reference: HMRC Pay
+  demo:
+    preparing_account: Preparing your new account...
+  deposits:
+    cheques:
+      select_dialog_title: Select Cheques
+      view_dialog_title: View Cheques
+  dialog:
+    account_start_date:
+      enter_balances: You'll only be able to enter opening balances before this date.
+      on_or_before: 'Since you''ve already entered some transactions, it should be
+        on or before '
+      record_start_date: Before you enter your opening balances, we need to know your
+        Accounts Start Date.
+      start_date_info: Accounts Start Date
+      transactions: Choose the earliest date you'll be entering transactions.
+      which_date: Which date should I choose?
+    advanced_uk/journal_code:
+      titles:
+        edit: Edit Journal Code
+        new: Create Journal Code
+    other_payments:
+      buttons:
+        continue_editing: Continue Editing
+        save: Save
+      message: HMRC provide **[guidance on when to use a Zero-rated or Exempt VAT
+        status](https://www.gov.uk/guidance/rates-of-vat-on-different-goods-and-services)**.
+      title: "'No VAT' status"
+      warning_message: You’ve selected ‘No VAT’ status on this payment. If you’re
+        unsure, you might want to consult your accountant for advice.
+    other_receipts:
+      buttons:
+        continue_editing: Continue Editing
+        save: Save
+      message: |
+        Do not use 'No VAT' status for **customers who are not VAT registered**. Although these customers can't reclaim VAT they should always be charged any applicable VAT.
+
+        HMRC provide **[guidance on when to use a Zero-rated or Exempt VAT status](https://www.gov.uk/guidance/rates-of-vat-on-different-goods-and-services)**.
+      title: "'No VAT' status"
+      warning_message: You've selected 'No VAT' status on this receipt. This applies
+        in special circumstances. You might want to consult your accountant for advice.
+    tax_number:
+      description: To do business in other EU countries, you must enter your USt-ID
+        number. We can then apply the right tax rates on your invoice, and prepare
+        your VAT return for you.
+      description_hint: If you've lost or need to apply for a USt-ID, contact the
+        Federal Central Tax Office.
+      note:
+        description: Please <a target='_blank' href='%{help_site_url}'>contact us</a>
+          so we can send you the right invoice each month, as a VAT registered business.
+        title: Your invoice
+      save: Save
+      title: Missing Vat-Number
+    titles:
+      import: Import %{plural_name}
+  direct_payment:
+    form_fields:
+      amount:
+        label: Amount
+      bank_account:
+        label: Bank Account
+        placeholder: Choose Your Bank Account
+      bic:
+        label: BIC
+      iban:
+        label: IBAN
+      pin:
+        label: PIN
+      receiver:
+        label: Receiver
+      receiver_bank:
+        label: Receiver Bank
+      tan_confirmation:
+        label: TAN
+      tan_medium:
+        label: TAN Medium
+        placeholder: Please choose a TAN medium
+      tan_system:
+        label: TAN System
+        placeholder: Please choose a TAN system
+      usage:
+        label: Usage
+    hints:
+      payment_data: Please fill in the complete payment data. If you want to pay the
+        invoice of a supplier, you can automatically import the invoice data into
+        this payment via the function Automatically Choose Invoice.
+      tan_confirmation: Please check the payment information below and enter the TAN
+        to authorize the payment. If all information are valid press "Submit Payment"
+        to perform the payment.
+      tan_medium: There are multiple TAN Media configured for this bank account. Please
+        choose your preferred TAN Medium for the chosen TAN System.
+      tan_system: Multiple TAN systems are available for this bank account. Please
+        choose the preferred TAN system.
+    messages:
+      created_payment_on_account: The invoice was marked as paid. An additional payment
+        on account was created because the payment amount was greater than the outstanding
+        amount of the invoice.
+      no_bank_accounts: Connect an HBCI supported bank account to use direct payment.
+      no_general_direct_payment: Direct payments are only possible from within outstanding
+        purchase invoices.
+      unsupported_bank_account: The selected bank account does not support direct
+        payment (missing HBCI support).
+    steps:
+      bank_login: Bank Login
+      payment_data: Payment Data
+      summary: Summary
+      tan_confirmation: TAN Confirmation
+      tan_medium: TAN Medium
+      tan_system: TAN System
+    submit: Submit Payment
+    summary:
+      back_to_invoice: Back to Invoice
+      overpaid_title: Invoice Overpaid
+      success_message: Payed at %{payment_time} with TAN %{tan}.
+      successful: The payment has been sent successfully.
+    tan_confirmation:
+      amount: Amount
+      from_bank_label: From
+      to_bank_label: To
+  dropdown:
+    advanced_uk/product_service:
+      prompt: Please Select
+    advanced_uk/state:
+      outside_country: Outside of %{country}
+  email:
+    fuji_invoicing/sales_corrective_invoice:
+      pdf_filename: Corrective invoice %{business_name} %{artefact_number}.pdf
+    fuji_invoicing/sales_credit_note:
+      pdf_filename: Credit note %{business_name} %{artefact_number}.pdf
+    fuji_invoicing/sales_estimate:
+      pdf_filename: Estimate %{business_name} %{artefact_number}.pdf
+    fuji_invoicing/sales_invoice:
+      pdf_filename: Invoice %{business_name} %{artefact_number}.pdf
+    fuji_invoicing/sales_quote:
+      pdf_filename: Quote %{business_name} %{artefact_number}.pdf
+  email_alert:
+    messages:
+      migrated_artefacts: You can't email one or more of the selected items because
+        it was migrated from your old accounting system.
+    titles:
+      migrated_artefacts:
+        credit_note: Email Sales Credit Note
+        invoice: Email Sales Invoice
+        sales_artefact: Email Sales Item
+  email_dialog:
+    also_print:
+      fuji_invoicing/sales_corrective_invoice: Also print a copy of this corrective
+        invoice
+      fuji_invoicing/sales_credit_note: Also print a copy of this credit note
+      fuji_invoicing/sales_estimate: Also print a copy of this estimate
+      fuji_invoicing/sales_invoice: Also print a copy of this invoice
+      fuji_invoicing/sales_quote: Also print a copy of this quote
+    attachment:
+      fuji_invoicing/sales_corrective_invoice: We'll attach a PDF of the corrective
+        invoice
+      fuji_invoicing/sales_credit_note: We'll attach a PDF of the credit note
+      fuji_invoicing/sales_estimate: We'll attach a PDF of the estimate
+      fuji_invoicing/sales_invoice: We'll attach a PDF of the invoice
+      fuji_invoicing/sales_quote: We'll attach a PDF of the quote
+      monthly_statement: We'll attach a PDF of the statement
+    attachment_label: Attach
+    change_later: Edit your email defaults in Settings
+    description:
+      advanced_uk/catalog_items: Email a list of products and services
+      advanced_uk/contact_activities: Email a list of contact activities
+      advanced_uk/customer_refund_payment: This is where you can send a Remittance
+        Advice to your customer as a PDF file attachment.
+      advanced_uk/purchase_artefacts: Email a purchase list
+      advanced_uk/purchase_batches: Email a purchase quick entry list
+      advanced_uk/sales_artefacts: Email sales documents
+      advanced_uk/sales_batches: Email a sales quick entry list
+      advanced_uk/stock_movements: Email a list of stock movements
+      advanced_uk/supplier_expense_payment: This is where you can send a Remittance
+        Advice to your supplier as a PDF file attachment.
+      fuji_banking/bank_accounts: Email a list of bank accounts
+      fuji_banking/bank_activities: Email a list of bank activities
+      fuji_contacts/contacts: Email a list of contacts
+      fuji_contacts/customers: Email a list of customers
+      fuji_contacts/suppliers: Email a list of suppliers
+      fuji_invoicing/purchase_corrective_invoices: Email a list of purchase corrective
+        invoices
+      fuji_invoicing/purchase_credit_notes: Email a list of purchase credit notes
+      fuji_invoicing/purchase_invoices: Email a list of purchase invoices
+      fuji_invoicing/sales_corrective_invoice: This is where you can send your corrective
+        invoice to your customer as a PDF file attachment.
+      fuji_invoicing/sales_corrective_invoices: Email multiple sales corrective invoices
+      fuji_invoicing/sales_credit_note: This is where you can send your credit note
+        to your customer as a PDF file attachment.
+      fuji_invoicing/sales_credit_notes: Email multiple sales credit notes
+      fuji_invoicing/sales_estimate: This is where you can send your estimate as a
+        PDF file attachment.
+      fuji_invoicing/sales_invoice: This is where you can send your invoice to your
+        customer as a PDF file attachment.
+      fuji_invoicing/sales_invoices: Email multiple sales invoices
+      fuji_invoicing/sales_quote: This is where you can send your quote as a PDF file
+        attachment.
+      fuji_invoicing/sales_quotes: Email multiple sales quotes and estimates
+    payment_label: Payment
+    pdf_attached: Include PDF Attachment
+    pdf_link:
+      credit_note: PDF_credit_note
+      invoice: PDF_invoice
+      quote: PDF_quote
+      remittance: PDF_remittance
+    send_bcc: Send me a copy
+    subject:
+      advanced_uk/catalog_items: Products and services list from %{business_name}
+      advanced_uk/contact_activities: Sales Documents from %{business_name}
+      advanced_uk/customer_refund_payment: "%{business_name} - Remittance for %{total}"
+      advanced_uk/purchase_artefacts: Purchase List from %{business_name}
+      advanced_uk/purchase_batches: Purchase Quick Entry List from %{business_name}
+      advanced_uk/sales_artefacts: Sales Documents from %{business_name}
+      advanced_uk/sales_batches: Sales Quick Entry List from %{business_name}
+      advanced_uk/stock_movements: Stock movement list from %{business_name}
+      advanced_uk/supplier_expense_payment: "%{business_name} - Remittance for %{total}"
+      extra:
+        fuji_invoicing/sales_corrective_invoice: "%{business_name} - Corrective Invoice
+          (%{artefact_number}) for %{total}, due on %{date}"
+        fuji_invoicing/sales_credit_note: "%{business_name} - Credit Note (%{artefact_number})
+          for %{total}, on %{date}"
+        fuji_invoicing/sales_estimate: "%{business_name} - Estimate (%{artefact_number})
+          for %{total}, on %{date}"
+        fuji_invoicing/sales_estimate_expires_on: "%{business_name} - Estimate (%{artefact_number})
+          for %{total}, on %{date} (Expires on %{expiry_date})"
+        fuji_invoicing/sales_invoice:
+          with_duedate: "%{business_name} - Invoice (%{artefact_number}) for %{total},
+            due on %{date}"
+          without_duedate: "%{business_name} - Invoice (%{artefact_number}) for %{total}"
+        fuji_invoicing/sales_quote: "%{business_name} - Quote (%{artefact_number})
+          for %{total}, on %{date}"
+        fuji_invoicing/sales_quote_expires_on: "%{business_name} - Quote (%{artefact_number})
+          for %{total}, on %{date} (Expires on %{expiry_date})"
+      fuji_banking/bank_accounts: Bank List from %{business_name}
+      fuji_banking/bank_activities: Bank Activity from %{business_name}
+      fuji_contacts/contacts: Contact List from %{business_name}
+      fuji_contacts/customers: Customer List from %{business_name}
+      fuji_contacts/suppliers: Supplier List from %{business_name}
+      fuji_invoicing/purchase_corrective_invoices: Purchase Corrective Invoice Documents
+        from %{business_name}
+      fuji_invoicing/purchase_credit_notes: Purchase Credit Note List from %{business_name}
+      fuji_invoicing/purchase_invoices: Purchase Invoice List from %{business_name}
+      fuji_invoicing/sales_corrective_invoices: Sales Corrective Invoice Documents
+        from %{business_name}
+      fuji_invoicing/sales_credit_notes: Sales Credit Note Documents from %{business_name}
+      fuji_invoicing/sales_invoices: Sales Invoice Documents from %{business_name}
+      fuji_invoicing/sales_quotes: Sales Quote and Estimate Documents from %{business_name}
+      statement: Statement from %{business}
+    subject_label: Subject
+    success_message: Email sent successfully
+    success_message_with_invalid_email_addresses: Email sent successfully, however
+      unable to send to %{email_addresses} because the email address is marked as
+      inactive
+    title:
+      advanced_uk/catalog_items: Email products and services
+      advanced_uk/contact_activities: Email Contact Activity
+      advanced_uk/customer_refund_payment: Email Remittance Advice
+      advanced_uk/purchase_artefacts: Email Purchase List
+      advanced_uk/purchase_batches: Email Purchase Quick Entries
+      advanced_uk/sales_artefacts: Email Sales Documents
+      advanced_uk/sales_batches: Email Sales Quick Entries
+      advanced_uk/stock_movements: Email Stock Movements
+      advanced_uk/supplier_expense_payment: Email Remittance Advice
+      fuji_banking/bank_accounts: Email Bank Accounts
+      fuji_banking/bank_activities: Email Bank Activity
+      fuji_contacts/contacts: Email Contacts
+      fuji_contacts/customers: Email Customers
+      fuji_contacts/suppliers: Email Suppliers
+      fuji_invoicing/purchase_corrective_invoice: Email Purchase Corrective Invoice
+      fuji_invoicing/purchase_corrective_invoices: Email Purchase Corrective Invoices
+      fuji_invoicing/purchase_credit_note: Email Purchase Credit Note
+      fuji_invoicing/purchase_credit_notes: Email Purchase Credit Notes
+      fuji_invoicing/purchase_invoice: Email Purchase Invoice
+      fuji_invoicing/purchase_invoices: Email Purchase Invoices
+      fuji_invoicing/sales_corrective_invoice: Email Sales Corrective Invoice
+      fuji_invoicing/sales_corrective_invoices: Email Sales Corrective Invoices
+      fuji_invoicing/sales_credit_note: Email Credit Note
+      fuji_invoicing/sales_credit_notes: Email Sales Credit Notes
+      fuji_invoicing/sales_estimate: Email Estimate
+      fuji_invoicing/sales_invoice: Email Invoice
+      fuji_invoicing/sales_invoices: Email Sales Invoices
+      fuji_invoicing/sales_quote: Email Quote
+      fuji_invoicing/sales_quotes: Email Sales Quotes and Estimates
+    unable_to_send_email: 'Unable to send email. Please try again and contact support
+      if problems still persist. Error code: %{error_code}'
+    unable_to_send_email_to_inactive_recipients: 'The following email addresses: %{email_addresses},
+      have been marked as inactive after generating a hard bounce or spam complaint.
+      Please update the recipients and try again.'
+    view_file: view file
+  email_template:
+    footer:
+      legal_notes_html: Sage, SAS. <br /> %{address} <br /> ©2017 The Sage Group Ltd
+        or its partners. All rights reserved
+      links_html: "<a href='%{privacy_url}' style='color: #547dbb; text-decoration:
+        none;'>Privacy policy</a>"
+    view_invoice: View Invoice
+  email_verification:
+    error: Your email could not be verified.
+    success: Your email has been verified, thank you.
+    text: We have successfully verified your E-Mail address. Please access Sage Business
+      Cloud Accounting via your reseller.
+    text_failure: There has been a problem verifying your E-Mail address. Please contact
+      your reseller.
+  email_verification_pattern:
+    description:
+      complete_status: "%{email_address}"
+      in_progress_status: "<br><br> You're in the process of changing your reply address
+        to <b>%{new_email_address}</b>"
+      initial_status: Logged in user's email (%{email_address})
+    email:
+      message: |-
+        Hi,
+
+        %{user_name} (%{user_email}) has asked that when emails are sent directly through Sage Business Cloud Accounting for %{business_name}, and a recipient replies, the replies should go to your email address - %{new_reply_address}.
+
+        To allow %{business_name} to do this, just log in to Accounting, go to Settings, then Email Defaults, and enter this verification code. Alternatively, you can forward this email to %{user_name}.
+      message2: If you don't approve of this request, no further action is needed
+        and no change will be made.
+      subject: Sage Verification Code
+    email_reply_address: Email Reply Address
+    in_progress_email_verification_dialog:
+      description: Check your emails and enter the verification code we sent you.
+      hint:
+        description: 'Please check any junk mail boxes, or we can '
+        link_label: re-send the email
+        title: Can't find the email?
+      resend: Email resent to <b>%{new_email_address}</b> at %{time}.
+      send: We've sent an email to <b>%{new_email_address}</b>, on %{time}.
+      title: Verify Email Reply Address
+      verification_code: Verification code
+    initial_email_verification_dialog:
+      email_reply_address_description: Your current reply address, <b>%{email_address}</b>,
+        will be used until this one is verified.
+      hint:
+        description: We'll send an email to the new reply address with a verification
+          code, so you'll need access to this mailbox.
+        title: What happens next?
+      list:
+        bullet1: When we send emails on your behalf, and a recipient responds, this
+          is the email address their replies go to.
+        bullet2: This setting will apply to all emails we send on behalf of %{business_name}.
+      title: Change Email Reply Address
+    reset_dialog:
+      list:
+        bullet1: When emails are sent directly through Accounting, and a recipient
+          replies, their reply will go to the email address of the user who sent the
+          original email.
+        bullet2: This setting will apply to everyone who logs in to %{business_name}.
+        title: If you remove this email reply address...
+      question: Are you sure you want to remove the email reply address?
+      title: Remove Email Reply Address
+  error:
+    messages:
+      delete_user_messages_as_admin: You do not have permission to delete this message.
+      no_services: You are currently not subscribed to any services. Please subscribe
+        to at least one service.
+  errors:
+    concurrency:
+      message: Someone else may have updated/deleted this record. Please check the
+        details and try again.
+    messages:
+      bankdrive_pdf_form_unavailable: The bank account pdf form is not available
+      cannot_modify: You cannot modify the code or classification of a ledger account.
+      catalog_items_modal_data_error: Sorry, a technical error means you can't create
+        an item right now. Please try again.
+      duplicate_cheque_number: This number was used on a cheque printed or issued
+        %{printed_date}.  Please try another.
+      duplicate_contact_reference: This reference is already taken for %{company}.
+        Please try another.
+      ensure_vat_number: This is not a valid VAT number.
+      extension_white_list_error: 'You are not allowed to upload %{extension} files,
+        allowed types: %{allowed_types}'
+      invalid_email_addresses: You have entered an illegal character in the email
+        address. Special characters allowed are '+', '.', '-' and '_'
+      max_value_reached: You have reached the maximum limit for this field
+      min_value_not_reached: You have entered a value below the minimum limit for
+        this field
+      must_be_active: This product or service is inactive.
+      must_be_unique: must be unique.
+      name_and_company_blank: A Contact or Company Name is required.
+      reconciling_cash_account_prohibited: Reconciling cash account prohibited.
+      terminate_string_does_not_match: The confirmation string doesn't match
+      too_many_email_addresses: You can only enter up to %{count} email addresses
+      validate_postcode_uk: Invalid format for a Postal code
+      vendor_cheque: You must choose a vendor to pay by cheque.
+      wrong_format: Wrong format
+    sop_core_models/business:
+      membership_not_saved: User was not added to the business
+      owner_not_set: In order to set the business owner, the user needs to be part
+        of the business. The owner was not set.
+    sop_settings/area_code:
+      primary_only_full_access: A System Manager must have full access
+    sop_settings/business_memberships:
+      current_user_cannot_delete_owner: Cannot delete business owner
+      current_user_cannot_delete_self: Cannot delete yourself
+      current_user_cannot_unset_primary: Cannot allow your own user to remove System
+        Manager
+      owner_must_have_full_access: A business owner must have full access and needs
+        to be a system manager
+    sop_settings/manage_businesses:
+      switch:
+        invalid_business: Access Denied. You are now allowed to switch to the specified
+          business
+    sop_settings/new_business:
+      multi_business_service_required: Please select a valid multi-business service
+        for the business you are adding
+      service_required: Please select a valid service for the business you are adding
+  export:
+    advanced_uk/catalog_items:
+      csv:
+        filename: product_and_service_list.csv
+      pdf:
+        filename: product_and_service_list.pdf
+        page_title: Product and Service List
+    advanced_uk/contact_activities:
+      csv:
+        filename: contact_activity.csv
+      pdf:
+        filename: sales_documents.pdf
+    advanced_uk/customer_refund_payments:
+      pdf:
+        filename: remittance.pdf
+        page_title: Remittance
+    advanced_uk/purchase_artefacts:
+      csv:
+        filename: purchase_list.csv
+      pdf:
+        filename: purchase_list.pdf
+    advanced_uk/purchase_batches:
+      csv:
+        filename: purchase_quick_entries.csv
+      pdf:
+        filename: purchase_quick_entries.pdf
+    advanced_uk/sales_artefacts:
+      csv:
+        filename: sales_list.csv
+      pdf:
+        filename: sales_documents.pdf
+    advanced_uk/sales_batches:
+      csv:
+        filename: sales_quick_entries.csv
+      pdf:
+        filename: sales_quick_entries.pdf
+    advanced_uk/sales_revenue:
+      csv:
+        filename: sales_revenue.csv
+      pdf:
+        filename: sales_revenue.pdf
+    advanced_uk/stock_movements:
+      csv:
+        filename: stock_movements.csv
+      download:
+        title: Download PDF
+      pdf:
+        filename: stock_movements.pdf
+        page_title: Stock Movements
+      print:
+        title: Print Stock Movements
+    advanced_uk/supplier_expense_payments:
+      pdf:
+        filename: remittance.pdf
+        page_title: Remittance
+    detailed_reports:
+      label: Export Detailed Report
+    fuji_banking/bank_accounts:
+      csv:
+        filename: bank_list.csv
+      pdf:
+        filename: bank_list.pdf
+        page_title: Bank List
+    fuji_banking/bank_activities:
+      csv:
+        filename: bank_activity.csv
+      pdf:
+        filename: bank_activity.pdf
+        page_title: Bank Activity
+        recurrance:
+          is_not_recurring: 'No'
+          is_recurring: 'Yes'
+    fuji_banking/bank_reconciliations:
+      pdf:
+        page_title: Bank Reconciliation
+    fuji_contacts/contacts:
+      csv:
+        filename: contact_list.csv
+      pdf:
+        filename: contact_list.pdf
+        page_title: Contact List
+    fuji_contacts/customers:
+      csv:
+        filename: customer_list.csv
+      pdf:
+        filename: customer_list.pdf
+        page_title: Customer List
+    fuji_contacts/export_pending_contacts_gdpr_data:
+      csv:
+        filename: contacts_to_remove_list.csv
+      pdf:
+        filename: contacts_to_remove_list.pdf
+        page_title: List of contacts to be removed
+    fuji_contacts/suppliers:
+      csv:
+        filename: supplier_list.csv
+      pdf:
+        filename: supplier_list.pdf
+        page_title: Supplier List
+    fuji_invoicing/purchase_corrective_invoices:
+      csv:
+        filename: purchase_corrective_invoice_list.csv
+      pdf:
+        filename: purchase_corrective_invoices_list.pdf
+        page_title: Purchase Corrective Invoices List
+    fuji_invoicing/purchase_credit_notes:
+      csv:
+        filename: purchase_credit_notes_list.csv
+      pdf:
+        filename: purchase_credit_notes_list.pdf
+        page_title: Purchase Credit Notes List
+    fuji_invoicing/purchase_invoices:
+      csv:
+        filename: purchase_invoice_list.csv
+      pdf:
+        filename: purchase_invoices_list.pdf
+        page_title: Purchase Invoices List
+    fuji_invoicing/sales_corrective_invoices:
+      bulk:
+        issue:
+          title: Issue
+        list:
+          title: List
+      csv:
+        filename: sales_corrective_invoice_list.csv
+      download:
+        description: How would you like to generate the selected corrective invoices?
+        title: Download PDF
+      pdf:
+        filename: sales_corrective_invoice_list.pdf
+        page_title: Sales Invoices List
+      print:
+        description: How would you like to print the selected corrective invoices?
+        title: Print Corrective Invoices
+    fuji_invoicing/sales_credit_notes:
+      csv:
+        filename: sales_credit_notes_list.csv
+      pdf:
+        filename: sales_documents.pdf
+        page_title: Sales Credit Notes List
+    fuji_invoicing/sales_invoices:
+      bulk:
+        issue:
+          title: Issue
+        list:
+          title: List
+      csv:
+        filename: sales_invoice_list.csv
+      download:
+        description: How would you like to generate the selected invoices?
+        title: Download PDF
+      pdf:
+        filename: sales_documents.pdf
+        page_title: Sales Invoices List
+      print:
+        description: How would you like to print the selected invoices?
+        title: Print Invoices
+    fuji_invoicing/sales_quotes:
+      bulk:
+        issue:
+          title: Issue
+        list:
+          title: List
+      csv:
+        filename: sales_quote_estimate_list.csv
+      download:
+        description: How would you like to generate the selected quotes and estimates?
+        title: Download PDF
+      pdf:
+        filename: sales_documents.pdf
+        page_title: Sales Quotes and Estimates List
+      print:
+        description: How would you like to print the selected quotes and estimates?
+        title: Print Quotes and Estimates
+    multiple_artefacts_to_pdf:
+      contact_activities:
+        filename: contact_activities.pdf
+      errors:
+        max_number_of_pdfs: Please select less than %{number_of_pdfs} documents.
+      filename: sales_documents.pdf
+      sales_corrective_invoices:
+        filename: sales_corrective_invoices.pdf
+    nominal_activity:
+      detailed: Export Detailed
+      detailed_tooltip: "<span class='beta_version'>BETA</span> Export transactions
+        for many Nominal Accounts in one go."
+      summary: Export Summary
+    reports:
+      csv: CSV
+      invalid_form: Please correct the highlighted errors and try again
+      label: Export
+      pdf: PDF
+      sap: SAP/SAPA
+    unreconciled_bank_transactions:
+      csv: CSV
+      label: Export
+      pdf: PDF
+  feedback:
+    cancel: Cancel
+    comment: Please provide a brief summary of your experience
+    email:
+      bdp: "(Business migrated via BDP on %{date}, from %{product} %{product_version},
+        source tool %{tool} %{tool_version} and schema id %{schema_id})"
+      contact_message: "Rating: %{rating} \n\nComment: %{comments} \n\nPage: %{page}
+        \n\nBusiness: %{business_guid} \nUser: %{user_guid} \n\nContact details: %{user},
+        %{email} \n\nBrowser: %{browser_name} (%{browser_ver}) \nOS: %{os_name} (%{os_ver}
+        - %{device_type}) \n\n %{migration_text}"
+      legacy: "(Business upgraded from legacy product on %{date})"
+      message: "Rating: %{rating} \n\nComment: %{comments} \n\nPage: %{page} \n\nBusiness:
+        %{business_guid} \nUser: %{user_guid} \n\nBrowser: %{browser_name} (%{browser_ver})
+        \nOS: %{os_name} (%{os_ver} - %{device_type}) \n\n %{migration_text}"
+      reply_to: "%{user} < %{email} >"
+      slack_message: "%{comments} \n\n%{page} \n\n %{migration_text}"
+      slack_subject: "%{type}: %{service} (%{country}) - %{rating}"
+      subject: "%{type}: %{service} (%{country}) - %{user}, %{business}, %{email}"
+    email_address: Email
+    feedback_checkbox: I am happy to be contacted to discuss this feedback
+    feedback_info: Your feedback will be shared with our product delivery teams, and
+      taken into consideration for future product development.
+    feedback_label: What would you like to tell us?
+    feedback_prompt:
+      link: "**We'd love your feedback** on this feature."
+    feedback_success:
+      check_help: Have your say about Accounting, test out improvements, and be the
+        first to see new features, by joining **[the Sage Experience Panel](%{panel_url})**.
+      close: Close
+      thanks_label: Your feedback helps us continually improve our software.
+      title: Thanks for your feedback!
+    feedback_title: Give Feedback
+    info: We'd really like to hear what you think about Accounting. If there's anything
+      you would like us to improve please tell us below, or if you need some help
+      using the service, please email us at sagebusinesscloudsupport@sage.com.
+    info_note: 'Note: Any response will be sent to your registered email address.'
+    link: Give Feedback
+    name: Name
+    rating: How does Accounting make you feel?
+    ratings:
+      level_1: Happy
+      level_2: Indifferent
+      level_3: Sad
+    response:
+      success:
+        message: We've received your feedback - many thanks!
+        title: Thank you for your feedback
+    send: Send
+    submit: Submit
+    support_checkbox: I am happy to be contacted regarding my help request
+    support_info: Your help request will be submitted to our customer service team,
+      who will be in touch shortly.
+    support_label: What can we help you with?
+    support_success:
+      check_help: You may find the answer to your question, along with other useful
+        information, including support articles and tutorials on our Help Site.
+      help: Get help now
+      thanks_label: Thank you, your request has been emailed to our customer services
+        team.  We aim to respond within 24 hours.
+      title: Help request sent
+    support_title: Ask for help
+    title: What would you like to do?
+    validation_errors:
+      comment_length_validation: Please enter less than %{count} characters.
+      rating_required: Please click one of the face icons.
+  filters:
+    scope:
+      label: Type
+    status:
+      active: Active
+      inactive: Inactive
+      label: Status
+    stock_level:
+      below_reorder_level: Below reorder level
+      label: Stock level
+      out_of_stock: Out of stock
+  financial_year_notification:
+    dismissed:
+      link_text: "%{day} %{month}"
+      text: 'Financial Year end: '
+    no_year_end_set: 'No financial year set. '
+    no_year_end_set_link: Set it
+    not_dismissed:
+      link_text: Change this
+      text: 'Your Financial Year is set to %{day} of %{month}. '
+  gdpr:
+    contacts:
+      confirmation_dialog:
+        save_button:
+          text: Remove Data
+        text_1: All personal data will be removed from this contact’s record and related
+          transactions by completing this process.
+        text_2_1: 'Please enter '
+        text_2_2: " below to confirm you wish to remove this contact’s personal data."
+        textbox:
+          label: Enter Confirmation Word*
+        title: Remove Personal Data
+        word: REMOVE
+      extension_date: Extended Removal Date
+      extension_reason:
+        help: You have to provide a reason if you're extending the period you hold
+          this contact's data.
+        label: Reason for Extension
+      last_transaction: Last Transaction Date
+      no_transaction: No transaction
+      obfuscated_at:
+        pending: Pending
+        title: Personal Data Removed
+      obfuscation:
+        bulk:
+          errors:
+            contact_already_obfuscated: The selected contacts could not have their
+              personal data removed.
+            in_extended_retention_period: The selected contacts could not have their
+              personal data removed.
+            in_retention_period: The selected contacts could not have their personal
+              data removed.
+            outstanding_balance: The selected contacts could not have their personal
+              data removed as one or more of them have an outstanding balance.
+            permanent_contact: The selected contacts could not have their personal
+              data removed.
+            suggested_removal_date_unset: The selected contacts could not have their
+              personal data removed.
+        errors:
+          contact_already_obfuscated: This contact has already been obfuscated.
+          in_extended_retention_period: The retention period has been extended and
+            this contact is still in it.
+          in_retention_period: This contact is still in the retention period.
+          outstanding_balance: This contact has an outstanding balance and can't be
+            obfuscated.
+          permanent_contact: This is a permanent contact and can't be obfuscated.
+          suggested_removal_date_unset: Suggested Removal Date can't be calculated
+            because you didn't set the gdpr configuration.
+        success: Personal data has been successfully removed for this contact.
+      outstanding_balance_dialog:
+        button:
+          text: Okay
+        message:
+          link:
+            text: Help on outstanding balances
+            url: https://help.sageone.com/en_uk/accounting/delete_contact_check_for_outstanding_balance
+          text: You can’t remove personal data for a contact with an outstanding balance.
+          title: This contact has an outstanding balance of %{amount} on their account.
+        title: Remove Personal Data
+      permanent_reason:
+        help: You have to provide a reason why the contact requires a permanent record.
+        label: Reason for Permanent Record
+      permanent_record:
+        label: This contact has consented to be a permanent record
+        title: Permanent Record
+      remove_data_button:
+        text: Remove Personal Data
+      retention_settings:
+        success:
+          message: Successfully updated GDPR Personal Data
+      set_retention_period_link: Set your retention period
+      suggested_removal_date:
+        not_applicable: Not applicable
+        not_set: Not set
+        title: Suggested Removal Date
+      title:
+        help: Under GDPR there are strict rules around how long you can keep personal
+          details. We'll help you by suggesting when a contact's personal data should
+          be removed, based on their last transaction with you and the retention period
+          you set up.
+        text: GDPR Personal Data
+    history:
+      by: by
+      item:
+        date_format: "%e %b %Y - %l:%M %p"
+        from: from
+        permanent_record_no: Remove Permanent Record
+        permanent_record_yes: Set to Permanent Record
+        removal_data: Removal Date changed to %{date}
+        retention_period_set: Retention Period Set to
+      title: Show history
+    info_dialog:
+      button_text: Set Up Now
+      checkbox:
+        label: Don’t show me this again
+      content_line_1: Accounting will help you get ready for this change by allowing
+        you to set a Retention Period for your business.  Setting this means we will
+        be able to prompt you at the end of this period so that you can decide if
+        you want to erase the personal data.
+      content_line_2: We recommend setting your Retention Period straight away.
+      error_setting_hide_dialog: Wrong parameters supplied to hide/unhide dialog
+      info_text: General Data Protection Regulation (GDPR) comes into effect on 25th
+        May 2018. It introduces new rules for how you manage your contact’s personal
+        data.
+      title: Get Ready for GDPR
+  grid:
+    cells:
+      masks:
+        category:
+          bank_transfer: 'Transfer: %{account_name}'
+          deposit: 'Deposit: %{account_name}'
+    titles:
+      advanced_uk/contact_activity:
+        currency_discount: Discount <span data-currency="%{currency_symbol}">&nbsp;</span>
+        currency_outstanding: Outstanding <span data-currency="%{currency_symbol}">&nbsp;</span>
+        currency_total: Total <span data-currency="%{currency_symbol}">&nbsp;</span>
+        currency_total_net_amount: Net <span data-currency="%{currency_symbol}">&nbsp;</span>
+        currency_total_tax_amount: VAT <span data-currency="%{currency_symbol}">&nbsp;</span>
+        discount: Discount <span data-currency="%{base_currency_symbol}">&nbsp;</span>
+        exchange_rate_gain: Exch. Variance <span data-currency="%{base_currency_symbol}">&nbsp;</span>
+        outstanding: Outstanding <span data-currency="%{base_currency_symbol}">&nbsp;</span>
+        total: Total <span data-currency="%{base_currency_symbol}">&nbsp;</span>
+        total_net_amount: Net <span data-currency="%{base_currency_symbol}">&nbsp;</span>
+        total_tax_amount: VAT <span data-currency="%{base_currency_symbol}">&nbsp;</span>
+      advanced_uk/journal_code:
+        code: Code
+        country_journal_type_id: Journal Type
+        name: Name
+      advanced_uk/tax_return:
+        total_amount: Value
+      auxiliary_account_formatted: Account Code
+      currency: Currency
+      from_date: Date From
+      fuji_contacts/contact:
+        formatted: Name
+      fuji_contacts/customer:
+        formatted: Name
+      fuji_contacts/supplier:
+        formatted: Name
+      homepage_url: Homepage
+      inventory/models/stock_movement:
+        cost_price: Cost Price
+        date: Date
+        details: Details
+        quantity: Quantity
+        quantity_in: In
+        quantity_out: Out
+        readable_type: Type
+        reference: Reference
+        sales_price: Sales Price
+      journal_code_code: Journal code
+      mysageone_core/user_activity:
+        authenticated_user_guid: User
+        created_at: Date/Time
+        description: Action
+      name: Name
+      paid_formatted: Paid
+      retailer_amount: RE
+      submitted_date: Submitted Date
+      tax_number: VAT Registration No
+      tax_rate: Tax Rate
+      tax_return_number: Return Number
+      tax_return_status_id: Status
+      to_date: Date To
+      total_amount: Total
+      transaction_number: Trx No
+  headings:
+    advanced_uk/customer_income_payment:
+      bank: Receipt Details
+      contact: Customer Details
+    advanced_uk/customer_refund_payment:
+      bank: Refund Details
+      contact: Customer Details
+    advanced_uk/other_expense_payment:
+      bank: Payment Details
+      contact: Supplier Details
+    advanced_uk/other_income_payment:
+      bank: Receipt Details
+      contact: Customer Details
+    advanced_uk/supplier_expense_payment:
+      bank: Payment Details
+      contact: Supplier Details
+    advanced_uk/supplier_refund_payment:
+      bank: Refund Details
+      contact: Supplier Details
+  heartbeat:
+    cancel: Log out
+    confirm: Stay logged in
+    message: We'll log you out in <span class='heartbeat-logout-timer'>%{time}</span>
+      seconds
+    retained_session:
+      message: We have noticed you are busy and have not automatically logged you
+        out.
+      title: You are still logged in
+    title: All done?
+  helpers:
+    label:
+      all: All
+      filter:
+        artefact_status_id: Status
+        category: Category
+        close: Close
+        coa_group_type_id: Group
+        end_date: To
+        exclude_disputed: Exclude Disputed
+        filter: Filter
+        filter_type: Show
+        ledger_account_classification_id: Class
+        ledger_account_type_id: Category
+        reset_filters: Reset Filters
+        search_text: Type to search
+        show_type: Included in Chart
+        start_date: From
+        type: Type
+      grid_filter_bank_accounts:
+        selection_text: Bank Accounts
+      grid_filter_sales_quotes:
+        end_date: To
+        quote_status: Status
+        quote_type: Type
+        start_date: From
+      report:
+        address_type_values:
+          main: Main
+        address_types: Address Types
+        analysis_category: Analysis Category
+        analysis_type: Analysis Type
+        cash_flow_forecast_detail_report: Cash Flow Forecast - Detailed Breakdown
+        cash_flow_forecast_prior_transactions: Cash Flow Forecast - Expected Prior
+          Cash Flow Detailed Breakdown
+        cash_flow_forecast_report: Cash Flow Forecast Report
+        cash_flow_statement_detail_report: Cash Flow Statement - Detailed Breakdown
+        cash_flow_summary_report: Cash Flow Statement Report
+        category: Category
+        classification: Class
+        cr: Cr
+        date: Date
+        dr: Dr
+        ec_sales_report: EC Sales List
+        end_date: To
+        ledger_account_id: Display Name
+        nominal_activity_report: Nominal Activity Report
+        nominal_activity_report_detail: Detailed Nominal Activity
+        sage_pay_ecommerce_payments: Ecommerce Payments
+        sage_pay_payments: Payments Received
+        search: Search
+        start_date: From
+        statement_period: Statement period %{start_date} to %{end_date}
+        total: Total
+        transaction_type: Transaction Type
+        transaction_type_group: Receipts/Payments
+        type: Show type
+        unreconciled_bank_transactions_report: Unreconciled Bank Transactions Report
+      signup:
+        business_coa_template_id: COA template
+        financial_settings_tax_number: VAT Number
+        financial_settings_tax_scheme_id: VAT Scheme
+        financial_settings_tax_submission_frequency_type_id: Submission Frequency
+    link:
+      fuji_invoicing/purchase_credit_note:
+        invoice: 'Invoice Number: %{invoice_number}'
+      fuji_invoicing/sales_credit_note:
+        invoice: 'Invoice Number: %{invoice_number}'
+    no_activity_for_date_range: No activity for the selected date range
+    select:
+      all: All
+      prompt_for_ledger_account: Select ledger account
+      sales_tax_prompt: Default from customer
+      tax_period_rate: Tax Rate
+  invoice:
+    credit_note_voided: Credit Note Voided
+    email_date_title:
+      credit_date: Credit Date
+      due_date: Due Date
+      expiry_date: Expiry Date
+    email_failure:
+      fuji_invoicing/sales_corrective_invoice: The Sales Corrective Invoice cannot
+        be emailed as it has been voided.
+      fuji_invoicing/sales_credit_note: The Sales Credit Note cannot be emailed as
+        it has been voided.
+      fuji_invoicing/sales_estimate: The Sales Invoice cannot be emailed as it has
+        been voided.
+      fuji_invoicing/sales_invoice: The Sales Invoice cannot be emailed as it has
+        been voided.
+      fuji_invoicing/sales_quote: The Sales Invoice cannot be emailed as it has been
+        voided.
+    email_powered_by_title: Powered By
+    email_subject:
+      fuji_invoicing/sales_corrective_invoice: Corrective invoice %{number} from %{business_name}
+      fuji_invoicing/sales_credit_note: Credit note %{number} from %{business_name}
+      fuji_invoicing/sales_estimate: Estimate %{number} from %{business_name}
+      fuji_invoicing/sales_invoice: Invoice %{number} from %{business_name}
+      fuji_invoicing/sales_quote: Quote %{number} from %{business_name}
+    email_success:
+      fuji_invoicing/sales_corrective_invoice: Sales Corrective Invoice has been sent.
+      fuji_invoicing/sales_credit_note: Sales Credit Note has been sent.
+      fuji_invoicing/sales_estimate: Sales Estimate has been sent.
+      fuji_invoicing/sales_invoice: Sales Invoice has been sent.
+      fuji_invoicing/sales_quote: Sales Quote has been sent.
+    email_total_title: Total
+    email_type:
+      sales_corrective_invoice: Invoice
+      sales_credit_note: Credit Note
+      sales_estimate: Estimate
+      sales_invoice: Invoice
+      sales_quote: Quote
+    print_failure:
+      fuji_invoicing/sales_corrective_invoice: The Sales Corrective Invoice cannot
+        be printed as it has been voided.
+      fuji_invoicing/sales_credit_note: The Sales Credit Note cannot be printed as
+        it has been voided.
+      fuji_invoicing/sales_invoice: The Sales Invoice cannot be printed as it has
+        been voided.
+    save_button: Save
+    void: The %{invoice} has been voided successfully.
+    voided: Invoice Voided
+  invoice_settings:
+    default:
+      sales_corrective_invoice_prefix: CI-
+      sales_credit_note_prefix: SCN-
+      sales_estimate_prefix: SE-
+      sales_invoice_prefix: SI-
+      sales_quote_prefix: SQ-
+  invoices_general:
+    corrections_applied:
+      show:
+        message_title: A correction has been applied to this invoice
+    eu_no_vat:
+      customer:
+        message_text: If they’re VAT registered, enter a VAT number on the customer’s
+          record to apply a zero rate and keep your returns and reports correct.
+        message_title: This customer has an address in the EU, but no VAT number.
+        show_message_text: This customer has an address in the EU, but no VAT number.
+      supplier:
+        message_title: This supplier has an address in the EU, but their VAT number
+          hasn't been entered.
+        show_message_text: This supplier has an address in the EU, but their VAT number
+          hasn't been entered.
+    eu_tax_registration:
+      customer:
+        message_text: VAT rates are therefore set to zero below. You’ll need to submit
+          an EC Sales List to HMRC.
+        message_title: This customer is registered for VAT in the EU.
+        show_message_text: This customer is registered for VAT in the EU.
+      show:
+      supplier:
+        message_text: This invoice will be treated as an EC Purchase and VAT will
+          be charged under the Reverse Charge mechanism. Please review the EU Goods/Services
+          and EC Sales Descriptions.
+        message_title: This supplier is registered for VAT in the EU.
+        show_message_text: This supplier is registered for VAT in the EU.
+    help:
+      original_number: Invoice Number (e.g. SI-1234)
+    invoice_already_issued:
+      message_text: If you make any changes, make sure you inform your customer and
+        provide an updated copy.
+      message_title: Invoice already issued
+    missing_business_address:
+      message: Before you can create a %{model}, you must supply your Business Address.  Click
+        'Ok' to enter this now, or 'Cancel' to return to the List.
+      title: Business Address Required
+    missing_financial_settings:
+      message: 'You have specified that this business is registered for VAT but have
+        not specified the following: '
+      submission_frequency: VAT Submission Frequency
+      tax_number: VAT Number
+      tax_rate: Flat Rate Percentage
+      tax_scheme: You must specify whether this business is registered for VAT.
+    original_number: Original Invoice Number
+    pdf:
+      company_registration: Registered in %{country} Number %{number}
+      company_registration_office: 'Registered Office: %{address}'
+      line_items:
+        tax_amount: VAT
+        tax_percentage: "% VAT"
+      mobile: 'Mobile: %{value}'
+      reference: Reference
+      telephone: 'Telephone: %{value}'
+      vat_number: VAT Number
+      website: 'Website: %{value}'
+    row:
+      customer:
+        message_text: VAT rates are therefore set to zero below.
+        message_title: This customer is outside the EU.
+        show_message_text: This customer is outside the EU.
+      supplier:
+        message_text: This invoice will be charged under the Reverse Charge mechanism.
+        message_title: This supplier is outside of the EU.
+        show_message_text: This supplier is outside of the EU.
+    tax_calculation:
+      cash: VAT on these entries will be collected on date of payment.
+      invoice: VAT on these entries will be collected on the date of invoice.
+      purchase_quick_entries: VAT on these entries may be collected on the date of
+        the invoice, or on payment, depending on your individual Supplier settings.
+        Please ensure you have the right method selected for your suppliers.
+      title: VAT Calculation Method
+    tax_on_non_taxable_business: You cannot add tax, your business is not registered
+      for tax
+  jwt_email_verification:
+    subject: Jwt Email Verification Subject
+  jwt_reseller_mailer:
+    subject: Reseller email subject
+  loading_animation:
+    text_end1: All done.
+    text_end2: Your accounting adventure begins here
+    text_start1: Just a moment…
+    text_start2: Customising your experience
+  locale_options:
+    de: German
+    en: English
+    en-CA: English (Canadian)
+    en-GB: English
+    en-US: English
+    en_IE: English
+    es: Spanish
+    es-US: Spanish (US)
+    fr: French
+    fr-CA: French (Canadian)
+  localised_suffix:
+    en: uk
+    en_IE: ireland
+  lockdown:
+    message: The transaction date must be later than the year-end lock down date of
+      %{date}.<a href="%{help_url}/find_by_tag?language=%{help_language}&locale=%{help_locale}&service=%{help_service}&tag=extra_financial_year_end"
+      target="_"> Change the year-end lock down date and try again.</a>
+  mailers:
+    footer:
+      col1: 'For further information about our terms and conditions please view our '
+      col2: 'If you have further queries, please visit the '
+      col3: To ensure that our emails get to your inbox, please add us to your email
+        Address Book or Safe List.
+    labels:
+      contact: Contact Us
+      help: Help
+      safe_list: Add us to your Safe List
+      terms: Terms &amp; Conditions
+    links:
+      contact: http://www.sageone.com/help/contact-us
+      help: http://www.sageone.com/help
+      terms: http://www.sageone.com/terms-conditions
+    page: " page"
+    plain_text:
+      footer:
+        col1: |-
+          For further information about our terms and conditions
+           please view our terms and conditions
+        col2: If you have further queries, please visit the contact us page
+        col3: To ensure that our emails get to your inbox, please\n add us to your
+          email Address Book or Safe List.
+      sage_info: |-
+        Sage (UK) Limited.
+         Registered in England at North Park,
+         Newcastle upon Tyne,
+         NE13 9AA.
+         Registration Number 1045967.
+      terms: Terms and Conditions
+    sage_info: Sage (UK) Limited. Registered in England at North Park, Newcastle upon
+      Tyne, NE13 9AA.<br />Registration Number 1045967.
+    tooltips:
+      contact_link: Contact Sage
+      finance_email: Sage Finance Email Address
+      help_link: Help
+      support_email: Sage Support Email Address
+      terms_link: Terms &amp; Conditions
+  making_tax_digital:
+    authentication:
+      error: Unable to authenticate with HMRC please try again.
+      failure: You must grant authority to interact with HMRC please try again.
+      not_authenticated: You are not authenticated with HMRC please reconnect.
+      success: Successfully authenticated with HMRC.
+    date_format: "%-d %b %Y"
+    due_date_message: HMRC requires this VAT return to be submitted by %{date}.
+    error_codes:
+      client_or_agent_not_authorised: Unable to connect to HMRC. Please verify your
+        VAT settings and try again.
+      duplicate_submission: You have already submitted a VAT return for this period.
+      invalid_numeric_value: Please check the information entered and try again.
+      invalid_request: Please check the information entered and try again.
+      not_finalised: Please check the information entered and try again.
+      period_key_invalid: Please select a valid VAT return period.
+      tax_period_not_ended: HMRC have rejected this return as the period has not ended.
+      unknown: Please check the information entered and try again.
+      vat_net_value: Please check the information entered and try again.
+      vat_total_value: Please check the information entered and try again.
+      vrn_invalid: Please enter a valid VAT registration number.
+    overdue_message: HMRC required this VAT return to be submitted by %{date}.
+  menu:
+    accountant:
+      text: Accountant
+    adjustments:
+      text: Adjustments
+    aged_creditors:
+      text: Aged Creditors
+    aged_debtors:
+      text: Aged Debtors
+    audit_trail_selector:
+      text: Audit Trail
+    balance_sheet:
+      text: Balance Sheet Report
+    balance_statement:
+      text: Balance Sheet
+    bank_accounts:
+      text: Banking
+    business_settings:
+      text: Business Settings
+    buy_and_sell:
+      text: Buy & Sell
+    cash_flow_forecast:
+      text: Cash Flow Forecast
+    cash_flow_summary:
+      text: Cash Flow Statement
+    chart_of_accounts:
+      text: Chart of Accounts List
+    contacts:
+      text: Contacts
+    corrections:
+      text: Correct Transactions
+    create:
+      text: Create...
+    customers:
+      text: Customers
+    ec_sales:
+      text: EC Sales Analysis Report
+    income_statement:
+      text: Income Statement
+    invoice_profit_analysis:
+      text: Profit Analysis
+    journals:
+      text: Journals
+    ledger_accounts:
+      text: Chart of Accounts
+    more_options:
+      text: More...
+    nominal_activity:
+      text: Nominal Activity
+    payments:
+      text: Payments
+    payments_and_receipts:
+      text: Payments & Receipts
+    products_services:
+      text: Products & Services
+    profit_and_loss:
+      text: Profit & Loss
+    purchase_batches:
+      text: Quick Entries
+    purchase_corrective_invoices:
+      text: Purchase Corrective Invoices
+    purchase_credit_notes:
+      text: Purchase Credit Notes
+    purchase_day_book:
+      text: Purchase Day Book
+    purchase_invoices:
+      text: Purchase Invoices
+    purchase_ledger:
+      text: Purchase Ledger
+    purchases:
+      text: Purchases
+    quotes:
+      text: Quotes
+    receipts:
+      text: Receipts
+    receipts_and_payments_day_book:
+      text: Receipts & Payments Day Book
+    reporting:
+      text: Reporting
+    reports:
+      text: Reports
+    return_of_trading_details:
+      text: Return of Trading Details
+    sage_pay_ecommerce_payments:
+      text: Ecommerce Payments
+    sage_pay_payments:
+      text: Payments Received
+    sales:
+      text: Sales
+    sales_batches:
+      text: Quick Entries
+    sales_corrective_invoices:
+      text: Sales Corrective Invoices
+    sales_credit_notes:
+      text: Sales Credit Notes
+    sales_day_book:
+      text: Sales Day Book
+    sales_invoices:
+      text: Sales Invoices
+    sales_ledger:
+      text: Sales Ledger
+    sales_quotes:
+      text: Quotes & Estimates
+    sales_tax:
+      text: Sales Tax Report
+    settings:
+      text: Settings
+    summary:
+      text: Summary
+    suppliers:
+      text: Suppliers
+    tax:
+      text: VAT
+    tax_returns:
+      text: VAT Returns
+    trial_balance:
+      text: Trial Balance
+    unallocated_payments:
+      text: Unallocated Receipts or Payments
+    unreconciled_bank_transactions:
+      text: Unreconciled Bank Transactions
+  micro:
+    actions:
+      advanced:
+        payment:
+          new: Money Out
+        receipt:
+          new: Money In
+      fuji_core_accounting:
+        ledger_account:
+          new: New Category
+    activerecord:
+      attributes:
+        advanced_uk/audit_trail_summary:
+          date: Date
+        advanced_uk/journal_opening_balance_line:
+          ledger_account_id: Category
+        advanced_uk/other_expense_payment:
+          name: Contact (optional)
+        advanced_uk/other_income_payment:
+          name: Contact (optional)
+        advanced_uk/payment:
+          bank_account: Bank Account
+          bank_account_id: Paid from Bank Account
+          contact_id: Name
+          formatted_type: Type
+          id: Number
+          money_in: Money in
+          money_out: Money out
+          payment_type: Method
+          recurrence: Repeat
+          reference: Reference
+          total_amount: Total
+          total_net_amount: Net
+          total_tax_amount: VAT
+        advanced_uk/payment_line_item:
+          ledger_account_id: Category
+        fuji_contacts/contact:
+          purchase_ledger_account_id: Purchase Category
+          purchases_to_date: Money out - to Date
+          sales_ledger_account_id: Sales Category
+          sales_to_date: Money in - to Date
+        fuji_core_accounting/business_retention_settings:
+          gdpr:
+            help_link: https://help.sageone.com/find_by_tag?language=en&locale=uk&service=start&tag=setup_gdpr_retention_period
+        fuji_core_accounting/ledger_account:
+          coa_group_type: Group
+          coa_group_type_id: Group
+          has_other_payment_scope: Money Out
+          has_other_receipt_scope: Money In
+          has_purchasing_scope: Supplier defaults
+          has_sales_scope: Sales - Invoice / Credit, Customer defaults
+          ledger_account_type_id: Type
+          name: Category Name
+          name_for_grid: Category Name
+          nominal_code: Category Code
+          nominal_code_formatted: Category Code
+        fuji_core_accounting/ledger_entry:
+          category: Type
+          recurrence: Repeat
+        fuji_support/recurrence:
+          expiry_date: Repeat Until
+        journal_line:
+          ledger_account_id: Category
+      models:
+        advanced_uk/other_expense_payment: Money out
+        advanced_uk/other_income_payment: Money in
+        fuji_core_accounting/ledger_account: Category
+    advanced_uk/summary:
+      balance: Balance
+      expense: Money out
+      income: Money in
+      new_expense: Add
+      new_income: Add
+    cashbook:
+      buttons:
+        new_expense: Money Out
+        new_income: Money In
+    contact_activity:
+      contacts:
+        dialog:
+          account_default: Default Category
+          invoice_details_tab: Contact Details
+    export:
+      nominal_activity:
+        detailed_tooltip: "<span class='beta_version'>BETA</span> Export transactions
+          for many categories in one go."
+    filters:
+      all_accounts: All Accounts
+      all_types: All Types
+      ledger_account_type_id: Type
+      show_type: Included in Chart
+    grid:
+      titles:
+        advanced_uk/audit_trail:
+          ledger_account_name: Category
+    headings:
+      advanced_uk/other_expense_payment:
+        contact: Contact Details
+      advanced_uk/other_income_payment:
+        contact: Contact Details
+    helpers:
+      label:
+        filter:
+          ledger_account_type_id: Type
+        report:
+          nominal_activity_report: Category Activity
+          nominal_activity_report_detail: Category Activity - Detailed
+    localised_lookup:
+      fuji_core_accounting:
+        transaction_type:
+          other_expense_payment: Money out
+          other_expense_payment_refund: Money in
+          other_income_payment: Money in
+          other_income_payment_refund: Money out
+    menu:
+      bank_accounts:
+        text: Banking
+      cashbook:
+        text: Cashbook
+      customer_receipt:
+        text: Customer receipt
+      deposit_cash:
+        text: Deposit cash
+      money_in:
+        text: Money in
+      money_out:
+        text: Money out
+      more:
+        text: More
+      new_bank_account:
+        text: Bank Account
+      new_journal:
+        text: Journal
+      withdraw_or_transfer:
+        text: Transfer
+    micro_invoicing:
+      actions:
+        fuji_invoicing/sales_corrective_invoice:
+          refund_dialog:
+            title: 'Refund Money In: %{paid_amount}'
+        fuji_invoicing/sales_invoice:
+          refund_dialog:
+            title: 'Refund Money In: %{paid_amount}'
+      activerecord:
+        attributes:
+          fuji_invoicing/sales_corrective_invoice:
+            currency_total_net_amount: Subtotal
+          fuji_invoicing/sales_invoice:
+            currency_total_net_amount: Subtotal
+      bulk_destroy:
+        messages:
+          warning_draft:
+            sales_artefact: One or more of the selected items has a Draft status.
+              Draft invoices or credit notes will be fully deleted and won't be retained
+              after deletion.
+            sales_invoice: One or more of the selected items has a Draft status. Draft
+              invoices will be fully deleted and won't be retained after deletion.
+      bulk_pay_or_allocate:
+        messages:
+          payments_allocated_or_voided:
+            sales_artefact: One or more of the selected items are already voided,
+              fully allocated or draft.
+            sales_invoice: One or more of the selected items are already voided, fully
+              allocated or draft.
+      invoices_general:
+        missing_business_address:
+          currency_total_tax_amount: VAT
+          message: Before you can create a %{model}, you must supply your Business
+            Address.
+      page_info:
+        advanced_uk/customer_income_payments:
+          info:
+            show: ''
+        advanced_uk/other_expense_payment_refunds:
+          info:
+            show: Record receipts, such as refunds for over the counter purchases,
+              that you've received during the course of running your business.
+          title:
+            default: Money In
+            show: Money In
+        advanced_uk/other_income_payment_refunds:
+          info:
+            show: Record payments, such as refunds for over the counter sales, that
+              you've paid out in the course of running your business.
+          title:
+            default: Money Out
+            show: Money Out
+        advanced_uk/reports:
+          help:
+            aged_debtors: start_aged_debtors_report
+            sales_day_book: start_sales_day_book
+          info:
+            aged_debtors: This report shows all outstanding or unallocated customer
+              transactions, broken down by ageing periods.
+        advanced_uk/sales_artefacts:
+          help:
+            index: start_sales_invoices_list
+        fuji_invoicing/sales_corrective_invoices:
+          help:
+            copy: start_create_sales_corrective_invoices
+            create: start_create_sales_corrective_invoices
+            edit: start_manage_sales_corrective_invoices
+            index: extra_sales_corrective_list
+            new: start_create_sales_corrective_invoice
+            show: start_manage_sales_corrective_invoices
+        fuji_invoicing/sales_credit_notes:
+          help:
+            copy: start_create_sales_credit_notes
+            create: start_create_sales_credit_notes
+            edit: start_manage_sales_credit_notes
+            index: extra_sales_list
+            new: start_create_sales_credit_note
+            show: start_manage_sales_credit_notes
+        fuji_invoicing/sales_invoices:
+          help:
+            copy: start_create_sales_invoices
+            create: start_create_sales_invoices
+            edit: start_manage_sales_invoices
+            index: extra_sales_list
+            new: start_create_sales_invoice
+            show: start_manage_sales_invoices
+        sop_settings/email_defaults:
+          info:
+            show: Set a default message which you can customise when you email an
+              invoice or credit note.
+        sop_settings/invoice_settings:
+          help:
+            show: start_invoice_settings
+          info:
+            show: Select the invoice template to use for your business, your numbering
+              defaults and enter the text to appear on your documents.
+          title:
+            default: Invoice Form Settings
+            show: Invoice Form Settings
+      sop_settings:
+        invoices_and_quotes:
+          link_text: Invoice Form Settings
+      table:
+        titles:
+          fuji_invoicing/sales_invoice_line_item:
+            currency_unit_price: Amount excl VAT
+            ledger_account_id: Category
+    page_info:
+      advanced_uk/cashbook:
+        help:
+          index: cashbook_option
+        info:
+          index: This is where you record the flow of money in and out of your business
+        title:
+          index: Cashbook
+      advanced_uk/other_expense_payments:
+        alert_not_home:
+          message: EC and Rest of World payments are not supported by Accounting.
+            Click <a href=%{help} target='new'>here</a> to find out more.
+          title: Overseas Supplier
+        help:
+          overseas_supplier: start_overseas_supplier
+          show: money_out
+        info:
+          show: Record one-off payments, over the counter purchases, and other money
+            that you’ve paid out in the course of running your business.
+        title:
+          show: Money Out
+      advanced_uk/other_income_payments:
+        help:
+          show: money_in
+        info:
+          show: Record receipts, such as for over the counter sales and other money
+            that you’ve received during the course of running your business.
+        title:
+          show: Money In
+      advanced_uk/payments:
+        help:
+          recurrence: extra_bank_recurring_entries
+        info:
+          recurrence: If you make payments and receipts on a regular basis you can
+            set them up as recurring entries.
+        title:
+          expense: Money Out
+          income: Money In
+      advanced_uk/reports:
+        help:
+          chart_of_accounts: chart_accounts_list
+          nominal_activity: category_report
+          profit_and_loss: extra_management_reports
+          receipts_and_payments_day_book: start_reports_incomeexpense_daybook
+        info:
+          chart_of_accounts: Use this report to view and export a list of your categories.
+          nominal_activity: This report shows the categories with activity for analysis
+            codes in a given date range.
+          nominal_activity_detail: This report shows the transaction activity for
+            specified category, analysis codes in a given date range.
+          trial_balance: This report shows the balance on your categories for a specified
+            date range. You can include brought forward values and include current
+            year’s profit and loss values only
+        title:
+          nominal_activity: Category Activity - Summary
+          nominal_activity_detail: 'Category Activity - Detailed: %{context_string}'
+          receipts_and_payments_day_book: Income and Expense Day Book
+      advanced_uk/reports/financial_statements/report:
+        message:
+          link: " Category Activity report "
+      advanced_uk/summary:
+        help:
+          index: start_summary
+        info:
+          index: ''
+        link:
+          help:
+            text: sageone.com/support
+      fuji_banking/bank_accounts:
+        title:
+          index: Banking
+      fuji_core_accounting/ledger_accounts:
+        info:
+          index: Create, view and manage your categories. Select existing categories
+            to view or change the areas they are visible in, or create new categories
+            for improved analysis.
+      journals:
+        info:
+          index: Create, view and manage your journals to directly update or move
+            values between categories.
+      outstanding_invoices:
+        one: "%{number_of_oustanding_invoices} invoice to be paid"
+        other: "%{number_of_oustanding_invoices} invoices to be paid"
+      sop_settings/default_settings:
+        chart_of_accounts:
+          list_order:
+            choice_code: Number
+            choice_name: Description
+            label: Sort order for lists
+        expenses_other_payment_ledger_account: Default for expenses
+        help: When you create new income or expenses, these categories are already
+          selected for you to make entry faster. You can still change them each time.
+        incomes_other_receipt_ledger_account: Default for income
+        invoice_sales_discount_ledger_account: Default for sales discounts
+        invoice_sales_ledger_account: Default for sales
+        title:
+          default: Default Categories
+      sop_settings/financial_settings:
+        info:
+          show: Record your financial details including VAT scheme information, financial
+            year end and the start date for transactions.
+      sop_settings/nominal_opening_balances:
+        info:
+          show: Record the balances of your categories from your previous accounting
+            system. Opening balances already entered through the customer, supplier
+            or bank opening balance options appear automatically. You can enter or
+            amend these by clicking each line. Each debit or credit balance is offset
+            against the opening balance control account, and when the full trial balance
+            is entered, this account should be zero.
+        title:
+          show: Category Opening Balances
+      sop_settings/settings:
+        help:
+          index: start_settings
+    quick_start:
+      description: Let's get set up in less than a minute
+      fields:
+        business_name:
+          hint: We'll put this on your reports automatically
+        business_type:
+          hint: Accounting Start is great for essential accounting - if your company
+            has lots of activity, find out if <u>Accounting</u> might be right for
+            you.
+      tax_scheme:
+        cash_accounting:
+          description: VAT is applied on money in or money out
+        flat_cash:
+          description: A flat VAT rate is applied on money in or money out
+    recurrence:
+      dialog:
+        fields:
+          label: Repeats every...
+      link:
+        edit: Edit Repeat
+        stop: Stop Repeat
+      notifications:
+        delete: Repeat deleted
+        set: Repeat set
+      payment: Money Out
+      receipt: Money In
+      title: "%{prefix} Recurring"
+    reporting:
+      cash_flow_statement_detail:
+        customer: Name
+        other_payments: Money Out
+        other_receipts: Money In
+        supplier: Name
+      cash_flow_summary:
+        liability_title: Owed to others
+      cash_reports:
+        description: Make your cash flow work for you!
+        receipts_and_payments_day_book_title: Income and Expense Day Book
+      detail_reports:
+        description: Clever stuff for your accountant or bookkeeper.
+        nominal_activity_title: Category Activity
+        title: ADVANCED REPORTS
+      export_dialog:
+        nominal_activity:
+          download: Category Activity (%{file_type})
+        nominal_activity_detail:
+          download: Category Activity Detail (%{file_type})
+        nominal_activity_transaction:
+          download: Category Activity Detailed (%{file_type})
+        receipts_and_payments_day_book:
+          download: Income and Expense Day Book (%{file_type})
+        title:
+          nominal_activity: Category Activity
+          nominal_activity_detail: Generate Category Activity - Detailed Report
+          nominal_activity_transaction: Generate Detailed Category Activity Report
+          receipts_and_payments_day_book: Generate Income and Expense Day Book
+      index_descriptions:
+        chart_of_accounts: What categories are set up?
+        nominal_activity: What transactions took place for each category?
+        trial_balance: What is the balance for each category?
+      index_sub_descriptions:
+        chart_of_accounts: 'Shows: A list of your categories, their type and tax rate.'
+        nominal_activity: 'Shows: Balances for each category for a given date range.'
+        trial_balance: 'Shows: Balance for each of your categories, for a given date
+          range.'
+      management:
+        description: How good is business? We’ll crunch the numbers for you.
+      nominal_activity:
+        category: Type
+        filename: category_activity
+        ledger_account: Category
+      nominal_activity_detail:
+        filename: category_activity_detailed
+      nominal_activity_transaction:
+        filename: category_activity_detail
+      receipts_and_payments_day_book:
+        filename: income_and_expense_day_book
+        title: Income and Expense Day Book
+        transaction_type_group: Income/Expense
+        transaction_type_group_values:
+          expense: Expense
+          income: Income
+          payments: Expense
+          receipts: Income
+      remote_reports:
+        category_activity: Category Activity
+        category_activity_detail: Category Activity - Detailed
+        category_activity_detailed: Category Activity - Detailed
+        income_and_expense_day_book: Income and Expense Day Book
+      sales_invoicing:
+        title: Invoices
+      tax_reports:
+        description: Keeping HMRC happy.
+      trial_balance:
+        ledger_account: Category Name
+        name: Category Name
+        nominal_code: Category Code
+      unreconciled_bank_transactions:
+        payment: Paid
+        receipt: Received
+    settings:
+      email_defaults:
+        email_defaults:
+          desc: Save time by setting up default email messages to use when sending
+            documents. You can easily customise these messages whenever you email
+            an invoice
+        pdf_attached:
+          desc: When sending an email we can automatically include a pdf version of
+            your invoice. Do you want us to do this?
+    sop_settings:
+      nominal_opening_balances:
+        link_text: Category Opening Balances
+    tabs:
+      titles:
+        fuji_contacts/contacts:
+          addresses: Address
+  migration:
+    mailer:
+      completed:
+        actions:
+          login_to_new:
+            html: Log in to New Account
+            text: 'Log in to New Account:'
+          login_to_old:
+            html: Back to Old Account
+            text: 'Back to Old Account:'
+        closing:
+          html: Thanks,<br>Sage Business Cloud Team
+          text: |-
+            Thanks,
+            Sage Business Cloud Team
+        footer:
+          html: The Sage Group plc
+          text: The Sage Group plc
+        greeting:
+          html: Hi %{name},
+          text: Hi %{name},
+        main_message:
+          part_1:
+            html: Thanks for waiting - your upgrade is now complete, and you're ready
+              to log in<br>to the latest version of Compta & Facturation!
+            text: |-
+              Thanks for waiting - your upgrade is now complete, and you're ready to log in
+              to the latest version of Compta & Facturation!
+          part_2:
+            html: You can still view your old data, but you can't make changes.<br>Deactivate
+              your old account when you're ready, so you'll no longer pay its<br>monthly
+              subscription.
+            text: |-
+              You can still view your old data, but you can't make changes.
+              Deactivate your old account when you're ready, so you'll no longer pay its
+              monthly subscription.
+        subject: Your upgrade is complete
+        title:
+          html: Your upgrade is complete!
+          text: Your upgrade is complete!
+      contact_link:
+        html: For any question, contact customer support by email at <a href='mailto:serviceclientsageone@sage.com'>serviceclientsageone@sage.com</a>
+          or by phone at 0 825 95 00 70.
+        text: |-
+          For any question, contact customer support by email at serviceclientsageone@sage.com
+          or by phone at 0 825 95 00 70.
+      failed:
+        closing:
+          html: Thanks,<br>Sage Business Cloud Team
+          text: |-
+            Thanks,
+            Sage Business Cloud Team
+        footer:
+          html: The Sage Group plc
+          text: The Sage Group plc
+        greeting:
+          html: Hi %{name},
+          text: Hi %{name},
+        main_message:
+          part_1:
+            html: It looks like your data is a little more complex than usual, so
+              it can’t be<br> upgraded automatically.
+            text: It looks like your data is a little more complex than usual, so
+              it can’t be upgraded automatically.
+          part_2:
+            html: So you can continue working, we’ve left your data in your existing
+              account.
+            text: So you can continue working, we’ve left your data in your existing
+              account.
+          part_3:
+            html: We will contact you when we have more information.
+            text: We will contact you when we have more information.
+        subject: We’ve had to stop your upgrade.
+        title:
+          html: Sorry about this, we've had to cancel your<br> upgrade.
+          text: Sorry about this, we've had to cancel your upgrade.
+      help_link:
+        html: For help and information, <a href="https://www.sageone.fr/nouvelle-version/">view
+          our guide</a>.
+        text: 'For help and information, view our guide: https://www.sageone.fr/nouvelle-version/'
+    user_admin:
+      bdp: Business migrated via BDP on %{date}, from %{product} %{product_version},
+        source tool %{tool} %{tool_version}.
+  mobile:
+    complete_setup:
+      ready: We now have enough information for you to start using Accounting
+    fieldsets:
+      business_name: 'My Business Name:'
+      your_details: 'My Details:'
+      your_email: 'My Email Address:'
+    get_started:
+      launch_demo: Have a go with the demo
+      login: Log In
+      login_help: Already have an account?
+      or: or
+      register: Sign Up
+      register_help: New to Accounting?
+    login:
+      errors:
+        auth_error:
+          access_denied: Please log in and accept the required permissions.
+          default: Please log in or sign up to Sage Business Cloud Accounting.
+          title: Authentication failed
+          user_denied: Please log in and accept the required permissions.
+        unlinked_account:
+          description: Please log in with a different account or sign up to Sage Business
+            Cloud Accounting.
+          title: Unable to authenticate account
+    placeholders:
+      business_name: Business Name
+      email: Email Address
+      user_first_name: First Name
+      user_last_name: Last Name
+    providers:
+      facebook: Facebook
+      google: Google
+    signup:
+      create_account: Create an Account
+      create_account_dev: Create an Account (Developer)
+      errors:
+        auth_already_exists: A user already exists with this authentication.
+      or_use_auth_provider: 'Or sign up with one of the following:'
+      terms_and_conditions:
+        acceptance: 'I agree to the %{link}:'
+        link: terms of use
+  multi_currency:
+    allocations:
+      error: You cannot allocate invoices and credit notes with different exchange
+        rates. You should edit the documents you want to allocate, and update the
+        exchange rates to ensure both use the same exchange rate.
+      title: Exchange Rate Difference
+      warning: The invoices and credit notes you are allocating have different exchange
+        rates. This may result in an imbalance between the currency value and base
+        value of your contact's account. Do you wish to proceed?
+    currency: Currency
+    exchange_rate: Exchange Rate
+  multi_tabs:
+    notes_title: Notes
+    terms_and_conditions_title: Terms and Conditions
+    voided_title: Void Reason
+  n_a: N/A
+  new_account_dialog:
+    account_name_prompt: e.g. Lloyds Current Account
+    address: Address
+    contact_details: Contact Details
+    starting_balance_source_placeholder: This transaction will be posted to Opening
+      Balances Control Account (9998)
+  notifications:
+    advanced_uk/category:
+      failure:
+        create: 'There was a problem creating the category: %{category_errors}'
+        delete: There was a problem deleting the selected categories.
+        update: 'There was a problem updating the category: %{category_errors}'
+      success:
+        delete: The selected categories have been deleted successfully
+    advanced_uk/sage_pay_notification:
+      messages:
+        multiple_transactions: There are %{transaction_count} transactions ready to
+          import from Sage Pay
+        single_transaction: There is %{transaction_count} transaction ready to import
+          from Sage Pay
+    advanced_uk/sage_pay_payment:
+      failure:
+        invoice: 'There was a problem with the Sage Pay MOTO payment: %{sage_pay_error}'
+        invoice_allocation: Sage Pay MOTO payment cannot be allocated to this invoice
+        payment: 'There was a problem with the Sage Pay MOTO payment: %{sage_pay_error}'
+        payment_allocation: Sage Pay MOTO payment cannot be allocated to this payment
+      problem:
+        transaction: Your payment has been processed successfully, but there has been
+          an issue displaying the confirmation page. If you require any further information,
+          please contact the vendor.
+        transaction_title: Sage Pay Payment Problem
+      success:
+        invoice: Sage Pay MOTO payment was successfully created for this Invoice
+        payment: Sage Pay MOTO payment was successfully created for this Payment
+      warning:
+        modifications:
+          payment: Received via Sage Pay - Any changes made to this payment will not
+            be reflected in your Sage Pay account. Some changes may result in the
+            entry no longer being flagged as received via Sage Pay.
+          receipt: Received via Sage Pay - Any changes made to this receipt will not
+            be reflected in your Sage Pay account. Some changes may result in the
+            entry no longer being flagged as received via Sage Pay.
+    advanced_uk/sage_pay_vendor:
+      success:
+        ecommerce_enabled: Edited Sage Pay Settings Successfully.  Your Sage Pay transactions
+          will be imported daily.  It may take up to 24 hours for your first transactions
+          to be ready to import.
+    core_accounting/tax_profiles:
+      success:
+        update: Tax settings saved successfully
+    core_accounting/tax_rate:
+      success:
+        create: Tax Rate saved successfully
+        update: Tax Rate updated successfully
+    email_defaults:
+      reset_email: Email reply address set back to use logged in user's email address.
+    failure:
+      payment_not_found: Payment not found.
+      user_already_activated: User already activated.
+      user_not_in_sageid: User's auth provider is not SageID. No E-Mail has been sent.
+    fuji_contacts/contacts:
+      changes_saved: Changes Saved
+      created_address: Successfully Created New Address
+      created_individual: Successfully Created New Individual
+      deleted_address: Successfully Deleted Address
+      deleted_individual: Successfully Deleted Individual
+      updated_account_details: Successfully Updated Account Details
+      updated_address: Successfully Updated Address
+      updated_analysis_types: Successfully Updated Analysis Types
+      updated_contact: Successfully Updated Contact
+      updated_individual: Successfully Updated Individual
+      updated_notes: Successfully Updated Notes
+      updated_payment_details: Successfully Updated Payment Details
+      updated_statement_settings: Successfully Updated Statement Settings
+    fuji_invoicing/purchase_corrective_invoice:
+      failure:
+        disputed: Paid Purchase Corrective Invoices cannot be disputed.
+      success:
+        cleared_disputed: Purchase Corrective Invoice Dispute Cleared Successfully.
+        disputed: Purchase Corrective Invoice Disputed Successfully.
+    fuji_invoicing/purchase_credit_note:
+      failure:
+        disputed: Paid Purchase Credit Notes cannot be disputed.
+      success:
+        cleared_disputed: Purchase Credit Note Dispute Cleared Successfully.
+        disputed: Purchase Credit Note Disputed Successfully.
+    fuji_invoicing/purchase_invoice:
+      failure:
+        disputed: Paid Purchase Invoices cannot be disputed.
+      success:
+        cleared_disputed: Purchase Invoice Dispute Cleared Successfully.
+        disputed: Purchase Invoice Disputed Successfully.
+    fuji_invoicing/sales_estimate:
+      failure:
+        declined: Draft and invoiced sales estimates cannot be declined.
+      success:
+        declined: Sales Estimate Declined Successfully.
+        undeclined: Sales Estimate Cleared Declined Successfully.
+    fuji_invoicing/sales_quote:
+      failure:
+        declined: Draft and invoiced sales quotes cannot be declined.
+      success:
+        declined: Sales Quote Declined Successfully.
+        undeclined: Sales Quote Cleared Declined Successfully.
+    notice:
+      title: 'Information: '
+    success:
+      delete_activity: Payment deleted successfully
+      email: "%{model} emailed successfully."
+      email_monthly_statement: Monthly Statement option has been saved
+      finish: This Bank Reconciliation has been successfully finished
+      interest_and_charges: Interest and Charges created
+      pay: VAT payment has been successfully created
+      payment_refunded: Payment successfully refunded.
+      payment_unallocated: Payment successfully unallocated.
+      reclaim: VAT reclaim has been successfully created
+      reconcile_all: All entries have been reconciled
+      reconcile_entry: The entry has been reconciled
+      reorder: Accounts reordered successfully.
+      resend_activation: An activation email has been sent to this user.
+      save: Saved %{model} Successfully
+      show: Edited %{model} Successfully
+      unreconcile_all: All entries have been unreconciled
+      unreconcile_entry: The entry has been unreconciled
+      verify: Email reply address changed successfully.
+  number:
+    currency:
+      format:
+        currency_code:
+          AUD: "$"
+          BGN: лв
+          BRL: R$
+          CAD: "$"
+          CHF: CHF
+          CNY: "¥"
+          CZK: Kč
+          DKK: kr
+          EUR: "€"
+          GBP: "£"
+          HKD: "$"
+          HRK: kn
+          HUF: Ft
+          IDR: Rp
+          ILS: "₪"
+          INR: "₹"
+          JPY: "¥"
+          KRW: "₩"
+          MXN: "$"
+          MYR: RM
+          NOK: kr
+          NZD: "$"
+          PHP: "₱"
+          PLN: zł
+          RON: lei
+          RUB: руб
+          SEK: kr
+          SGD: "$"
+          THB: "฿"
+          TRY: "₺"
+          USD: "$"
+          ZAR: R
+        unit_html: "&pound"
+  online_payment:
+    allow_online_payment: Allow customer to pay this invoice online
+    auto_refund_warning: Payments processed with %{providers} are automatically refunded.  Are
+      you sure you wish to delete this bank activity?
+    buttons:
+      alert:
+        timeout: You’ve already attempted to make a payment. To avoid duplicate payments
+          you must wait %{timeout} before trying again.
+        title: 'Alert:'
+      prompt:
+        default: 'Payment options:'
+        owner: Process Payment
+    disable: Disable
+    edit_delete_payment_warning:
+      one: It is strongly recommended that you do not modify this payment transaction.
+        It was created from a transaction processed outside of Accounting and may
+        not match the original value if modified.  Before editing this transaction,
+        review the details from your payment processor. Failure to do so may result
+        in inconsistent transaction details.
+      other: It is strongly recommended that you do not modify these payment transactions.
+        They were created from transactions processed outside of Accounting and may
+        not match the original value if modified.  Before editing these transaction,
+        review the details from your payment processor. Failure to do so may result
+        in inconsistent transaction details.
+    email:
+      message:
+        invoice:
+          greeting: Hello %{recipient},
+          parting: Thanks!
+        payment:
+          full: You have paid Invoice# %{invoice} in full. The amount paid was $%{amount}.
+          greeting:
+            default: Hello %{recipient},
+            owner: Dear %{recipient},
+          log_in: log into Sage Business Cloud Accounting
+          owner: We thought you would like to know that your customer, %{cus_bus_name}
+            made an online payment of $%{amount} for invoice %{invoice}. You can
+          owner_end: to view invoice and payment details.
+          partial: You have paid $%{amount} towards Invoice# %{invoice}. The remaining
+            balance is $%{balance}.
+          parting:
+            default: Thank you for your payment!
+            owner: The Sage Business Cloud Accounting Team
+      subject:
+        invoice: Invoice# %{invoice} from %{business}
+        payment: Payment confirmation for Invoice# %{invoice} from %{business}
+      view:
+        html: View this invoice.
+        text: To view this invoice, copy the link and paste it into your browser address
+          bar.
+      view_and_pay:
+        html: View and pay this invoice.
+        text: To view and pay this invoice, copy the link and paste it into your browser
+          address bar.
+    errors:
+      expired:
+        message: Access to your invoice has expired. In order to regain access you
+          will need to have the invoice resent to you.
+        title: Access Unavailable
+      non_refundable: Paid through a non-refundable provider
+      not_setup: Payment provider is not set up for use
+      voided:
+        message: This invoice has been deleted and is no longer available.
+        title: Access Unavailable
+    in_progress: Your payment can not be processed. Payment of this invoice has been
+      recently attempted. For security reasons there is a 20 minute waiting period
+      between attempts.
+    invoice_number: Invoice#
+    minute: minute
+    minutes: minutes
+    no_foreign_currency: Online payments are not available for invoices in foreign
+      currency. You may accept payment externally, then manually record the payment
+      in Accounting.
+    notification:
+      error:
+        ajax: Your invoice could not be processed. Please reload the page and try
+          again.
+    paid: This invoice is paid in full.
+    paypal:
+      bank_account_id: Default Bank Account
+      button:
+        default: PayPal
+      disable_confirm: Do you want to stop accepting payments through PayPal?
+      disable_success: You will now stop accepting payments through PayPal.
+      disable_title: Disable PayPal
+      email: PayPal Email
+      reference_prefix: 'PayPal: '
+      settings_logo: paypal_logo.png
+      settings_title: PayPal Account
+      title: PayPal
+    processing: Processing...
+    required_field: "* Required field"
+    save: Save PDF
+    select_or_type: Select or type to search
+    settings_subtitle: 'Account Settings:'
+    settings_success: Your changes have been saved.
+    sps:
+      aux_promo: Get immediate payment and reduce your collections by accepting electronic
+        payments from your customers!
+      bank_account_id: Default Bank Account
+      button:
+        default: Credit Card
+        single_owner: Process Credit Card
+      cannot_delete: We were unable to delete this transaction. Please try again later.
+      delete_payment:
+        error: Error deleting %{txn_id}. %{response}.
+      disable_confirm: Do you want to stop accepting payments through Paya?
+      disable_success: You will now stop accepting payments through Paya.
+      disable_title: Disable Paya
+      invalid_merchant: The account information entered for your Paya account is invalid.
+        Please re-enter this information in the Settings panel.
+      merchant_id: Merchant ID
+      merchant_key: Merchant Key
+      reference_prefix: 'Authorization #: '
+      report:
+        aux_title: Credit card transaction reports
+        description: View credit card reports in the Paya Virtual Terminal.
+        link_title: credit card transaction reports
+        title: Paya Reports
+      settings_logo: paya_logo.png
+      settings_title: Paya Account
+      signup:
+        get_started: Get Started Now
+        promo: Get paid faster by accepting credit card payments online.
+        sub_title: Existing Paya customer? Enter Merchant ID and Key.
+      title: Paya
+      view_report: View your %{link} in the Paya Virtual Terminal.
+    status:
+      approved: Congratulations! Your credit card payment for %{amount} has been approved.
+      button: Continue
+      continue: Don't worry - you can continue working and we'll automatically update
+        your invoice as soon as your payment is finished processing.
+      declined: We're sorry, but your payment has been declined.
+      description: We'll update your invoice automatically.
+      error: We're sorry, there was an error processing your payment.
+      please_wait: Please wait
+      taking_longer: We're sorry, it's taking longer than expected to process your
+        payment.
+      timeout: Your payment transaction has timed out. Please try again.
+      title: Processing your payment
+    title:
+      invoice: View Invoice
+      link_desc: Manage your Paypal and Paya settings.
+      sales_corrective_invoice: View Invoice
+      sales_credit_note: View Credit Note
+      sales_estimate: View Estimate
+      sales_invoice: View Invoice
+      sales_quote: View Quote
+      settings: Paypal and Paya
+    unknown: An unexpected error has occurred. Please contact customer support at
+      %{support}.
+  opening_balance:
+    add_itemised_opening_balances: Add itemised opening balances
+    title: Opening Balance
+  page_info:
+    advanced_uk/batches:
+      alert:
+        cross_border_contact:
+          message: You cannot record Quick Entries for Cross Border contacts. To correctly
+            deal with VAT when recording cross border transactions, you must use the
+            Invoice or Credit Note Option. Delete these lines and resave.
+        foreign_currency_contact:
+          message: You cannot record Quick Entries for this contact. To correctly
+            deal with foreign currency transactions, you must use the Invoice or Credit
+            Note option.
+        retailer_contact:
+          message: |
+            You can't create quick entries for this customer, because you need to charge equivalence surcharge.
+
+            To calculate the right VAT, create an Invoice or Corrective Invoice instead.
+          title: Customer with recargo
+    advanced_uk/catalog_items:
+      help:
+        data_import: extra_products_and_services_import
+        default: Products & Service
+        index: extra_products_and_services_list
+      info:
+        default: If you have Products or Services that you sell frequently, to save
+          you typing the details into an invoice repeatedly, record them here.
+        index: Create, view and manage records of the products or services that you
+          sell.
+      title:
+        default: Products & Services
+        index: Products & Services
+    advanced_uk/categories:
+      title:
+        default: Categories
+        edit: Edit Category
+        index: Manage Categories
+        new: Create New Category
+    advanced_uk/customer_allocations:
+      help:
+        new: extra_account_allocations
+      info:
+        new: Allocate outstanding invoices, credit notes and payments on account together
+          without recording a receipt. The date of the most recent transaction being
+          allocated will be used as your allocation date.
+      title:
+        new: 'Account Allocation: %{context_string}'
+        show: 'Account Allocation: %{context_string}'
+    advanced_uk/customer_income_payments:
+      help:
+        show: extra_customer_receipts
+      info:
+        show: Record money received from your customers and allocate it to one or
+          more outstanding invoices, or save it as a payment on account to allocate
+          later.
+      negative_payment_message:
+        allocated:
+          text: This is a negative payment that has been allocated to an invoice.
+            This negative payment was created in a previous system as you cannot create
+            or change negative payments in Accounting.
+          title: Allocated Negative Payment
+        identified:
+          text: Negative payments allocated to invoices are included here. These negative
+            payments were created in a previous system. You cannot create or change
+            negative payments in Accounting.
+          title: Negative Payments Identified
+        link: Read more about this.
+      title:
+        create: Receipt
+        default: Customer Receipt
+    advanced_uk/customer_refund_payments:
+      help:
+        show: extra_customer_refunds
+      info:
+        show: Record money paid to your customers to refund outstanding credit notes,
+          or return a payment on account.
+      title:
+        create: Payment
+        default: Customer Refund
+    advanced_uk/direct_payment:
+      title:
+        default: Direct Payment
+    advanced_uk/global_tax_returns:
+      title:
+        default: VAT Returns
+    advanced_uk/income_tax_es:
+      help:
+        index: modelo_130_return
+        new: modelo_130_return
+        show: modelo_130_return
+    advanced_uk/journal_codes:
+      help:
+        index: extra_journal_codes
+      info:
+        index: Create, show and manage journal codes.
+      title:
+        index: Journal Codes
+    advanced_uk/migration:
+      title:
+        default: Upgrade
+    advanced_uk/online_payment:
+      title:
+        show: ''
+    advanced_uk/opening_balances:
+      accounts_start_date: 'Accounts Start Date: '
+    advanced_uk/other_expense_payment_refunds:
+      alert:
+        message: You cannot record Other Payment Refunds for this contact. To correctly
+          deal with foreign currency transactions you must use the Invoice option.
+        title: Overseas Customer
+      alert_not_home:
+        message: You cannot record Other Payment Refunds for this contact. To correctly
+          deal with VAT for overseas contacts, you must use the Invoice option.
+        title: Overseas Customer
+      help:
+        show: banking_other_receipt_refund
+      info:
+        show: Record one-off purchase payments, such as a refund and other money you've
+          paid linked to a purchase where you haven't been issued a credit note.
+      link:
+        text: Enter a refund for a purchase
+      title:
+        create: Refund
+        default: Purchase Other Receipt (Incoming money)
+        show: Purchase Other Receipt (Incoming money)
+    advanced_uk/other_expense_payments:
+      alert:
+        message: You cannot record Other Payments for this contact. To correctly deal
+          with foreign currency transactions you must use the Invoice option.
+        title: Overseas Supplier
+      alert_not_home:
+        message: You cannot record Other Payments for this contact. To correctly deal
+          with VAT for overseas contacts, you must use the Invoice option.
+        title: Overseas Supplier
+      help:
+        show: extra_bank_payments_other_payments
+      info:
+        show: Record one-off payments, such as over the counter purchases, and other
+          money you've paid where you haven't received an invoice.
+      title:
+        create: Payment
+        default: Other Payment
+        show: Other Payment
+    advanced_uk/other_income_payment_refunds:
+      alert:
+        message: You cannot record Other Receipt Refunds for this contact. To correctly
+          deal with foreign currency transactions you must use the Invoice option.
+        title: Overseas Customer
+      alert_not_home:
+        message: You cannot record Other Receipt Refunds for this contact. To correctly
+          deal with VAT for overseas contacts, you must use the Invoice option.
+        title: Overseas Customer
+      help:
+        show: banking_other_payment_refund
+      info:
+        show: Record one-off sales payments, such as a refund and other money you've
+          paid linked to a sale where you haven't issued a credit note.
+      link:
+        text: Enter a refund for a sale
+      title:
+        create: Refund
+        default: Sales Other Payment (Outgoing money)
+        show: Sales Other Payment (Outgoing money)
+    advanced_uk/other_income_payments:
+      alert:
+        message: You cannot record Other Receipts for this contact. To correctly deal
+          with foreign currency transactions you must use the Invoice option.
+        title: Overseas Customer
+      alert_not_home:
+        message: You cannot record Other Receipts for this contact. To correctly deal
+          with VAT for overseas contacts, you must use the Invoice option.
+        title: Overseas Customer
+      help:
+        show: extra_bank_receipts_other_receipts
+      info:
+        show: Record one-off receipts, such as for over the counter sales, and other
+          money you've received without issuing an invoice.
+      title:
+        create: Receipt
+        default: Other Receipt
+        show: Other Receipt
+    advanced_uk/part_payments:
+      allocation_warning:
+        payment:
+          message: The value of selected items exceeds the total payment value. Reduce
+            the allocated amount by deselecting or part paying selected items.
+        receipt:
+          message: The value of selected items exceeds the total receipt value. Reduce
+            the allocated amount by deselecting or part paying selected items.
+        refund:
+          message: The value of selected items exceeds the total refund value. Reduce
+            the allocated amount by deselecting items or increase the total refund
+            amount.
+        title: 'Warning: '
+      credits_warning:
+        message: Allocation of credits should be entered as a negative value.
+        title: 'Note: '
+      saved_allocation_warning: You are editing a saved allocation
+    advanced_uk/payments:
+      add_another: Add Another
+      help:
+        extra_error_corrections: extra_error_corrections
+        recurrence: extra_bank_recurring_entries
+        remove_cleared_status: remove_cleared_status
+      info:
+        modifications:
+          headers:
+            multi:
+              bank_and_cleared:
+                editable: 'You can only make limited changes because this transaction
+                  is:'
+              bank_and_excluded:
+                editable: 'You can only make limited changes because this transaction
+                  is:'
+              bank_and_tax:
+                editable: 'You can only make limited changes because this transaction
+                  is:'
+              cleared_and_excluded:
+                editable: 'You can only make limited changes because this transaction
+                  is:'
+              cleared_and_tax:
+                editable: 'You can only make limited changes because this transaction
+                  is:'
+              default:
+                editable: 'You can only make limited changes because this transaction
+                  is:'
+            single:
+              bank_reconciled:
+                editable: You can only make limited changes because this transaction
+                  was bank reconciled on the statement dated %{bank_reconciliation_date}.
+              cleared:
+                editable: You can only make limited changes because this transaction
+                  is marked as cleared in your bank account.
+              locked:
+                uneditable: Transactions created by third-party integrations cannot
+                  be changed.
+              tax_excluded:
+                editable: You can only make limited changes because this transaction
+                  was manually excluded when VAT Return %{return_no} was calculated
+                  (covering %{date_from} to %{date_to}).
+              tax_included:
+                editable: You can only make limited changes because this transaction
+                  is included on VAT Return %{return_no} (covering %{date_from} to
+                  %{date_to}).
+              uneditable:
+                uneditable: You can’t edit this transaction as it has an associated
+                  payment or refund.
+          help_link:
+            bank_reconciled:
+              text: Get help with corrections.
+              url: extra_error_corrections
+            cleared:
+              text: Get help on removing cleared status.
+              url: remove_cleared_status
+            corrections:
+              text: Get help with corrections.
+              url: extra_error_corrections
+            tax_excluded:
+              text: Get help on correcting VAT reconciled transactions.
+              url: extra_error_corrections
+            tax_included:
+              text: Get help on correcting VAT reconciled transactions.
+              url: extra_error_corrections
+            uneditable:
+              text: ''
+              url: ''
+          messages:
+            editable:
+              bank_reconciled: Bank reconciled on the statement dated %{bank_reconciliation_date}.
+              cleared: Marked as cleared in your bank account.
+              tax_excluded: Manually excluded from VAT Return %{return_no} (covering
+                %{date_from} to %{date_to}).
+              tax_included: On VAT Return %{return_no} (covering %{date_from} to %{date_to}).
+          titles:
+            multi:
+              bank_and_excluded: Transaction Excluded from VAT Return and Bank Reconciled
+              bank_and_tax: VAT and Bank Reconciled Transaction
+              cleared_and_excluded: Transaction Excluded from VAT Return and Cleared
+              cleared_and_tax: VAT Reconciled and Cleared Transaction
+              default: Only limited changes allowed
+            single:
+              bank_reconciled: Bank Reconciled
+              cleared: Cleared Transaction
+              locked: This transaction was created through an integration with another
+                service.
+              tax_excluded: Excluded from VAT Returns
+              tax_included: VAT Reconciled
+              uneditable: ''
+        recurrence: If you make payments and receipts on a regular basis you can set
+          them up as recurring entries.
+      pay_existing_invoice: "<a class='UILink' href='%{href}' data-tag='%{data_tag}'
+        data-role='%{data_tag}'>Pay an existing invoice</a> instead?"
+      print_remittance: Print Remittance
+      save: Save
+      title:
+        expense: Payment (Outgoing money)
+        income: Receipt (Incoming money)
+    advanced_uk/purchase_artefacts:
+      help:
+        index: extra_the_purchases_list
+      info:
+        index: Create, view and manage your purchase invoices and credit notes.
+      title:
+        default: Purchases
+    advanced_uk/purchase_batches:
+      alert:
+        message: You cannot record Quick Entries for this contact. To correctly deal
+          with foreign currency transactions, you must use the Invoice or Credit Note
+          option.
+        title: Overseas Supplier
+      help:
+        entries: extra_purchase_quick_entries_list
+        new: extra_purchase_quick_entries
+      import:
+        help:
+          data_import: extra_quick_entry_import
+      info:
+        entries: Create batch purchase transactions to quickly enter invoices and
+          credit notes from each supplier against a single ledger account, without
+          specifying a product.
+        new: Quickly record purchase invoices and credit notes as single lines on
+          the batch, choosing the appropriate details for each entry.
+        show: Quickly record purchase invoices and credit notes as single lines on
+          the batch, choosing the appropriate details for each entry.
+      title:
+        default: Quick Entries
+    advanced_uk/reports:
+      alert:
+        audit_trail:
+          drilldown_alert:
+            message: The selected entry has been deleted, and there are no subsequent
+              versions which can be viewed.
+            title: Deleted Entry
+        export:
+          error:
+            message: An error occurred generating the report.
+          failure:
+            message: You already have a report being generated
+          success:
+            message: Your report is being generated and a notification will appear
+              in the top bar when it is available
+          title: Report Generation
+      cash_flow_forecast:
+        text:
+          inbound_adjustments_dialog: 'Enter manual adjustments to include in forecast.  NB:
+            Entries dated prior to your forecast period will be included in the opening
+            balance figure.'
+          outbound_adjustments_dialog: 'Enter manual adjustments to include in forecast.  NB:
+            Entries dated prior to your forecast period will be included in the opening
+            balance figure.'
+          payroll_adjustments_dialog: 'Enter your estimated payroll costs. NB: Entries
+            dated prior to your forecast period will be included in the opening balance
+            figure.'
+        title:
+          inbound_adjustments_dialog: Adjustments In
+          outbound_adjustments_dialog: Adjustments Out
+          payroll_adjustments_dialog: Payroll costs
+      drilldown:
+        headers:
+          category: Category
+          closing_balance: Closing Balance
+          contact_name: Name
+          cr: Credit
+          credits: Total Credits
+          date: Date
+          debits: Total Debits
+          description: Description
+          display_name: Ledger Name
+          dr: Debit
+          invoice_number: Inv No
+          nominal_code: Nominal Code
+          opening_balance: Opening Balance
+          reference: Reference
+          running_total: Running Total
+          transaction_number: Trans Number
+          transaction_type: Type
+          variance: Variance
+        ledger_account: Account
+        rows:
+          closing_balance: 'Closing balance: %{end_date}'
+          opening_balance: 'Opening balance: %{start_date}'
+          variance: 'Variance:'
+        subheader: Up until %{end_date}
+        subheader_period: From %{start_date} to %{end_date}
+      help:
+        aged_creditors: extra_aged_creditors_report
+        aged_creditors_breakdown: extra_aged_creditors_report
+        aged_debtors: extra_aged_debtors_report
+        aged_debtors_breakdown: extra_aged_debtors_report
+        audit_trail: extra_audit_trail
+        audit_trail_summary: extra_audit_trail
+        balance_sheet: extra_management_reports
+        cash_flow_forecast: extra_cash_flow
+        cash_flow_forecast_detail: extra_cash_flow
+        cash_flow_forecast_prior_transactions: extra_cash_flow
+        cash_flow_statement_detail: extra_cash_flow
+        cash_flow_summary: extra_cash_flow
+        chart_of_accounts: chart_accounts_list
+        ec_sales: extra_ec_sales_analysis_report
+        index: extra_reports_index
+        invoice_profit_analysis: extra_profit_analysis_report
+        nominal_opening_balance: extra_opening_balances
+        profit_and_loss: extra_management_reports
+        purchase_day_book: extra_reports_purchase_daybook
+        purchase_day_book_detailed: extra_reports_purchase_daybook
+        receipts_and_payments_day_book: extra_reports_receipts_and_payments_daybook
+        return_of_trading_details: return_of_trading_details
+        sage_pay_ecommerce_payments: extra_sage_pay_ecommerce
+        sage_pay_payments: extra_sage_pay
+        sales_day_book: extra_reports_sales_daybook
+        sales_day_book_detailed: extra_reports_sales_daybook
+        trial_balance: extra_management_reports
+        unallocated_payments: extra_reports_unallocated_receipts_and_payments
+        unreconciled_bank_transactions: extra_unreconciled_bank_transactions_report
+      info:
+        aged_creditors: This report shows all outstanding or unallocated supplier
+          transactions, broken down by the ageing periods specified in Record and
+          Transactions Settings.
+        aged_creditors_breakdown: This report shows all outstanding or unallocated
+          supplier transactions, broken down by the ageing periods specified in Record
+          and Transactions Settings.
+        aged_debtors: This report shows all outstanding or unallocated customer transactions,
+          broken down by the ageing periods specified in Record and Transactions Settings.
+        aged_debtors_breakdown: This report shows all outstanding or unallocated customer
+          transactions, broken down by the ageing periods specified in Record and
+          Transactions Settings.
+        audit_trail: The audit trail breakdown is a detailed record of all transactions
+          posted. You can view this by transaction type for a specified date range.
+        audit_trail_selector: The audit trail report shows a summary or breakdown
+          of all transactions posted. You can view this by transaction type for a
+          specified date range.
+        audit_trail_summary: The audit trail summary is a record of all transactions
+          posted. You can view this by transaction type for a specified date range.
+        balance_sheet: The balance sheet shows what you own, your assets, and what
+          you owe, your liabilities.
+        cash_flow_forecast: View expected cash flow in and cash flow out for a future
+          date range, using recurrence date, or expected payment dates. Use this to
+          estimate when funds will come into or out of the business.
+        cash_flow_summary: Analyse your current financial position by viewing cash
+          flow into and out of selected bank accounts for a specified date range.  View
+          the detailed breakdown to see all entries affecting the selected banks in
+          that period.
+        chart_of_accounts: Use this report to view and export a list of your ledger
+          accounts.
+        contact_personal_data: This report provides you with a list of contacts whose
+          personal data is now outside of the retention period for accounting records.
+          You can remove contacts' data from this list.
+        ec_sales: This report shows all EC Sales transactions within a specified period.  Use
+          this report to help you complete your EC Sales List on HMRC's website.
+        index: Use reports to view your company and financial information at a glance.
+        invoice_profit_analysis: This report analyses the profit on your sales invoices
+          and quotations using the cost price and sales price of your products.
+        nominal_opening_balance: Record the balances of your ledger accounts from
+          your previous accounting system. Opening balances already entered through
+          the customer, supplier or bank opening balance options appear automatically.
+          You can enter or amend these by clicking each line. Each debit or credit
+          balance is offset against the opening balance control account, and when
+          the full trial balance is entered, this account should be zero.
+        profit_and_loss: This report shows your business income and expense, giving
+          the profit for your chosen date range.
+        purchase_day_book: This report shows purchase transactions for a specified
+          date range. You can view a certain transaction type, or all of your purchase
+          transactions, listed in date order.
+        purchase_day_book_detailed: This report shows detailed purchase transactions
+          for a specified date range. You can view a certain transaction type, or
+          all of your purchase transactions, listed in date order.
+        receipts_and_payments_day_book: This report shows receipt or payment transactions
+          for a selected bank account, for a specified date range.
+        sage_pay_ecommerce_payments: This is where you can view imported Sage Pay
+          ecommerce payments.
+        sage_pay_payments: This is where you can view invoice payments received via
+          Sage Pay.
+        sales_day_book: This report shows sales transactions for a specified date
+          range. You can view a certain transaction type, or all of your sales transactions,
+          listed in date order.
+        sales_day_book_detailed: This report shows detailed sales transactions for
+          a specified date range. You can view a certain transaction type, or all
+          of your sales transactions, listed in date order.
+        sales_revenue_detailed: This report shows the sales revenue for products and
+          services.
+        sales_revenue_summary: This report shows the sales revenue for products and
+          services.
+        sales_tax: This report shows a summary of the total sales tax due for each
+          tax rate.
+        sales_tax_breakdown: This report shows a breakdown of sales tax per rate per
+          artefact.
+        stock_movement_detailed: This report shows the stock movements for a specified
+          stock item for a given date range.
+        stock_movement_summary: This report shows the quantities received and dispatched
+          for each stock item.
+        summary: Welcome to Sage One Accounts. This summary screen allows you to keep
+          an eye on your financial status and your bank history.
+        tax_return: This report will submit VAT Returns to the HMRC.
+        trial_balance: This report displays the balance on your nominal accounts for
+          a specified date range. You can include brought forward values and include
+          current year’s profit and loss values only.
+        trial_balance_with_year_end_enabled: View the balance on your ledger accounts
+          for a specific date range - if viewing prior year values, your financial
+          year end journals will be excluded from the figures displayed.
+        unallocated_payments: This report shows receipts or payment transactions from
+          contacts that are not fully allocated.
+        unreconciled_bank_transactions: This report shows all unreconciled bank transactions.  You
+          can view these transactions by bank account up to a specified date.
+      notes:
+        accounting_type_indicator: 'Your current accounting type is: '
+      pod:
+        cash_flow:
+          description: Use these reports to analyse your cash flow in and cash flow
+            out for current and future periods.
+          title: Cash Flow
+      title:
+        aged_creditors: Aged Creditors Report
+        aged_creditors_breakdown: Aged Creditors Breakdown
+        aged_debtors: Aged Debtors Report
+        aged_debtors_breakdown: Aged Debtors Breakdown
+        audit_trail: Audit Trail Breakdown
+        audit_trail_summary: Audit Trail
+        balance_sheet: Balance Sheet Report
+        cash_flow_forecast: Cash Flow Forecast Report
+        cash_flow_forecast_detail: Cash Flow Forecast - Detailed Breakdown
+        cash_flow_forecast_prior_transactions: Cash Flow Forecast - Expected Prior
+          Cash Flow Detailed Breakdown
+        cash_flow_statement_detail: Cash Flow Statement - Detailed Breakdown
+        cash_flow_summary: Cash Flow Statement Report
+        chart_of_accounts: Chart of Accounts List
+        contact_personal_data: Contacts Personal Data
+        ec_sales: EC Sales List
+        index: Reports
+        invoice_profit_analysis: Profit Analysis
+        ledger_entries: Ledger Entries
+        profit_and_loss: Profit and Loss Report
+        purchase_day_book: Purchase Day Book Report
+        purchase_day_book_detailed: Purchase Day Book - Detailed
+        receipts_and_payments_day_book: Receipts and Payments Day Book Report
+        sage_pay_ecommerce_payments: Ecommerce Payments
+        sage_pay_payments: Payments Received
+        sales_day_book: Sales Day Book Report
+        sales_day_book_detailed: Sales Day Book - Detailed
+        sales_revenue_detailed: Sales Revenue Detailed - Products & Services
+        sales_revenue_summary: Sales Revenue - Products & Services
+        sales_tax: Sales Tax Report
+        sales_tax_breakdown: Sales Tax Breakdown
+        stock_movement_detailed: 'Stock Movement Detailed: %{context_string}'
+        stock_movement_detailed_export: Stock Movement Detailed
+        stock_movement_summary: Stock Movement Summary Report
+        summary: Summary
+        trial_balance: Trial Balance Report
+        unallocated_payments: Unallocated Receipts or Payments
+        unreconciled_bank_transactions: Unreconciled Bank Transactions
+    advanced_uk/reports/auxiliary_balance:
+      help:
+        auxiliary_balance: extra_management_reports
+      info:
+        auxiliary_balance: Allows you to see the results of your business and the
+          balance of each subaccounts at a given time.
+      title:
+        auxiliary_balance: Auxiliary Balance
+    advanced_uk/reports/cashbook_reports:
+      help:
+        cashbook: cashbook_report
+      info:
+        cashbook: This report shows receipts, payments and balances for the selected
+          bank account.
+      title:
+        cashbook: Cashbook Report
+      tooltip:
+        cashbook: 'Shows: Receipts, payments and balances for a selected bank account.'
+    advanced_uk/reports/financial_statements/report:
+      help:
+        balance_statement: extra_management_reports
+        income_statement: extra_management_reports
+      info:
+        balance_statement: How much is my business worth?
+        balance_statement_with_year_end_enabled: View the value of your business at
+          a specific date – if viewing prior year values, your financial year end
+          journals will be excluded from the figures displayed.
+        income_statement: How profitable was my business this period?
+        income_statement_with_year_end_enabled: View the profitability of your business
+          during a specific period - if viewing prior year values, your financial
+          year end journals will be excluded from the figures displayed.
+      message:
+        content_1: A technical problem means we can’t show you the figures that make
+          up the item you’ve selected right now - please try again later.
+        content_2: In the meantime, the
+        content_3: might be useful.
+        link: " Nominal Activity report "
+        title: Sorry about this...
+      title:
+        balance_statement: Balance Sheet
+        income_statement: Income Statement
+    advanced_uk/reports/income_tax:
+      help:
+        income_tax_expense: income_tax_statement
+        income_tax_revenue: irpf_income_statement
+      info:
+        income_tax_expense: How much IRPF was withheld from my purchase invoices
+        income_tax_revenue: How much IRPF was withheld from my sales invoices
+      title:
+        income_tax_expense: IRPF withheld from my suppliers
+        income_tax_revenue: IRPF withheld from my customers
+    advanced_uk/reports/nominal_activity:
+      help:
+        nominal_activity: extra_nominal_activity_report
+        nominal_activity_detail: extra_nominal_activity_report
+      info:
+        nominal_activity: This report shows the nominal accounts with activity for
+          analysis codes in a given date range.
+        nominal_activity_detail: This report shows the transaction activity for specified
+          nominal account, analysis codes in a given date range.
+      title:
+        nominal_activity: Nominal Activity Report
+        nominal_activity_detail: 'Detailed Nominal Activity: %{context_string}'
+    advanced_uk/reports/sales_revenue/detailed:
+      help:
+        sales_revenue_detailed: extra_sales_revenue_report
+      title:
+        sales_revenue_detailed: Sales Revenue Detailed - Products & Services
+    advanced_uk/reports/sales_revenue/report:
+      help:
+        sales_revenue: extra_sales_revenue_report
+      title:
+        sales_revenue: Sales Revenue
+    advanced_uk/reports/stock_movements/detailed:
+      help:
+        stock_movements_detailed: extra_stock_movements
+      title:
+        stock_movements_detailed: Stock Movements Detailed
+    advanced_uk/reports/stock_movements/report:
+      help:
+        stock_movements: extra_stock_movements
+      title:
+        stock_movements: Stock Movements
+    advanced_uk/reports/vendors:
+      help:
+        vendors: 1099_vendor_report
+      info:
+        vendors: This report gives you your total payments for each of your 1099 Vendors
+          for the year, to help you fill out a 1099 Misc Form when this is required.
+      title:
+        vendors: 1099 Vendor Report
+      tooltip:
+        vendors: How much have I paid my 1099 Vendors?
+    advanced_uk/sales_artefacts:
+      help:
+        index: extra_sales_list
+      info:
+        index: Create, view and manage your sales invoices and credit notes.
+      title:
+        default: Sales
+        index: Sales
+    advanced_uk/sales_batches:
+      alert:
+        message: You cannot record Quick Entries for this contact. To correctly deal
+          with foreign currency transactions, you must use the Invoice or Credit Note
+          option.
+        title: Overseas Customer
+      help:
+        entries: extra_sales_quick_entries_list
+        new: extra_sales_quick_entries
+      import:
+        contact_overseas_error: You cannot record Quick Entries for Cross Border contacts.
+        help:
+          data_import: extra_quick_entry_import
+      info:
+        entries: Create batch sales transactions, without producing a physical invoice
+          or credit note.  For example, where you have a separate invoicing system
+          and just want to record the value of existing invoices.
+        new: Quickly record sales invoices and credit notes as single lines on a batch,
+          choosing the appropriate details for each entry.
+        show: Quickly record sales invoices and credit notes as single lines on a
+          batch, choosing the appropriate details for each entry.
+      title:
+        default: Quick Entries
+    advanced_uk/stripe_transactions:
+      help:
+        status: view_stripe_activity
+    advanced_uk/summary:
+      header:
+        index: Hi, <strong>%{name}</strong>
+      help:
+        index: extra_summary
+      info:
+        index: The Summary tab gathers key information about your business.
+      title:
+        index: Summary
+    advanced_uk/supplier_allocations:
+      help:
+        new: extra_account_allocations
+      info:
+        new: Allocate outstanding invoices, credit notes and payments on account together,
+          without recording a payment. The date of the most recent transaction being
+          allocated will be used as your allocation date.
+      title:
+        new: 'Account Allocation: %{context_string}'
+        show: 'Account Allocation: %{context_string}'
+    advanced_uk/supplier_expense_payments:
+      help:
+        show: extra_supplier_payments
+      info:
+        show: Record money paid to suppliers and allocate it to one or more outstanding
+          invoices, or save it as a payment on account to allocate later.
+      negative_payment_message:
+        allocated:
+          text: This is a negative payment that has been allocated to an invoice.
+            This negative payment was created in a previous system as you cannot create
+            or change negative payments in Accounting.
+          title: Allocated Negative Payment
+        link: Read more about this.
+      title:
+        create: Payment
+        default: Supplier Payment
+        show: Supplier Payment
+    advanced_uk/supplier_refund_payments:
+      help:
+        show: extra_supplier_refunds
+      info:
+        show: Record money received from suppliers to refund outstanding credit notes,
+          or return a payment on account.
+      title:
+        create: Receipt
+        default: Supplier Refund
+        show: Supplier Refund
+    advanced_uk/tax_returns:
+      action:
+        save_draft: Save this return and submit it later
+        save_online: Submit to HMRC by other means
+        submit_mtd: Submit online to HMRC
+        submit_online: Submit online to the Government Gateway
+      button_submit_later: Submit later
+      button_submit_online: Submit Online
+      confirm_dialog_message:
+        info: " before this date not yet included on any VAT return."
+        title: This tax return is from %{date}
+        transactions:
+          one: There is %{number} transaction
+          other: There are %{number} transactions
+      detailed_report: Detailed Report
+      draft_failed_tax_return_does_not_exist: Your changes cannot be saved because
+        another user has already submitted the return
+      draft_tax_return_for_tax_type_exists: Please complete or remove your current
+        draft tax return before creating a new one
+      draft_waiting_failed_tax_return_exists: You already have a draft, waiting or
+        failed tax return
+      excluded_transactions_message:
+        info: You chose to exclude %{tax_return_excluded_entries} %{transaction_text}
+          dated before %{tax_return_from_date} from this return.
+        transactions:
+          one: transaction
+          other: transactions
+      excluded_transactions_view_pdf: Excluded Prior Transactions
+      feedback_status_correlation: 'Correlation ID: %{correlation_id}'
+      feedback_status_format_date: Submitted %-d %b %Y at %-l:%M%P
+      feedback_status_format_user: " by %{username}"
+      feedback_status_migrated: This VAT return is based on data migrated from your
+        old accounting system, so you can't adjust, delete, or submit it to HMRC.
+      fix_help_link:
+        text: How do I fix this?
+        url: http://help.sageone.com/en_uk/accounting/vat-submission-errors.html
+      help:
+        index: extra_vat_return_uk
+        new: extra_vat_return_uk
+        show: extra_vat_return_uk
+      info:
+        index: 'Create, view and manage your VAT Returns. '
+        new: Select the date range for your VAT Return and click Calculate.  To view
+          transactions included on your return, click detailed report.
+        show: You're viewing an existing VAT Return.  To see how the VAT Return was
+          calculated, click detailed report.
+      must_be_taxable: You must be VAT Registered to do a VAT Return
+      prior_transactions_message:
+        exclude: "<strong>Never</strong> - Exclude them from all future returns."
+        include: "<strong>Now</strong> - Include them on this return."
+        info: "<strong>Would you like to include these transactions on your VAT return…</strong>"
+        note: 'NOTE: If you choose No, these transactions will be permanently excluded
+          from all VAT Returns. You should print and save the available report before
+          continuing.'
+        skip: "<strong>Later</strong> - Ask me again when I run my next return."
+      prior_transactions_pdf_contact_name: Contact Name
+      prior_transactions_pdf_date: Date
+      prior_transactions_pdf_net_amount: Net
+      prior_transactions_pdf_reference: Reference
+      prior_transactions_pdf_title: Previous Unreconciled Transactions
+      prior_transactions_pdf_title_excluded: Excluded Transactions
+      prior_transactions_pdf_total_amount: Total
+      prior_transactions_pdf_type: Type
+      prior_transactions_pdf_vat_amount: VAT
+      prior_transactions_title: Including Previous Transactions
+      prior_transactions_view_pdf: View Previous Transactions
+      settings_dialog:
+        tax_rate_label: What Flat Rate VAT Percentage applies to your business?
+        tax_submission_frequency_type_label: How often do you submit VAT Returns?
+        text: 'In order to calculate your VAT Return correctly, you need to provide
+          the following information:'
+        title: VAT Return Settings
+      summary_report_view_pdf: Print
+      tax_return_for_range_already_exists: "#TR There already exists a tax return
+        for the selected date range. Please use the correction button on the index
+        page to create a correction for a existing tax return."
+      title:
+        default: VAT Returns
+        hmrc_response: HMRC Response
+        index: VAT Return List
+        new: VAT Return
+        show: View VAT Report
+        status: 'Status: '
+    core_accounting/taxes:
+      tax_rates_manager:
+        title: Manage Tax Rates
+    email_dialog:
+      button: Send
+    fuji_banking/bank_accounts:
+      alert_dialogs:
+        messages:
+          default_account: One or more of the selected bank accounts is a default
+            bank account and cannot be deleted.
+        title:
+          default_account: Default Bank Accounts
+      assets:
+        all_accounts_icon: bank_accounts/all-accounts-icon.svg
+        bank_hour_glass_icon_color: bank_accounts/bank-hour-glass-icon-color.svg
+        bank_icon: bank_accounts/bank-icon.svg
+        bank_icon_color: bank_accounts/bank-icon-color.svg
+        cash_icon: bank_accounts/bank-cash-icon.svg
+        credit_card_icon: bank_accounts/bank-credit-card-icon.svg
+        credit_card_icon_color: bank_accounts/credit-card-icon-color.svg
+        safe_icon_color: bank_accounts/safe-icon-color.svg
+        stripe_icon_color: bank_accounts/stripe-icon-color.png
+        wallet_icon_color: bank_accounts/wallet-icon-color.svg
+      confirm_dialogs:
+        messages:
+          bank_transfer: Please note that both sides of a transfer will be removed.
+      help:
+        cheque_register: extra_pay_into_bank
+        deposit: extra_pay_into_bank
+        index: extra_bank_account_list
+        new: extra_bank_accounts_create
+        show: extra_bank_record
+        transfer: extra_transfer_funds_between_bank_accounts
+      info:
+        deposit: Record cash and cheques deposited into your current account, from
+          your cash in hand account.
+        index: Create, view and manage your bank accounts and banking transactions
+          such as payments, receipts and transfers.
+        landing_page: Add your bank accounts, credit cards and loans. Connect to your
+          online bank account to automatically import your transactions.
+        new: Record details of your new bank account.  You should only record an opening
+          balance here, if you're transferring from a different accounting system.
+        show: View your bank account details and account activity.  Use New Entry
+          to record new transactions for this bank account, or use the Reconcile option
+          to check entries on this account against your bank statement.
+        transfer: Record the transfer of money between your bank accounts.  This includes
+          payments from your bank account to a credit card or loan account.
+      opening_balances:
+        add: Add an opening balance
+        after_start:
+          a: To enter a balance on this account after your Start Date, create an Other
+            Payment transaction for the amount owed, or a Transfer to move a balance
+            from another card.
+          b: If there was an opening balance on this account prior to you starting
+            to use Accounting, select a date prior to %{start_date} and record an
+            opening balance.
+        balance: Balance (%{currency_symbol})
+        balance_today: Today's Balance (%{currency_symbol})
+        credit:
+          cash_in_hand: Overdrawn Balance
+          credit_card: Card Balance
+          current: Overdrawn Balance
+          loan: Loan Balance
+          other: Overdrawn Balance
+          savings: Overdrawn Balance
+        debit:
+          cash_in_hand: Balance
+          credit_card: Overpayment
+          current: Balance
+          loan: Overpayment
+          other: Balance
+          savings: Balance
+        no_start: In order to enter an opening balance for this account, please first
+          go to the %{financial_link} Settings page and set your Accounts Start Date.
+        remove: Remove opening balance
+      title:
+        default: Bank Accounts
+        index: Banking
+    fuji_banking/bank_reconciliations:
+      calculation_running: A Bank Reconciliation is already running and should be
+        complete shortly. Please try again in a few minutes.
+      confirm_dialogs:
+        reconcile_all_prompt: This will reconcile all entries up to the statement
+          end date. Are you sure?
+        total_mismatch:
+          message: Your target balance and reconciled balance don't match. Are you
+            sure you want to finish?
+          title: Target Balance Mismatch
+        unreconcile_all_prompt: This will unreconcile all entries currently flagged
+          for reconciliation. Are you sure?
+      help:
+        reconcile: extra_bank_reconciliation
+      info:
+        reconcile: Check and match entries against your bank statement.  You can fully
+          save your reconciliation when done, or save it for later and complete it
+          another time.
+      links:
+        finish: Finish
+        interest_and_charges: Interest and Charges
+        print: Print
+        reconcile_all: Reconcile All Entries
+        save_for_later: Save for later
+        unreconcile_all: Unreconcile All Entries
+      title:
+        default: Bank Reconciliation
+        interest_and_charges: Interest and Charges
+    fuji_banking/bank_transfers:
+      title:
+        default: Bank Transfers
+    fuji_banking/cheque_register:
+      help:
+        index: check_register
+      info:
+        index: View all the cheque payments you've recorded and select cheques to
+          print.
+      title:
+        index: Cheque Register
+    fuji_banking/deposits:
+      help:
+        index: extra_pay_into_bank
+      info:
+        index: Record cash and cheques deposited into your current account, from your
+          cash in hand account.
+    fuji_contacts/contacts:
+      help:
+        data_import: extra_contacts_import
+        index: extra_contacts_list
+        new: extra_create_contacts
+        show: extra_contact_records
+      info:
+        index: Create and manage your customer and supplier records.
+        new: Record details of your customers or suppliers, including their name and
+          the reference you want to use for them. If this contact is VAT registered,
+          enter their VAT number and, so that this is validated correctly, ensure
+          you choose their country.
+      title:
+        default: Contacts
+        index: Contacts
+        new: New Contact
+        show: 'Contact: %{responding_with}'
+    fuji_contacts/customers:
+      help:
+        data_import: extra_contacts_import
+        index: extra_contacts_list
+        new: extra_create_contacts
+        show: extra_contact_records
+        statement: extra_customer_statements
+      info:
+        index: Create, view and manage your customer records.
+        new: Record your customer's details, including their name and the reference
+          you want to use for them. If this customer is VAT registered, enter their
+          VAT number and, so that this is validated correctly, ensure you choose their
+          country.
+        statement: View transactions within the specified date range and use Manage
+          Statements to print or email your customer's statement.
+      title:
+        default: Customers
+        index: Customers
+        new: New Customer
+        show: 'Customer: %{responding_with}'
+        statement: 'Statement: %{contact_name}'
+    fuji_contacts/suppliers:
+      help:
+        data_import: extra_contacts_import
+        index: extra_contacts_list
+        new: extra_create_contacts
+        show: extra_contact_records
+        statement: extra_supplier_statements
+      info:
+        index: Create, view and manage your supplier records.
+        new: Record your supplier's details, including their name and the reference
+          you want to use for them. If this supplier is VAT registered enter their
+          VAT number and, so that this is validated correctly, ensure you choose their
+          country.
+        statement: View transactions within the specified date range, and use Manage
+          Statements to print a statement of items on the account.
+      title:
+        default: Suppliers
+        field: Supplier
+        index: Suppliers
+        new: New Supplier
+        show: 'Supplier: %{responding_with}'
+        statement: 'Statement: %{contact_name}'
+    fuji_core_accounting/coa_accounts:
+      title:
+        default: COA Accounts
+    fuji_core_accounting/coa_templates:
+      title:
+        default: COA Templates
+    fuji_core_accounting/ledger_accounts:
+      edit_dialog:
+        account_name_label: Account Name
+        category_label: Category
+        class_label: Class
+        control_account: This account must be included because it's essential to your
+          accounting system.
+        deleted_bank_notification: You cannot make any changes to this ledger because
+          it belongs to a deleted bank account.
+        deleted_bank_notification_title: Deleted Bank Account Ledger
+        display_name_label: Display Name
+        duplicate_account: Duplicate Account
+        duplicate_notification: This is a new ledger account - the original account
+          hasn’t been changed.
+        duplicate_notification_title: Details Duplicated to New Ledger Account
+        excluded: Excluded
+        excluded_copy: hidden from view across Accounting.
+        included: Included
+        included_copy: available to use across Accounting.
+        included_hint: Where would you like to use this account?
+        number_label: Number
+        title:
+          duplicate: Duplicate Ledger Account
+          edit: Edit Ledger Account
+          new: New Ledger Account
+        tva_label: TVA
+        update_successful: Ledger account updated successfully
+        update_unsuccessful: The ledger account failed to update
+      filters:
+        all: All
+        all_categories: All Categories
+        all_codes: All Codes
+        categories: Category
+        category_groups: Category Groups
+        control_account: Control Account
+        control_account_tip: These accounts must be included for use, because they’re
+          essential to your accounting system.
+        display_name: Display Name
+        excluded: Excluded
+        included: Included
+        included_excluded: Included and Excluded
+        included_tip: Included accounts are available to use in Accounting. Select
+          a row to include or exclude an account.
+        mark_as_excluded: Exclude
+        mark_as_excluded_tip: Makes accounts hidden in Accounting
+        mark_as_included: Include
+        mark_as_included_tip: Makes accounts available to use in Accounting
+        new_account: New Account
+        number: Number
+        searchbox: Search for a code or name
+        type_to_search: Type to Search
+      help:
+        index: extra_chart_of_accounts
+      info:
+        deleted: Deleted Ledger Account
+        index: Create, view and manage your ledger accounts.  Select existing accounts
+          to view or change the areas they are visible in, or create new accounts
+          for improved analysis.
+      message:
+        excluded_success: Successfully Excluded
+        included_success: Successfully Included
+      title:
+        index: Chart of Accounts
+        new_ledger_account: New Ledger Account
+    fuji_invoicing/purchase_corrective_invoices:
+      help:
+        copy: extra_create_purchase_corrective_invoices
+        create: extra_create_purchase_corrective_invoices
+        index: extra_the_purchases_corrective_list
+        new: extra_create_purchase_corrective_invoices
+        show: extra_create_purchase_corrective_invoices
+      info:
+        copy: Record a new corrective invoice you've received. To search for or to
+          create a new supplier, start typing in the Name box.
+        create: Record a new corrective invoice you've received. To search for or
+          to create a new supplier, start typing in the Name box.
+        draft: When you’re ready to fully save your corrective invoice, remove the
+          Save as draft tick.
+        edit: Make changes to invoice details or values. %{additional_text}
+        index: Create, view and manage the corrective invoices your suppliers send
+          to you, particularly those you want to split by multiple ledger accounts
+          or products.
+        new: Record a new corrective invoice you've received. To search for or to
+          create a new supplier, start typing in the Name box.
+        show: View or edit the corrective invoice, or use the options available to
+          create a credit note, or set the status of the invoice to disputed.
+      title:
+        copy: New Purchase Corrective Invoice
+        create: New Purchase Corrective Invoice
+        default: Purchase Corrective Invoices
+        edit: 'Purchase Corrective Invoice: %{context_string}'
+        new: New Purchase Corrective Invoice
+        show: 'Purchase Corrective Invoice: %{context_string}'
+    fuji_invoicing/purchase_credit_notes:
+      help:
+        copy: extra_create_purchase_credit_notes
+        create: extra_create_purchase_credit_notes
+        index: extra_the_purchases_list
+        new: extra_create_purchase_credit_notes
+        show: extra_create_purchase_credit_notes
+      info:
+        copy: Record a new credit note issued by your supplier. To search for or to
+          create a new supplier, start typing in the Name box.
+        create: Record a new credit note issued by your supplier. To search for or
+          to create a new supplier, start typing in the Name box.
+        draft: When you’re ready to fully save your credit note, remove the Save as
+          draft tick.
+        edit: Make changes to credit note details or values. %{additional_text}
+        index: Create, view and manage the credit notes your suppliers send to you,
+          particularly those you want to split by multiple ledger accounts or products.
+        new: Record a new credit note issued by your supplier. To search for or to
+          create a new supplier, start typing in the Name box.
+        show: View or edit the credit note, or use the option available to set the
+          status of the credit note to disputed.
+      title:
+        copy: New Purchase Credit Note
+        create: New Purchase Credit Note
+        default: Purchase Credit Notes
+        edit: 'Purchase Credit Note: %{context_string}'
+        new: New Purchase Credit Note
+        show: 'Purchase Credit Note: %{context_string}'
+    fuji_invoicing/purchase_invoices:
+      help:
+        copy: extra_create_purchase_invoices
+        create: extra_create_purchase_invoices
+        index: extra_the_purchases_list
+        new: extra_create_purchase_invoices
+        show: extra_create_purchase_invoices
+      info:
+        copy: Record a new invoice you've received. To search for or to create a new
+          supplier, start typing in the Name box.
+        create: Record a new invoice you've received. To search for or to create a
+          new supplier, start typing in the Name box.
+        draft: When you’re ready to fully save your invoice, remove the Save as draft
+          tick.
+        edit: Make changes to invoice details or values. %{additional_text}
+        index: Create, view and manage the invoices your suppliers send to you, particularly
+          those you want to split by multiple ledger accounts or products.
+        new: Record a new invoice you've received. To search for or to create a new
+          supplier, start typing in the Name box.
+        show: View or edit the invoice, or use the options available to create a credit
+          note, or set the status of the invoice to disputed.
+      title:
+        copy: New Purchase Invoice
+        create: New Purchase Invoice
+        default: Purchase Invoices
+        edit: 'Purchase Invoice: %{context_string}'
+        new: New Purchase Invoice
+        show: 'Purchase Invoice: %{context_string}'
+    fuji_invoicing/sales_corrective_invoices:
+      help:
+        copy: extra_create_sales_corrective_invoices
+        create: extra_create_sales_corrective_invoices
+        index: extra_sales_corrective_list
+        new: extra_create_sales_corrective_invoices
+        show: extra_create_sales_corrective_invoices
+      info:
+        copy: Create a new corrective invoice to send to your customer. To search
+          for or to create a new customer, start typing in the Name box.
+        create: Create a new corrective invoice to send to your customer. To search
+          for or to create a new customer, start typing in the Name box.
+        draft: When you’re ready to fully save your corrective invoice, remove the
+          Save as draft tick.
+        edit: Make changes to invoice details or values. %{additional_text}
+        index: Create, view and manage the corrective invoices you send to your customers.
+        new: Create a new corrective invoice to send to your customer. To search for
+          or to create a new customer, start typing in the Name box.
+        show: View or edit the corrective invoice, or use the options available to
+          create a credit note, email it to your customer, or produce a PDF.
+      title:
+        copy: New Sales Corrective Invoice
+        create: New Sales Corrective Invoice
+        default: Sales Corrective Invoices
+        edit: 'Sales Corrective Invoice: %{context_string}'
+        new: New Sales Corrective Invoice
+        show: 'Sales Corrective Invoice: %{context_string} <span class=''invoice-status
+          %{status_css_class}''>%{status_string}</span>'
+    fuji_invoicing/sales_credit_notes:
+      help:
+        copy: extra_create_sales_credit_notes
+        create: extra_create_sales_credit_notes
+        index: extra_sales_list
+        new: extra_create_sales_credit_notes
+        show: extra_create_sales_credit_notes
+      info:
+        copy: Create a new credit note to send to your customer. To search for or
+          to create a new customer, start typing in the Name box.
+        create: Create a new credit note to send to your customer. To search for or
+          to create a new customer, start typing in the Name box.
+        draft: When you’re ready to fully save your credit note, remove the Save as
+          draft tick.
+        edit: Make changes to credit note details or values. %{additional_text}
+        index: Create, view and manage the credit notes you send to your customers.
+        new: Create a new credit note to send to your customer. To search for or to
+          create a new customer, start typing in the Name box.
+        show: View or edit the credit note, or use the options available to email
+          it to your customer, or produce a PDF.
+      title:
+        copy: New Sales Credit Note
+        create: New Sales Credit Note
+        default: Sales Credit Notes
+        edit: 'Sales Credit Note: %{context_string}'
+        new: New Sales Credit Note
+        show: 'Sales Credit Note: %{context_string}'
+    fuji_invoicing/sales_estimates:
+      help:
+        copy: accounting_sales_estimate
+        create: accounting_sales_estimate
+        new: accounting_sales_estimate
+        show: accounting_sales_estimate
+      info:
+        copy: Create a new estimate to send to a prospective customer. To search for
+          or create a new customer, start typing in the Name box.
+        create: Create a new estimate to send to a prospective customer. To search
+          for or create a new customer, start typing in the Name box.
+        draft: When you're ready to fully save your estimate, remove the Save as draft
+          tick.
+        edit: Make changes to estimate details or values. %{additional_text}
+        new: Create a new estimate to send to a prospective customer. To search for
+          or create a new customer, start typing in the Name box.
+        show: View or edit the estimate, or use the options available to set the status
+          of the estimate, email it to your customer or produce a PDF.
+      title:
+        copy: New Sales Estimate
+        create: New Sales Estimate
+        default: Sales Estimates
+        edit: 'Sales Estimate: %{context_string}'
+        new: New Sales Estimate
+        show: 'Sales Estimate: %{context_string}'
+    fuji_invoicing/sales_invoices:
+      help:
+        copy: extra_create_sales_invoices
+        create: extra_create_sales_invoices
+        index: extra_sales_list
+        new: extra_create_sales_invoices
+        show: extra_create_sales_invoices
+      info:
+        copy: Create a new invoice to send to your customer. To search for or to create
+          a new customer, start typing in the Name box.
+        create: Create a new invoice to send to your customer. To search for or to
+          create a new customer, start typing in the Name box.
+        draft: When you’re ready to fully save your invoice, remove the Save as draft
+          tick.
+        edit: Make changes to invoice details or values. %{additional_text}
+        index: Create, view and manage the invoices you send to your customers.
+        new: Create a new invoice to send to your customer. To search for or to create
+          a new customer, start typing in the Name box.
+        show: View or edit the invoice, or use the options available to create a credit
+          note, email it to your customer, or produce a PDF.
+      sage_pay:
+        pay_now_button: Pay Now
+        pay_now_multi_currency_text: Pay Now option will take payment of outstanding
+          value in %{base_currency}. Total outstanding for this invoice %{base_outstanding}
+        pay_now_text: <p>We accept online payments. It's a fast, secure and very easy
+          way to pay.<br />Simply click the "Pay Now" button to pay this invoice using
+          your credit or debit card.</p>
+      title:
+        copy: New Sales Invoice
+        create: New Sales Invoice
+        default: Sales Invoices
+        edit: 'Sales Invoice: %{context_string}'
+        new: New Sales Invoice
+        show: 'Sales Invoice: %{context_string} <span class=''invoice-status %{status_css_class}''>%{status_string}</span>'
+    fuji_invoicing/sales_quotes:
+      help:
+        copy: extra_sales_quotes
+        create: extra_sales_quotes
+        index: extra_sales_quotes_list
+        new: extra_sales_quotes
+        show: extra_sales_quotes
+      info:
+        copy: Create a new quote to send to a prospective customer. To search for
+          or create a new customer, start typing in the Name box.
+        create: Create a new quote to send to a prospective customer. To search for
+          or create a new customer, start typing in the Name box.
+        draft: When you’re ready to fully save your quote, remove the Save as draft
+          tick.
+        edit: Make changes to quote details or values. %{additional_text}
+        index: Create quotes (for a firm price) and estimates (if the price may change)
+          for your customers to accept or decline.
+        new: Create a new quote to send to a prospective customer. To search for or
+          create a new customer, start typing in the Name box.
+        show: View or edit the quote, or use the options available to set the status
+          of the quote, email it to your customer or produce a PDF.
+      title:
+        copy: New Sales Quote
+        create: New Sales Quote
+        default: Sales Quotes
+        edit: 'Sales Quote: %{context_string}'
+        index: Quotes and Estimates
+        new: New Sales Quote
+        show: 'Sales Quote: %{context_string}'
+    link_texts:
+      add_address: Add Address
+      add_address_contact: Add Contact
+      view_contact_statement: View Statement
+    mysageone_core/jwt_resellers:
+      title:
+        show: Reseller integration details
+    mysageone_core/oauth:
+      title:
+        authorize: Authorise application
+    sop_admin/business_memberships:
+      info:
+        default: Customer list including activation status.
+        show: Manage and view user details.
+      title:
+        default: Administrator View
+        show: 'Viewing User: %{responding_with}'
+    sop_admin/super/jwt_resellers:
+      title:
+        index: Resellers
+        show: Resellers
+    sop_admin/users:
+      info:
+        default: Customer list including activation status.
+        show: Manage and view user details.
+      title:
+        default: Administrator View
+        show: 'Viewing User: %{responding_with}'
+    sop_settings/accounts:
+      description: Use this area to manage and make changes to your personal settings.
+      title:
+        default: My Sage One
+    sop_settings/analysis_types:
+      help:
+        index: analysis_types
+      info:
+        index: Create analysis types and categories to suit your business and choose
+          the areas that you want each type to be available in.  Use Transactional
+          Analysis to break down your income and expenditure, and use Group Analysis
+          to segment your records, such as customers and suppliers.
+      title:
+        index: Analysis Types
+    sop_settings/bank_opening_balances:
+      help:
+        show: extra_opening_balances
+      info:
+        show: Enter bank account opening balances. If your account balance is made
+          up of a reconciled value and items that have not yet appeared on your bank
+          statement, enter these as separate items. You can then reconcile the entries
+          when they appear on your statement.
+      title:
+        show: Bank Account Opening Balances
+        update: Bank Account Opening Balances
+    sop_settings/business_settings:
+      antifraud:
+        button: Export certificate
+        desc: Export a copy of the anti-fraud compliance certificate for your business
+        title: Anti-fraud compliance
+      business:
+        changes: Changes will be reflected across all Sage applications.
+        desc: Where do you run your business from day-to-day?
+        title: Business Name & Trading Address
+      business_type:
+        desc: Where is your business registered for official purposes?
+        registered_address: Registered Address
+        title: Business Type
+      help:
+        show: extra_business_settings
+      info:
+        show: Edit your business name, address and company type.
+      registration_numbers:
+        desc: Registration numbers description
+        title: Registration numbers
+      title:
+        default: About your Business
+      update:
+        failure: Your business could not be updated.
+    sop_settings/businesses:
+      help_url:
+        default: http://www.sageone.com/help/accounts/settings/business-settings
+      info:
+        default: Use this area to manage your Business settings.
+      title:
+        default: Business Settings
+    sop_settings/check_settings:
+      help:
+        show: check_printing_settings
+      info:
+        show: Make payments by printing directly onto special check paper.
+      title:
+        show: Check Printing Settings
+    sop_settings/currency_settings:
+      accounting_settings:
+        desc: Set how you’d like to handle bank charges and exchange rate gains or
+          losses in your accounts.
+        title: ACCOUNTING SETTINGS
+      currency_transactions:
+        desc: Enable foreign currency transactions, and choose whether you’d like
+          to use our live exchange rates, or enter your own.
+        title: CURRENCY TRANSACTIONS
+      help:
+        show: extra_foreign_currency
+      info:
+        show: Get set up to handle foreign currency transactions and manage your exchange
+          rates.
+      title:
+        default: Currency Settings
+    sop_settings/customer_opening_balances:
+      help:
+        data_import: extra_import_opening_balances
+        index: extra_opening_balances
+      info:
+        index: 'Record outstanding customer transactions from your previous accounting
+          system. Opening balances must be dated prior to your start date. Note: Your
+          opening balance batch total automatically provides the balance for your
+          trade debtors account in the Nominal Opening Balances option.'
+      message:
+        no_customers: You need to create customers before you can set customer opening
+          balances
+      title:
+        index: Customer Opening Balances
+        update: Customer Opening Balances
+    sop_settings/data_managements:
+      title:
+        default: Data Management
+    sop_settings/datev_export_settings:
+      title:
+        default: DATEV Export Settings
+    sop_settings/default_settings:
+      ageing_periods:
+        ageing: Ageing
+        ageing_note: "(for reporting)"
+        from: From
+        older: Older
+        to: To
+      bank:
+        title: Bank Defaults
+      bank_charges_ledger_account: Bank Interest and Charges Paid Ledger Account
+      bank_gains_ledger_account: Bank Interest Received Ledger Account
+      bank_payment_type: Default Payment Type
+      bank_receipt_type: Default Receipt Type
+      carriage_ledger_account: Carriage Ledger Account
+      catalog_items_order:
+        choice_description: Item Description
+        choice_item_code: Item Code
+        label: Sort order for Product/Service Menus
+      chart_of_accounts:
+        desc: Set how you’d like ledger accounts to be sorted in menus and the Chart
+          of Accounts, and how you’d like to handle negative assets.
+        list_order:
+          choice_code: Nominal Code
+          choice_name: Ledger Name
+          label: Sort order for Ledger Accounts list
+        negative_assets:
+          choice_liabilities: As Liabilities
+          choice_negative_assets: As Negative Assets
+          label: Show Negative Assets on Balance Sheet
+        separate_profit_loss:
+          choice_include: Within calculated Profit/Loss
+          choice_separate: Separately on Balance Sheet
+          label: Show Profit and Loss Account value
+        title: Accounting Settings
+      customer:
+        changes: You can override these for individual sales later if you like.
+        desc: Set defaults for your sales to customers.
+        title: Customers
+      customer_receipt_discount_ledger_account: Customer Receipt - Discount Ledger
+        Account
+      customer_statement_type: Customer Statement Type
+      expenses_other_payment_ledger_account: Other Payment Ledger Account
+      help:
+        show: extra_default_settings
+      incomes_other_receipt_ledger_account: Other Receipt Ledger Account
+      info:
+        show: Choose the preferences and defaults to use when creating records and
+          transactions.
+      invoice_purchase_discount_ledger_account: Purchase Discount Ledger Account
+      invoice_purchase_ledger_account: Purchase Ledger Account
+      invoice_sales_discount_ledger_account: Sales Discount Ledger Account
+      invoice_sales_ledger_account: Sales Ledger Account
+      payments_receipts:
+        desc: Set how you’d like to handle payment transactions to suppliers, and
+          receipt transactions from customers.
+        title: Payments & Receipts
+      product:
+        title: Product Defaults
+      product_labels_enabled: Set global pricing labels
+      product_purchases_ledger_account: Purchase Account
+      product_sales_ledger_account: Sales Account
+      product_service:
+        desc: Set the prices or rates you’d like to use when you sell products or
+          services to customers.
+        product_ledgers: Default Non-stock Ledger Accounts
+        product_prices: Product Prices
+        service_ledgers: Default Service Ledger Accounts
+        service_rates: Service Rates
+        stock_ledgers: Default Stock Ledger Accounts
+        title: Products & Services
+        weight_settings:
+          measurement_unit:
+            g: Gram (g)
+            kg: Kilogram (kg)
+            label: Default Measurement
+            lb: Pound (lb)
+            oz: Ounce (oz)
+            ton: Ton (t)
+            tonne: Tonne (t)
+          title: Weight Settings
+          unit_of_measure:
+            imperial_uk: Imperial (UK)
+            imperial_us: Imperial (US)
+            label: Default Unit of Measure
+            metric: Metric
+      service:
+        title: Service Defaults
+      service_labels_enabled: Set global rate labels
+      service_purchases_ledger_account: Purchase Account
+      service_sales_ledger_account: Sales Account
+      stock_purchases_ledger_account: Purchase Account
+      supplier:
+        changes: You can override these for individual purchases later if you like.
+        desc: Set defaults for your purchases from suppliers.
+        title: Suppliers
+      supplier_payment_discount_ledger_account: Supplier Payment - Discount Ledger
+        Account
+      supplier_statement_type: Supplier Statement Type
+      title:
+        default: Record and Transactions Settings
+        show: Record and Transactions Settings
+    sop_settings/email_defaults:
+      help:
+        show: extra_email_defaults
+      info:
+        show: Set a default message which you can customise when you email an invoice,
+          statement or other document.
+      title:
+        default: Email Defaults
+    sop_settings/financial_settings:
+      accounting_dates:
+        desc: Choose when your financial year starts and ends. Choose a ‘Lockdown’
+          date to stop new transactions being saved before this.
+        title: Accounting Dates
+      help:
+        accounting_types: extra_accounting_types
+        show: extra_financial_settings
+      info:
+        accounting_types: Please ask your accountant which accounting method is best
+          for your business.
+        show: Record financial details including VAT scheme information, financial
+          year end and the start date for transactions.
+      tax_info:
+        desc: Enter details of your VAT registration, including how often you’ll submit
+          VAT returns to HMRC. Enter your HMRC User ID to submit VAT returns directly
+          from Accounting.
+        tax_calculation:
+          applicability: The VAT Calculation method will apply to future transactions
+            only.
+          cash:
+            label: On payment
+            text: The VAT collected is due when payment is collected.
+          invoice:
+            label: On invoice
+            text: The VAT collected is due from the date of issue of the invoice.
+          title: VAT Calculation
+        title: VAT Details
+      title:
+        default: Financial Settings
+    sop_settings/financial_years:
+      actions:
+        archive_download: Download
+        continue: Continue
+        run_year_end: Close
+        view: View
+      headers:
+        action: Action
+        archive: Archive
+        end_date: To
+        start_date: From
+        status: Status
+      help:
+        index: extra_financial_year_end_process
+        show: extra_financial_year_end_process
+      index:
+        message:
+          text: Your year-end journals have been applied, and your %{current_financial_year_formatted}
+            financial Year-End process is complete.
+          title: Happy New Year!
+      missing_lockdown_date: Choose a Lockdown Date
+      missing_year_end_date: Choose a Year End Date
+      show:
+        message:
+          text: Your year-end journals have been applied, and your %{current_financial_year_formatted}
+            financial Year-End process is complete.
+          title: 'Status:'
+        reason_cannot_undo: Because you’ve also completed the %{next_financial_year_formatted}
+          financial year, you can no longer undo this step.
+        step:
+          archiving:
+            done:
+              header: We're generating your archive. You can continue with your Year
+                End while it processes.
+              tasks:
+              - Your archive is being generated. We’ll email you when it’s available,
+                and it will be available from the top bar when complete.
+            title: Archive your financial reports
+            todo:
+              button_text: Request archive
+              header: 'We''ll generate an archive of your financial reports. You must
+                save this archive somewhere secure. '
+              tasks:
+              - 'The reports included in the archive are as follows: Nominal Activity,
+                Journal Export, Audit Trail, All Sales Invoices/Credit Notes, Balance
+                Sheet and Profit and Loss'
+              - " "
+              - The archive can take up to 48 hours to generate. We'’ll email you
+                when it''s ready, and it will be available from the top bar when complete.
+          close:
+            balance_journal_reference: Accounts Closing
+            creditor_journal_reference: Credit Accounts Closing
+            custom_message:
+              undo: To enter adjustments in your re-opened financial year, please
+                check your lockdown date
+            debtor_journal_reference: Debit Accounts Closing
+            dialogs:
+              do:
+                button_text: Close Financial Year
+                date_range: "%{current_financial_year_start_date} to %{current_financial_year_end_date}"
+                description: Are you sure you'd like to lock the %{current_financial_year_formatted}
+                  financial year?
+                footer:
+                - This step will number your transactions and create journals. You
+                  can un-do this change, but it's best to avoid this.
+                title: Close Financial Year
+              undo:
+                button_text: Undo Closing Financial Year
+                description: Are you sure you want to undo closing the %{current_financial_year_formatted}
+                  financial year?
+                footer:
+                - This will mean...
+                - "- You can move lockdown date before %{next_financial_year_start_date}."
+                - "- Year-end journals are reversed, but the originals and the reversals
+                  will still show up in your audit trial."
+                title: Undo Closing Financial Year
+            profit_loss_journal_reference: Retained Earnings
+            title: Close the %{current_financial_year_formatted} Financial Year
+            todo:
+              button_text: Close Financial Year
+              footer:
+              - You and your accountant should decide the best time to do this - ideally,
+                wait until all transactions are complete for the year.
+              - You can undo this step, but it’s best to avoid this.
+              header: 'We''ll get your accounts ready for the end of the year by:'
+          open:
+            balance_carried_forward_reference: Balance Carried Forward
+            creditor_balance_carried_forward_reference: Credit Balance Carried Forward
+            debtor_balance_carried_forward_reference: Debit Balance Carried Forward
+            dialogs:
+              do:
+                button_text: Open Financial Year
+                date_range: "%{next_financial_year_start_date} to %{next_financial_year_end_date}"
+                description: Are you sure you'd like to open the %{next_financial_year_formatted}
+                  financial year?
+                footer:
+                - You can un-do this change, but it's best to avoid this.
+                title: Open Financial Year
+              undo:
+                button_text: Undo Opening Financial Year
+                description: Are you sure you want to undo opening the %{next_financial_year_formatted}
+                  financial year?
+                footer:
+                - This will mean year-end journals are reversed, but the originals
+                  and the reversals will show up in your audit trial.
+                title: Undo Opening Financial Year
+            title: Open the %{next_financial_year_formatted} Financial Year
+            todo:
+              button_text: Open Financial Year
+              header: 'We''ll set you up for the new financial year by:'
+        title: "%{current_financial_year_formatted} Financial Year"
+        undo_button_text: Undo
+        undo_close:
+          text: Verify lockdown date to create new transactions
+          title: 'Status:'
+      status:
+        archiving: 'Step %{step_number}: Request archive'
+        close: 'Step %{step_number}: Financial Year to close'
+        complete: Year End Process Complete
+        current: Current Financial Year
+        generating: Generating...
+        next: Next Financial Year
+        open: 'Step %{step_number}: Open next Financial Year'
+      title: Manage Financial Years
+    sop_settings/google_drive_settings:
+      access_text: Sage will not be able to access any other data in your Google account.
+      disable_button: Disable
+      disable_text: Disable Sage access to your Google Drive?
+      enable_button: Enable
+      enable_failure: Google Drive cannot be enabled.
+      enable_success: Google Drive has been enabled.
+      enable_text: Enable Sage access to your Google Drive?
+      folder_name: Sage Invoices
+      help:
+        show: google_drive
+      info:
+        show: Use this area to manage your Google Drive Settings
+      initial_text: By enabling Google Drive, every time you create or update a sales
+        invoice, credit note, quote or estimate, a PDF copy is created in your Google
+        Drive.
+      revoke_success: Google Drive access has been removed successfully.
+      title:
+        default: Google Drive Settings
+    sop_settings/invoice_settings:
+      help:
+        show: extra_invoice_quote_settings
+      info:
+        show: Configure the defaults shown on invoices and other sales and purchases
+          forms
+      title:
+        default: Invoice Form Settings
+        show: Invoice Form Settings
+    sop_settings/logo_and_theme_settings:
+      help:
+        show: logo_and_document_templates
+      info:
+        show: Tailor the presentation of documents you print or send to suit your
+          business.
+      title:
+        default: Logo & Document Template
+        show: Logo & Document Template
+    sop_settings/nominal_opening_balances:
+      help:
+        show: extra_opening_balances
+      info:
+        show: Record the balances of your ledger accounts from your previous accounting
+          system.  Opening balances already entered through the customer, supplier
+          or bank opening  balance options appear automatically. You can enter or
+          amend these by clicking each line.  Each debit or credit balance is offset
+          against the opening balance control account, and when the full trial balance
+          is entered, this account should be zero.
+      title:
+        show: Nominal Opening Balances
+        update: Nominal Opening Balances
+    sop_settings/online_payment_settings:
+      help:
+        show: extra_sage_pay
+      info:
+        show: Manage your Paypal and Paya settings.
+        signup: Give your customers a convenient way to pay you. Accept online credit
+          card with Paya.
+      title:
+        show: Paypal and Paya
+        signup: Paya
+    sop_settings/opening_balances:
+      amount: Amount
+    sop_settings/payroll_settings:
+      help:
+        show: settings_payroll_integration
+        update: settings_payroll_integration
+      info:
+        show: Use this area to manage your Payroll integration settings
+        update: Use this area to manage your Payroll integration settings
+      note: 'Note: This account will be used for payments posted automatically from
+        payroll such HMRC and Pension payments.'
+      payroll_journals_enabled: Enable Journals from Payroll
+      post_net_wages_to_liability:
+        default_payroll_bank_account: Post employee net wages to the default bank
+          account above.
+        net_wages_liability_account: Post employee net wages to liability account.
+      title:
+        create_journals: Creates journals in the selected bank account when you complete
+          a pay run in Payroll.
+        header: Payroll journals
+        separate_journals: Separate journals are posted for payments to employees,
+          HMRC, and pensions payments.
+        show: Payroll Integration Settings
+        update: Payroll Integration Settings
+    sop_settings/sage_pay_settings:
+      account_details:
+        desc: Enter the details of your Sage Pay account.
+        title: ACCOUNT DETAILS
+      accounting_settings:
+        bank_account: Bank Account
+        desc: Set where you'd like your Sage Pay transactions to be recorded in Sage
+          Business Cloud Accounting <br/><br/>'Default Customer' records all your
+          transactions against one customer account.
+        surcharge: Separate Account for surcharges
+        title: ACCOUNTING SETTINGS
+      help:
+        show: extra_sage_pay
+        update: extra_sage_pay
+      info:
+        show: Manage your Sage Pay settings.
+        update: Manage your Sage Pay settings.
+      title:
+        show: Sage Pay
+        update: Sage Pay
+    sop_settings/services:
+      info:
+        default: Manage your settings.
+      title:
+        default: Service Settings
+    sop_settings/settings:
+      help:
+        index: accounting_settings
+      help_url:
+        index: http://www.sageone.com/help/accounts/settings
+      info:
+        default: Manage your settings.
+        index: Manage your settings.
+      title:
+        default: Settings
+        index: Settings
+    sop_settings/stripe_settings:
+      help:
+        show: connect_to_stripe
+      info:
+        show: Easy card payments straight from customer invoices. Sign up to Stripe
+          or manage your settings.
+      title:
+        show: Card Payments
+    sop_settings/supplier_opening_balances:
+      help:
+        data_import: extra_import_opening_balances
+        index: extra_opening_balances
+      info:
+        index: 'Record supplier transactions from your previous accounting system.
+          Opening balances must be dated prior to your start date. Note: Your opening
+          balance batch total automatically provides the balance for your trade creditors
+          account in the Nominal Opening Balances option.'
+      message:
+        no_suppliers: You need to create suppliers before you can set supplier opening
+          balances.
+      title:
+        index: Supplier Opening Balances
+        update: Supplier Opening Balances
+    sop_settings/tax_settings:
+      help:
+        index: extra_sales_tax_rates
+      info:
+        index: Create, view and manage the tax rates for products and services you
+          sell.
+      title:
+        default: Sales Tax Rates
+    sop_settings/user_managements:
+      alerts:
+        aged_creditor:
+          message: Purchases reports require access to purchases and contacts, and
+            won't be available to this user.
+        aged_debtor:
+          message: Sales reports require access to sales and contacts, and won't be
+            available to this user.
+        management_report:
+          message: Management reports require Full or Read Only access to all areas,
+            and won't be available to this user.
+        reports:
+          title: Access to Reports
+      info:
+        default: Use this area to manage your users.
+        new: Enter the user's email address, establish permissions, and invite them
+          to work with your data.
+      title:
+        default: User Management
+        new: Invite User
+    sop_settings/user_preferences:
+      info:
+        show: Make changes to suit your style of working.
+      title:
+        default: Navigation and Data Grids
+    sop_settings/users:
+      help_url:
+        default: http://www.sageone.com/help/manage-my-sage-one/sage-one-accounts/user-settings
+        index: http://www.sageone.com/help/manage-my-sage-one/sage-one-accounts/user-settings
+      info:
+        default: Manage your settings.
+        show: Manage your settings.
+      only_service_users_can_be_added: "%{email} is invalid"
+      title:
+        default: User Settings
+  payment_dialog:
+    discount: Discount Given%{currency_tag}
+    outstanding_balance: Outstanding Balance%{currency_tag}
+  payments:
+    dialog:
+      amount_to_pay: Amount to Pay
+      description: 'Enter the amount you want to pay:'
+      discount: Discount
+      new_outstanding_amount: New Outstanding Amount
+      outstanding: Outstanding
+      reference: Reference
+      title: Part Pay
+    grid_filter:
+      display:
+        due: Due
+        outstanding: Outstanding
+        paid_unpaid: All
+        this_allocation: This allocation
+    paid_on_invoice:
+      successful: Payment added successfully
+    ui:
+      payments_pod:
+        amount_paid: Amount Paid
+        invoice_receipt_details: Invoice Payment Details
+        outstanding: Amount Outstanding
+        pay: Record Payment
+        pay_receipt: Record Payment
+        payment_details: Invoice Payment Details
+        take_a_card_payment: Card Payment
+      refunds_pod:
+        amount_paid: Amount Paid
+        outstanding: Amount Outstanding
+        refund: Record Refund
+        refund_details: Refund Details
+  payments_pod:
+    amount_outstanding: Amount Outstanding
+    amount_paid: Amount Paid
+    amount_received: Amount Received%{currency_tag}
+    currency_charges: Currency Charges%{currency_tag}
+    last_paid: Last payment made
+    last_payment: Last payment received
+    last_refund: Last refunded
+    pay_now: Pay now
+    record_payment: Record Payment
+    record_refund: Record Refund
+    take_a_card_payment: Card Payment
+    voided_date: Voided Date
+  pdf:
+    of: of
+    page: Page
+  pdf_helpers:
+    address: Address
+    messages:
+      migrated_artefacts: You can't create a PDF for one or more of the selected items
+        because it was migrated from your old accounting system.
+    prefix:
+      advanced_uk/customer_income_payment: Remittance Advice
+      advanced_uk/customer_refund_payment: Customer Refund
+      advanced_uk/supplier_expense_payment: Remittance Advice
+      fuji_invoicing/sales_corrective_invoice: Sales_Corrective_Invoice_
+      fuji_invoicing/sales_credit_note: Credit_Note_
+      fuji_invoicing/sales_estimate: Sales_Estimate_
+      fuji_invoicing/sales_invoice: Sales_Invoice_
+      fuji_invoicing/sales_quote: Sales_Quote_
+    titles:
+      migrated_artefacts:
+        credit_note: Create Sales Credit Note PDF
+        invoice: Create Sales Invoice PDF
+        sales_artefact: Create Sales Item PDF
+  period_date_range:
+    list:
+      custom: Custom
+      last_month: Last month
+      last_year: Last year
+      this_month: This month
+      this_year: This year
+    title:
+      end: End
+      start: Start
+      type: Period
+  placeholder:
+    contacts:
+      reference: e.g. Account Number
+      search_text: Type the company / name to search
+    generic:
+      type_to_search: Type to search
+    payments:
+      advanced_uk/customer_income_payment:
+        reference: e.g. Cheque number
+      advanced_uk/customer_refund_payment:
+        reference: e.g. Cheque number or BACS Ref
+      advanced_uk/other_expense_payment:
+        reference: e.g. Cheque number or BACS Ref
+      advanced_uk/other_expense_payment_refund:
+        reference: e.g. Cheque number or BACS Ref
+      advanced_uk/other_income_payment:
+        reference: e.g. Cheque number
+      advanced_uk/other_income_payment_refund:
+        reference: e.g. Cheque number
+      advanced_uk/supplier_expense_payment:
+        reference: e.g. Cheque number or BACS Ref
+      advanced_uk/supplier_refund_payment:
+        reference: e.g. Cheque number
+    products_and_services:
+      category: Select a Category
+      code: e.g. Short name or code
+      no_categories: No categories found
+      no_suppliers: No suppliers found
+      purchase_description: Description on purchase forms
+      usual_supplier: Select a supplier
+    purchase_corrective_invoice:
+      reference: e.g. Purchase Order Number
+      supplier_reference: e.g. Supplier's Invoice Number
+    purchase_credit_note:
+      reference: e.g. Original Invoice Number
+      supplier_reference: e.g. Supplier's Credit Note number
+    purchase_invoice:
+      reference: e.g. Purchase Order Number
+      supplier_reference: e.g. Supplier's Invoice Number
+    sales_credit_note:
+      reference: e.g. Invoice Number
+    sales_estimate:
+      reference: e.g. Customer's Ref
+    sales_invoice:
+      reference: e.g. Order Number
+    sales_quote:
+      reference: e.g. Customer's Ref
+  purchase_corrective_invoice:
+    confirm:
+      helper_text:
+        confirm_no_vat: |
+          **You can use 'No VAT' if your supplier is not VAT registered,** as they can’t charge you VAT.
+
+          **Do not use 'No VAT' for overseas purchases -** instead, enter the supplier’s address and any VAT number on their record. Enter the VAT rate charged, and the Reverse Charge mechanism means the VAT value is cancelled out on your return.
+
+          **[Read guidance from HMRC](https://www.gov.uk/guidance/rates-of-vat-on-different-goods-and-services)** on when to use Zero rated or Exempt instead.
+        confirm_vat_only: "**For example, do not create VAT-only corrective invoices
+          for goods previously purchased** if you’ve just become VAT registered."
+      messages:
+        confirm_no_vat: |
+          **'No VAT' has been selected on this corrective invoice.**
+          If you’re unsure, check with an accountant.
+        confirm_vat_only: |
+          **This corrective invoice only has a VAT value.**
+          This is for special situations only - check with an accountant to be sure.
+        stock_cost_zero: |
+          One or more of your stock items has a price of %{currency_amount}. This will affect the average cost calculation for your stock.
+
+          Would you like to save it anyway, or continue editing?
+        total_zero: |
+          This Corrective Invoice has a value of %{currency_amount}.
+          Would you like to save it anyway, or continue editing?
+      title:
+        confirm_no_vat: Choosing 'No VAT'
+        confirm_vat_only: VAT-only Corrective Invoices
+        stock_cost_zero: Zero Value Stock Item
+        total_zero: Zero Value Corrective Invoice
+    eu_no_vat:
+      supplier:
+        message_text: If the supplier is registered for VAT in the EU, enter their
+          VAT number on the supplier record to apply the correct VAT treatment.
+    eu_tax_registration:
+      supplier:
+        message_text: VAT is set to zero and will be charged under the Reverse Charge
+          mechanism. Please review the EU Goods/Services selection on each invoice
+          line.
+    row:
+      supplier:
+        message_text: VAT is set to zero and will be charged under the Reverse Charge
+          mechanism. Please review the Goods/Services selection on each invoice line.
+  purchase_credit_note:
+    confirm:
+      helper_text:
+        confirm_no_vat: |
+          **You can use 'No VAT' if your supplier is not VAT registered,** as they can’t charge you VAT.
+
+          **Do not use 'No VAT' for overseas purchases -** instead, enter the supplier’s address and any VAT number on their record. Enter the VAT rate charged, and the Reverse Charge mechanism means the VAT value is cancelled out on your return.
+
+          **[Read guidance from HMRC](https://www.gov.uk/guidance/rates-of-vat-on-different-goods-and-services)** on when to use Zero rated or Exempt instead.
+        confirm_vat_only: "**For example, do not create VAT-only credit notes for
+          goods previously purchased** if you’ve just become VAT registered."
+      messages:
+        confirm_no_vat: |
+          **'No VAT' has been selected on this credit note.**
+          If you’re unsure, check with an accountant.
+        confirm_vat_only: |
+          **This credit note only has a VAT value.**
+          This is for special situations only - check with an accountant to be sure.
+        stock_cost_zero: |
+          One or more of your stock items has a price of %{currency_amount}. This will affect the average cost calculation for your stock.
+
+          Would you like to save it anyway, or continue editing?
+        total_zero: |
+          This Credit Note has a value of %{currency_amount}.
+          Would you like to save it anyway, or continue editing?
+      title:
+        confirm_no_vat: Choosing 'No VAT'
+        confirm_vat_only: VAT-only Credit Notes
+        stock_cost_zero: Zero Value Stock Item
+        total_zero: Zero Value Credit Note
+  purchase_credit_notes:
+    eu_no_vat:
+      supplier:
+        message_text: If the supplier is registered for VAT in the EU, enter their
+          VAT number on the supplier record to apply the correct VAT treatment.
+    eu_tax_registration:
+      customer:
+        message_text: The credit note address has been fixed and the VAT Rate has
+          been set to zero (0). Please review the EU Goods/Services.
+      supplier:
+        message_text: VAT is set to zero and will be charged under the Reverse Charge
+          mechanism. Please review the EU Goods/Services selection on each invoice
+          line.
+    row:
+      customer:
+        message_text: The credit note address has been fixed and the VAT Rate has
+          been set to zero (0). Please review the EU Goods/Services.
+      supplier:
+        message_text: VAT is set to zero and will be charged under the Reverse Charge
+          mechanism. Please review the Goods/Services selection on each invoice line.
+  purchase_invoice:
+    confirm:
+      helper_text:
+        confirm_no_vat: |
+          **You can use 'No VAT' if your supplier is not VAT registered,** as they can’t charge you VAT.
+
+          **Do not use 'No VAT' for overseas purchases -** instead, enter the supplier’s address and any VAT number on their record. Enter the VAT rate charged, and the Reverse Charge mechanism means the VAT value is cancelled out on your return.
+
+          **[Read guidance from HMRC](https://www.gov.uk/guidance/rates-of-vat-on-different-goods-and-services)** on when to use Zero rated or Exempt instead.
+        confirm_vat_only: "**For example, do not create VAT-only invoices for goods
+          previously purchased** if you’ve just become VAT registered."
+      messages:
+        confirm_no_vat: |
+          **'No VAT' has been selected on this invoice.**
+          If you’re unsure, check with an accountant.
+        confirm_vat_only: |
+          **This invoice only has a VAT value.**
+          This is for special situations only - check with an accountant to be sure.
+        stock_cost_zero: |
+          One or more of your stock items has a price of %{currency_amount}. This will affect the average cost calculation for your stock.
+
+          Would you like to save it anyway, or continue editing?
+        total_zero: |
+          This Invoice has a value of %{currency_amount}.
+          Would you like to save it anyway, or continue editing?
+      title:
+        confirm_no_vat: Choosing 'No VAT'
+        confirm_vat_only: VAT-only Invoices
+        stock_cost_zero: Zero Value Stock Item
+        total_zero: Zero Value Invoice
+  purchase_invoices:
+    eu_no_vat:
+      supplier:
+        message_text: If the supplier is registered for VAT in the EU, enter their
+          VAT number on the supplier record to apply the correct VAT treatment.
+    eu_tax_registration:
+      customer:
+        message_text: The invoice address has been fixed and the VAT Rate has been
+          set to zero (0). Please review the EU Goods/Services.
+      supplier:
+        message_text: VAT is set to zero and will be charged under the Reverse Charge
+          mechanism. Please review the EU Goods/Services selection on each invoice
+          line.
+    row:
+      customer:
+        message_text: The invoice address has been fixed and the VAT Rate has been
+          set to zero (0). Please review the EU Goods/Services.
+      supplier:
+        message_text: VAT is set to zero and will be charged under the Reverse Charge
+          mechanism. Please review the Goods/Services selection on each invoice line.
+  quick_entry:
+    total_items:
+      one: 1 item
+      other: "%{count} items"
+      zero: 0 items
+    totals_dialog:
+      title: Quick Entry Totals
+      total_amount: Total
+      total_batch_entry_type_1: Totals of %{count} Invoices
+      total_batch_entry_type_2: Totals of %{count} Credit Notes
+      total_description: ''
+      total_footer: Total
+      total_net_amount: Net
+      total_tax_amount: VAT
+  quick_start:
+    business_postcode:
+      placeholder: e.g. AB12 3CD
+    coa:
+      label: Chart of Accounts
+      skr03:
+        description: for small and medium companies
+        name: Standard (SKR03)
+      skr04:
+        description: for corporations
+        name: SKR04
+    fields:
+      accounts_start_date:
+        hint: This is the date that you’d like to start recording your transactions.
+          It’s best to choose a date that matches the start of your VAT period. Later,
+          you can enter opening balances before this date if you like.
+      business_classification:
+        hint: Type a word that describes what your business does, then choose one
+          of the suggestions.  This helps us provide the best experience for businesses
+          like yours.
+        placeholder: Type to search
+      business_name:
+        hint: This will appear on your customer invoices.
+      business_phone_number:
+        hint: We'll customise your customer invoices with this.
+      business_registered_street_1:
+        hint: This goes at the bottom of your customer invoices.
+      business_start_date:
+        hint: Tell us when your business officially started. This helps us to provide
+          the right products and services for you.
+      business_street_1:
+        hint: We'll put this address at the top of your customer invoices.
+      business_type:
+        hint: Choose your business type, and we’ll set up the right accounting structure
+          for you.
+      financial_year_end_date:
+        hint: We use this date to help produce your year-end accounts.
+      registered_country:
+        hint: We'll use this to customise your invoices and apply the right legislation,
+          keeping you compliant.
+        prompt: Select a Country
+      registered_number:
+        hint: Companies House give you this when you register with them. It could
+          be 2 letters and 6 numbers, or 8 numbers. You can look it up on the Companies
+          House website.
+        label: Registration Number
+      tax_number:
+        hint: you get from the tax office
+        label: tax identification number
+        placeholder: e.g. 123456789
+      tax_office:
+        hint: where your company is registered
+        label: tax office
+      vat_number:
+        hint: Issued by HM Revenue & Customs when you registered for VAT. It has 9
+          numbers, and can be found on your VAT registration certificate (sometimes
+          called a VAT 4 form). We'll put it on your customer invoices.
+      vat_rate:
+        hint: Your rate is set by HMRC, and depends on your type of business. For
+          more information, see the HMRC website.
+    finish: All Done!
+    help_text_link: Need some help?
+    mobile_view:
+      android_link: https://play.google.com/store/apps/details?id=com.sage.accounting
+      available_on: It's available for free for iOS and Android devices.
+      continue_desktop: Keep using the desktop version.
+      ios_link: https://itunes.apple.com/app/sage-accounting/id1341612411
+      pre_continue_desktop: Not quite ready?
+      screen_message: "(Designed for screens larger than 958px)"
+      summary_text: To get the very best experience on this device, download the Sage
+        Accounting app.
+      title: Get <span>the app!</span>
+    next: Save and Continue
+    prev: Back
+    required_note: "* Required"
+    step_header:
+      of: of
+      step: Step
+    steps:
+      business_address:
+        subtitle: Where do you run your business from day-to-day?
+        title: Business Trading Address
+      business_basics:
+        subtitle: Just a few quick questions, and you're ready to go!
+        title: ''
+      important_dates:
+        title: Important dates
+      registered_address:
+        subtitle: Where is your business registered for official purposes?
+        title: Registered Address
+      tax:
+        empty:
+        - We’re having issues verifying your zip code.
+        - Click Back to make sure you entered the correct zip code and try again.
+        - If you continue to have issues, you can manually create your tax rates in
+          Settings.
+        subtitle: And finally, do you charge VAT?
+        title: VAT
+    tax_calculation_method:
+      cash:
+        description: The VAT collected is due when payment is collected.
+        name: On payment
+      heading: VAT Calculation Method
+      invoice:
+        description: The VAT collected is due from the date of issue of the invoice.
+        name: On invoice
+      title: VAT Calculation Method
+    tax_scheme:
+      cash_accounting:
+        description: I pay VAT based on invoices as they are paid
+        name: Cash accounting
+      flat_cash:
+        description: I pay a flat rate on invoices as they are paid
+        name: Flat rate cash based
+      flat_invoice:
+        description: I pay a flat rate on invoices as they are raised
+        name: Flat rate invoice based
+      not_registered:
+        description: I don't have a VAT number
+        name: Not registered
+      simplified:
+        description: I deliver tax reports each month.
+        name: Simplified
+      standard:
+        description: I pay VAT based on invoices as they are raised
+        name: Standard
+    title: Let’s set up <span>your business</span>
+    vat_number:
+      placeholder: e.g. 123456789
+  quote_profit_breakdown:
+    dialog:
+      description: 'Note: Where an item does not have a cost price it is not included'
+      title: Profit Summary
+    report:
+      headers:
+        description: Description
+        profit: Profit
+        profit_percentage: Profit %
+        total_cost: Total Cost
+        total_sales: Total Sales
+  quotes:
+    estimate_already_invoiced: You cannot edit this estimate as it has been converted
+      to an invoice.
+    quote_already_invoiced: You cannot edit this quote as it has been converted to
+      an invoice.
+    quote_statuses:
+      converted: Converted
+      expired: Expired
+      pending: Pending
+  recurrence:
+    create: Create
+    dialog:
+      fields:
+        label: Recurs every...
+    edit: Edit
+    make: Make
+    notifications:
+      delete: Recurrence deleted
+      set: Recurrence set
+    payment: Payment
+    receipt: Receipt
+    title: "%{prefix} Recurring"
+  registered_country:
+  - England and Wales
+  - Wales
+  - Scotland
+  - Northern Ireland
+  - Republic of Ireland
+  reporting:
+    accounts_and_audit:
+      audit_trail_selector_title: Audit Trail
+      title: Accounting & Audit
+      trial_balance_title: Trial Balance
+    aged:
+      auxiliary_account: ", Auxiliary Account: %{auxiliary_account}"
+      contact_details: ", Tel: %{contact_number}"
+      contact_details_multiple: ", Tel: %{telephone_number} / %{mobile_number}"
+      contact_name: "%{contact_name}"
+      credit_limit: Credit limit
+      credit_limit_prefix: ", Credit limit: "
+      currency_prefix: ", Currency: "
+      customer: Customer
+      date: Date
+      due_date: Due Date
+      interval: "< %{end} days"
+      multi_currency_footer_message: All foreign values are calculated using the exchange
+        rate of the original transaction.
+      name: Name
+      older: Older
+      original_amount: Total
+      outstanding_amount: Outstanding Amount
+      overdue: " - OVERDUE"
+      payment_terms: ", Terms: %{payment_terms} days"
+      reference: Reference
+      sort_criteria: Sort by
+      sums_for_classes:
+        fuji_journals/journal: All Journals
+      supplier: Supplier
+      total: O/S Amt
+      total_uppercased: TOTAL
+      totals: Totals
+    aged_creditors:
+      csv_filename: aged_creditors_to_%{end_date}
+      description: This report shows all outstanding or unallocated supplier transactions,
+        broken down by the ageing periods specified in Record and Transactions Settings.
+      filename: aged_creditors
+      link_to_breakdown: Detailed
+      title: Aged Creditors Report
+    aged_creditors_breakdown:
+      filename: aged_creditors_breakdown
+      link_to_summary: Summary
+    aged_debtors:
+      csv_filename: aged_debtors_to_%{end_date}
+      description: This report shows all outstanding or unallocated customer transactions,
+        broken down by the ageing periods specified in Record and Transactions Settings.
+      filename: aged_debtors
+      link_to_breakdown: Detailed
+      title: Aged Debtors Report
+    aged_debtors_breakdown:
+      filename: aged_debtors_breakdown
+      link_to_summary: Summary
+    archive:
+      email:
+        body_html: 'Hello %{user}, <br><br><strong>Your archive of financial reports
+          is now available to download.</strong><br><br> It''ll be available when
+          you next sign in, or you can download it from the Financial Years page in
+          Settings.<br><br> <img src=''%{button_src}'' width=''400px'' style=''margin:0
+          auto; display:block;'' /><br><br> Make sure you remember to save the archive
+          to your computer.<br><br> <a href=''%{path}'' target=''_blank'' style=''width:
+          200px; display:block; margin: 0 auto; background-color:#ba296c; padding:
+          12px 0; color: #FFFFFF; font-family: Arial; font-size: 16px; font-weight:
+          bold; text-decoration:none; text-align: center;''>Sign in</a><br> Thank
+          you, <br> Sage'
+        subject: Email Confirmation Archive generated
+      filename: Archive_%{start_date}_%{end_date}
+    audit_trail:
+      description: The audit trail breakdown is a detailed record of all transactions
+        posted. You can view this by transaction type for a specified date range.
+      filename: audit_trail_breakdown
+      generic_description: The audit trail shows all transactions posted.
+      generic_title: Audit Trail
+      is_reconciled: 'Yes'
+      link_to_summary_report: Summary
+      not_reconciled: 'No'
+      short_title: Breakdown
+      status:
+        active: Exclude deleted
+        all: All
+        deleted: Deleted only
+        status: Status
+      title: Audit Trail Breakdown
+      transaction_type: Type
+    audit_trail_summary:
+      description: The audit trail summary is a record of all transactions posted.
+        You can view this by transaction type for a specified date range.
+      filename: audit_trail_summary
+      link_to_detailed_report: Detailed
+      short_title: Summary
+      title: Audit Trail
+    auxiliary_balance:
+      account: Account
+      account_name: Account Name
+      all_accounts: All Accounts
+      apply: Apply
+      auxiliary_account: Account Code
+      credit: Credit
+      credit_balance: Credit Balance
+      date: To
+      debit: Debit
+      debit_balance: Debit Balance
+      description: Allows you to see the results of your business and the balance
+        of each subaccounts at a given time.
+      filename: auxiliary_balance_%{collective_account_name}
+      grand_total: GRAND TOTAL
+      title: Auxiliary Balance
+      total: TOTAL
+    balance_sheet:
+      assets: Assets
+      current_assets: Current Assets
+      current_liabilities: Current Liabilities
+      description: The balance sheet shows what you own, your assets, and what you
+        owe, your liabilities.
+      equity: Equity
+      filename: balance_sheet
+      fixed_assets: Fixed Assets
+      liabilities: Liabilities
+      liabilities_equity: Liabilities & Equity
+      long_term_liabilities: Future Liabilities
+      net_assets: Net Assets
+      prior_years: "(prior year(s))"
+      title: Balance Sheet Report
+      total_tax_liabilities: VAT
+      trading_activity: Net Profit / Loss
+      trading_activity_current_year: Net Profit / Loss (current year)
+      trading_activity_prior_years: Net Profit / Loss (prior year(s))
+      vat: VAT
+    balance_statement:
+      filename: balance_statement
+    beta: BETA
+    cash_flow:
+      bank_accounts: Bank Account(s)
+      from_date: From
+      to_date: To
+      view_detailed_breakdown: Detailed
+    cash_flow_forecast:
+      bank_account_balances: Selected bank balance(s)
+      description: Use this report to analyse your projected cash flow in and cash
+        flow out for future periods.
+      detailed_reports: Detailed Breakdown
+      filename: cash_flow_forecast
+      forecast_transaction_prefix: Expected
+      forecast_transaction_title: Expected %{transaction_type}
+      inbound_adjustments: Manual Adjustments
+      outbound_adjustments: Manual Adjustments
+      payroll_adjustments: Payroll costs for forecast period
+      prior_expected_net_cashflow: Expected net cash flow prior to selected date range
+      title: Cash Flow Forecast Report
+      view_detailed_breakdown: Detailed
+      view_prior_transactions: View Prior Transactions
+    cash_flow_forecast_detail:
+      adjustment_details: Details
+      customer: Customer
+      expected_amount: Expected Amount
+      expected_customer_receipts: Expected Customer Receipts
+      expected_customer_refunds: Expected Customer Refunds
+      expected_date: Expected Date
+      expected_other_payments: Expected Other Payments
+      expected_other_receipts: Expected Other Receipts
+      expected_supplier_payments: Expected Supplier Payments
+      expected_supplier_refunds: Expected Supplier Refunds
+      filename: cash_flow_forecast_detail
+      inbound_manual_adjustments: Manual Adjustments
+      outbound_manual_adjustments: Manual Adjustments
+      payroll_manual_adjustments: Payroll Adjustments
+      reference: Reference
+      supplier: Supplier
+      total: Total
+    cash_flow_forecast_prior_transactions:
+      filename: cash_flow_forecast_prior_transactions
+    cash_flow_statement_detail:
+      amount: Amount
+      cashflow_in: Cash Flow In
+      cashflow_out: Cash Flow Out
+      contact: Contact
+      customer: Customer
+      customer_receipts: Customer Receipts
+      customer_refunds: Customer Refunds
+      filename: cash_flow_statement_detail
+      interest_charges_in: Interest/Charges In
+      interest_charges_out: Interest/Charges Out
+      journals_in: Journals In
+      journals_out: Journals Out
+      no_data: You do not have any %{type} transactions based on the current filter
+        selection.
+      no_data_title: There is nothing to show.
+      other_payment_refunds: Other Payment Refunds
+      other_payments: Other Payments
+      other_receipt_refunds: Other Receipt Refunds
+      other_receipts: Other Receipts
+      payment_date: Payment Date
+      receipt_date: Receipt Date
+      reference: Reference
+      revenue_payments: Revenue Payments
+      staff_payments: Staff Payments
+      supplier: Supplier
+      supplier_payments: Supplier Payments
+      supplier_refunds: Supplier Refunds
+      tax_payments: VAT Payments
+      tax_reclaims: VAT Reclaims
+      total: Total
+      transfers_in: Transfers/Deposits In
+      transfers_out: Transfers/Deposits Out
+    cash_flow_summary:
+      closing_balance: Closing Balance
+      current_vat_liability: VAT Liability for current period*
+      current_vat_liability_text: "* Current VAT Liability is estimate only, VAT period
+        not closed"
+      description: Use this report to analyse your cash flow in and cash flow out
+        for current periods.
+      filename: cash_flow_statement
+      flat_rate_current_vat_liability_text: "* Current VAT Liability is estimate only,
+        VAT period not closed. Based on Standard Scheme, Flat rate calculation will
+        differ."
+      graph:
+        balance: Balance
+        inbound_cashflow: Cash Flow In
+        outbound_cashflow: Cash Flow Out
+      inbound_cashflow: Cash Flow In
+      inbound_cashflow_balance: Total Cash Flow In
+      liability_title: Liability to offset
+      liability_total: Total Liability
+      net_balance: Net Balance
+      opening_balance: Opening Balance
+      outbound_cashflow: Cash Flow Out
+      outbound_cashflow_balance: Total Cash Flow Out
+      payroll_vat_liability: Payroll Taxes
+      period_cashflow: Cash Flow for period
+      previous_vat_liability: VAT Liability for previous period
+      title: Cash Flow Statement Report
+      view_detailed_breakdown: Detailed
+    cash_reports:
+      cash_flow_forecast_title: Cash Flow Forecast
+      cash_flow_summary_title: Cash Flow Statement
+      cashbook_title: Cashbook Report
+      description: Help you to manage your money and understand your cash flow.
+      receipts_and_payments_day_book_title: Receipts and Payments Day Book
+      title: CASH REPORTS
+      unallocated_payments_title: Unallocated Receipts or Payments
+      unreconciled_bank_transactions_title: Unreconciled Bank Transactions
+    cashbook:
+      buttons:
+        apply: Calculate
+        csv: CSV
+        export: Export
+        pdf: PDF
+      columns:
+        balance: Balance
+        contact: Contact
+        currency: Currency
+        date_entered: Date Entered
+        method: Method
+        money_in: Money In (%{currency}) %{currency_symbol}
+        money_out: Money Out (%{currency}) %{currency_symbol}
+        reference: Reference
+        transaction_date: Transaction Date
+        transaction_number: Trx
+        type: Type
+      filename: cashbook
+      filter:
+        bank_account: Bank Account
+        end_date: To
+        reporting_period: Period
+        start_date: From
+      grid:
+        closing_balance: Closing Balance
+        movement: Movement
+        opening_balance: Opening Balance
+        totals: TOTALS
+      messages:
+        max_date_range_error: Choose two dates that are less than a year apart
+    chart_of_accounts:
+      description: Use this report to view and export a list of your ledger accounts.
+      filename: chart_of_accounts
+      title: Chart of Accounts List
+    corrections:
+      create:
+        error_header: Corrections not available
+        error_message: Sorry. We've had to switch Corrections off while we do some
+          work. We'll turn things back on as soon as we can.
+      search:
+        error_header: We can't show these transactions right now
+        error_message: We'll soon get this sorted. Try again in a short while and
+          we can forget this ever happened.
+      toast_error_message: Sorry. We've had to switch corrections off while we do
+        some work. We'll turn things back on as soon as we can.
+    customer_activity:
+      filename: customer_activity
+      no_records: No activity for the selected date range
+      report_name: customer_activity
+      title: Customer Activity Report
+    customer_addresses:
+      filename: customer_addresses
+      no_records: No addresses for the selected customers and address types
+      report_name: customer_addresses
+      title: Customer Address List
+    customer_statement_summary:
+      filename: customer_statement_summary
+      no_records: No activity for the selected date range
+      report_name: customer_statement_summary
+      title: Statement Summary Report
+    customer_statements_batch:
+      no_records: No activity for the selected date and outstanding amount
+      report_name: customer_statements
+      title: Statements Batch Report
+    datev_export:
+      dialog:
+        coming_soon: COMING SOON
+        description: You can export your audit trail into the DATEV format. Please
+          note that the period needs to be within one calendar year.
+        fields:
+          account_labels: Account labels
+          button_text: Export
+          creditor_debtor: Creditor and debtor
+          end_date: End date
+          export_sum: Also export trail balance report
+          start_date: Start date
+        title: DATEV export
+      no_data_available: No transactions available for the given period
+    detail_reports:
+      audit_trail_selector_title: Audit Trail
+      chart_of_accounts_title: Chart of Accounts
+      description: Detailed lists for you to review, or export and analyse.
+      invoice_profit_analysis_title: Profit Analysis
+      nominal_activity_title: Nominal Activity
+      purchase_day_book_title: Purchase Day Book
+      sales_day_book_title: Sales Day Book
+      sales_revenue_title: Sales Revenue - Products & Services
+      title: DETAILED REPORTS
+      trial_balance_title: Trial Balance
+    ec_sales:
+      contact_name: Customer
+      contact_tax_number: VAT Number
+      country_code: Country Code
+      date: Date
+      description: This report shows all EC Sales transactions within a specified
+        period. Use this report to help you complete your EC Sales List on HMRC's
+        website.
+      filename: ec_sales
+      goods_amount: Goods and Related Services
+      include: Include
+      no_tax_number: Not available
+      reference: Reference
+      services_amount: Standalone Services
+      title: EC Sales List
+      total: Total
+      transaction_type: Type
+      triangulated_goods_amount: Triangulated Goods
+    export_dialog:
+      audit_trail_breakdown:
+        download: Audit Trail Breakdown (%{file_type})
+      audit_trail_summary:
+        download: Audit Trail (%{file_type})
+      auxiliary_balance:
+        download: Auxiliary balance (%{file_type})
+      balance_sheet:
+        download: Balance Sheet (%{file_type})
+      balance_statement:
+        download: Balance Sheet (%{file_type})
+      chart_of_accounts:
+        download: Chart of Accounts List (%{file_type})
+      default:
+        download: Report (%{file_type})
+      description: To generate a new report, based on the latest selection criteria
+        you’ve specified, choose the format you want to use.  Depending on the amount
+        of data included on the report, it may take some time to generate.
+      detailed_receipts_and_payments_day_book:
+        download: Detailed Receipts and Payments Day Book (%{file_type})
+      filename: "%{file_name}.%{file_type}"
+      filesize: "%{file_size}"
+      income_statement:
+        download: Income Statement (%{file_type})
+      ledger_entries:
+        download: Ledger Entries (%{file_type})
+      legal_certificate:
+        download: Legal Certificate (%{file_type})
+      message:
+        export_all_warning: Are you sure you want to export all accounts?
+      nominal_activity:
+        download: Nominal Activity (%{file_type})
+      nominal_activity_detail:
+        download: Nominal Activity Detail (%{file_type})
+      nominal_activity_transaction:
+        download: Nominal Activity Detailed (%{file_type})
+      other_expense_payment_detailed_report:
+        download: Other Payment Detailed Report (%{file_type})
+      other_income_payment_detailed_report:
+        download: Other Receipt Detailed Report (%{file_type})
+      overseas_purchase_of_goods:
+        download: Overseas Purchase of Goods (%{file_type})
+      overseas_sales_of_goods:
+        download: Overseas Sale of Goods (%{file_type})
+      previous_reports: The following report(s) have already been generated and can
+        be accessed immediately.
+      purchase_day_book:
+        download: Purchase Day Book (%{file_type})
+      purchase_day_book_detailed:
+        download: Purchase Day Book - Detailed (%{file_type})
+      receipts_and_payments_day_book:
+        download: Receipts and Payments Day Book (%{file_type})
+      sales_day_book:
+        download: Sales Day Book (%{file_type})
+      sales_day_book_detailed:
+        download: Sales Day Book - Detailed (%{file_type})
+      sales_revenue:
+        download: Product & Service Sales Revenue (%{file_type})
+      sales_revenue_detailed:
+        download: Sales Revenue Detailed - Products & Services (%{file_type})
+      stock_movements:
+        download: Stock Movements (%{file_type})
+      stock_movements_detailed:
+        download: Stock Movements Detailed (%{file_type})
+      title:
+        audit_trail_breakdown: Generate Audit Trail Breakdown Report
+        audit_trail_summary: Generate Audit Trail Report
+        auxiliary_balance: Auxiliary balance report
+        balance_statement: Generate Balance Sheet Report
+        chart_of_accounts: Generate Chart Of Accounts List
+        detailed_receipts_and_payments_day_book: Generate Detailed Receipts and Payments
+          Day Book Report
+        income_statement: Generate Income Statement Report
+        ledger_entries: Export Ledger Entries
+        legal_certificate: Export Legal Certificate
+        nominal_activity: Generate Nominal Activity Report
+        nominal_activity_detail: Generate Detailed Nominal Activity Report
+        nominal_activity_transaction: Generate Detailed Nominal Activity Report
+        other_expense_payment_detailed_report: Generate Other Payment Detailed Report
+        other_income_payment_detailed_report: Generate Other Receipt Detailed Report
+        overseas_purchase_of_goods: Export Overseas Purchase of Goods
+        overseas_sales_of_goods: Export Overseas Sale of Goods
+        purchase_day_book: Generate Purchase Day Book Report
+        purchase_day_book_detailed: Generate Purchase Day Book Detailed Report
+        receipts_and_payments_day_book: Generate Receipts and Payments Day Book Report
+        receipts_and_payments_detailed_day_book: Generate Receipts and Payments Day
+          Book Report
+        sales_day_book: Generate Sales Day Book Report
+        sales_day_book_detailed: Generate Sales Day Book Detailed Report
+        sales_revenue: Generate Sales Revenue - Products & Services Report
+        sales_revenue_detailed: Generate Sales Revenue Detailed - Products & Services
+          Report
+        stock_movements: Generate Stock Movements Report
+        stock_movements_detailed: Generate Stock Movements Detailed Report
+        tax_returns: Generate Detailed %{tax_name} Report
+        unallocated_payments: Generate Unallocated Receipts or Payments Report
+        vat_return_detailed: Generate Vat Return Detailed Report
+      unallocated_payments:
+        download: Unallocated Payments Report (%{file_type})
+      unallocated_receipts:
+        download: Unallocated Receipts Report (%{file_type})
+      vat_return_detailed:
+        download: Vat Return Detailed Report (%{file_type})
+    export_dialog_with_advanced_filter:
+      description: To generate a new export, select a period and choose the format
+        you want to use. Depending on the amount of data included in the export, it
+        may take some time to generate.
+      previous_reports: The following export(s) have already been generated and can
+        be accessed immediately.
+    file_titles:
+      detailed_csv: Detailed CSV
+      detailed_pdf: Detailed PDF
+      payments: Payments
+      receipts: Receipts
+    gdpr:
+      contact_personal_data_title: Contacts Personal Data
+      description: Help you manage the personal data of your contacts
+      title: DATA REPORTS
+    general:
+      created_by_on: Created by %{user} on %{date}
+      page_count: Page <span id='pagenumber'></span> of <span id='pagecount'></span>
+      produced_by_sage_one: Produced by Sage Business Cloud %{service_name}
+      user_who_generated_report: 'Who: %{user}'
+    income_statement:
+      name: income_statement
+    index_descriptions:
+      aged_creditors: Who do I owe money to?
+      aged_debtors: Who owes money to me?
+      audit_trail_selector: What took place during a specified date range?
+      auxiliary_balance: What is the balance for each sub account?
+      balance_sheet: How much are my assets and liabilities worth?
+      balance_statement: How much is my business worth?
+      cash_flow_forecast: How much cash in and out should I expect?
+      cash_flow_summary: How much actual cash came in and out?
+      cashbook: What are the transactions and running balance for a selected bank
+        account?
+      chart_of_accounts: What ledger accounts are set up?
+      contact_personal_data: Which contacts' personal data can now be removed?
+      datev_export: Export your journal entries to the DATEV format.
+      ec_sales: Help me complete my EC Sales List
+      income_statement: How profitable was my business this period?
+      invoice_profit_analysis: How much profit did I make on each of my sales?
+      ledger_entries: Export raw data for all my accounting activity.
+      modelo_390: Calculate my Annual VAT return
+      nominal_activity: What transactions took place for each ledger account?
+      overseas_purchase_of_goods: Help me understand my imports, and enable me to
+        reconcile my VAT return
+      overseas_sales_of_goods: Help me understand my exports, and enable me to reconcile
+        my VAT return
+      post_migration_tasks: Download important documents from your previous service.
+      profit_and_loss: How much profit have I made?
+      purchase_day_book: What were my purchases?
+      receipts_and_payments_day_book: What payments did I send and receive?
+      saft: Export data for a selected financial year for an accountant, auditor,
+        or tax authority
+      sage_pay_ecommerce_payments: Which ecommerce payments did I receive through
+        Sage Pay?
+      sage_pay_payments: Which invoice payments did I receive through Sage Pay?
+      sales_day_book: What were my sales?
+      sales_revenue: What was my revenue from sales of products and services?
+      sales_tax: How much sales tax do I owe?
+      stock_movements: What stock items came in and out during a given period?
+      tax_return: Calculate my VAT return
+      trial_balance: What is the balance for each ledger account?
+      unallocated_payments: What transactions haven't been allocated to invoices?
+      unreconciled_bank_transactions: What transactions haven't been matched?
+      vendors: How much have I paid my 1099 Vendors?
+    index_dropdown:
+      all_reports: All Reports
+      favorites: Favourites
+      got_it: Got it
+      notification_text_sage_intelligence: 'Make smart business decisions - '
+      preview_sage_intelligence: Preview Sage Intelligence
+      sage_intelligence: Sage Intelligence
+      sage_intelligence_normal_text: create and customise reports in just a few clicks.
+    index_sub_descriptions:
+      aged_creditors: 'Shows: Outstanding or unallocated supplier transactions by
+        age.'
+      aged_debtors: 'Shows: Outstanding or unallocated customer transactions by age.'
+      audit_trail_selector: 'Shows: All transactions posted for a specified date range.'
+      auxiliary_balance: 'Shows: The balances of your main debtors and creditors accounts,
+        broken down by individual customers and suppliers.'
+      balance_sheet: 'Shows: Assets, liabilities, and equity, up to a given date.'
+      balance_statement: 'Shows: Fixed and current assets, equity, and debts, up to
+        a given date.'
+      cash_flow_forecast: 'Shows: Funds that might come in and out, using expected
+        payment dates.'
+      cash_flow_summary: 'Shows: Funds that came in and out, for a selected period,
+        and selected bank accounts.'
+      cashbook: 'Shows: Receipts, payments and balances for a selected bank account.'
+      chart_of_accounts: 'Shows: A list of your ledger accounts, their category, and
+        tax rate.'
+      contact_personal_data: 'Shows: A list of contacts that is now outside of your
+        business data retention period.'
+      datev_export: Export to DATEV format
+      ec_sales: Helps you complete your EC Sales List on the HMRC website.
+      income_statement: 'Shows: Income and expenses for a given date range.'
+      invoice_profit_analysis: 'Shows: Profit made on sales invoices, credit notes,
+        quotes, and estimates, using product cost and sales prices.'
+      ledger_entries: Export raw data for all your accounting activity.
+      modelo_390: View and submit an Annual VAT return online.
+      nominal_activity: 'Shows: Balances for each ledger account for a given date
+        range.'
+      overseas_purchase_of_goods: All purchase transactions from the EU and the Rest
+        of World
+      overseas_sales_of_goods: All sale transactions from the EU and the Rest of World
+      post_migration_tasks: Sales PDFs from your previous service, and important upgrade
+        tasks
+      profit_and_loss: 'Shows: Income, expense, and profit, for a given date range.'
+      purchase_day_book: 'Shows: Purchase invoices and credit notes for a given date
+        range.'
+      receipts_and_payments_day_book: 'Shows: Payments and receipts for a selected
+        bank account and date range.'
+      saft: Standard Audit File for Tax export.
+      sage_pay_ecommerce_payments: 'Shows: Payments received for a given date range.'
+      sage_pay_payments: 'Shows: Payments received for a given date range.'
+      sales_day_book: 'Shows: Sales invoices and credit notes for a given date range.'
+      sales_revenue: 'Shows: Sales Revenue for products and services for a given date
+        range'
+      sales_tax: 'Shows: Total sales tax due for each tax rate.'
+      stock_movements: 'Shows: Summary stock movements for a given date range.'
+      tax_return: View and submit a VAT return online to HMRC.
+      trial_balance: 'Shows: Balance for each of your ledger accounts, for a given
+        date range.'
+      unallocated_payments: 'Shows: Transactions from contacts that aren''t fully
+        allocated to invoices.'
+      unreconciled_bank_transactions: 'Shows: Unreconciled transactions for a selected
+        bank account, up to a given date.'
+      vendors: 'Shows: Your total payments for each of your 1099 Vendors for the year,
+        to help you fill out a 1099 Misc Form when this is required.'
+    invoice_profit_analysis:
+      all: All
+      cost: Cost
+      cost_price_warning: "*Cost price is not available for one or more line items,
+        therefore profit may not be accurate."
+      customer: Customer name
+      date: Date
+      description: This report analyses the profit on your sales invoices and quotations
+        using the cost price and sales price of your products.
+      detailed: Show details
+      filename: profit_analysis
+      filename_detailed: profit_analysis_detailed
+      filename_summary: profit_analysis_summary
+      from_date: From
+      include: 'Include:'
+      included:
+        all: All
+        invoices_credit_notes: Invoices / Credit Notes
+        quotes: Quotes / Estimates
+      invoice_credit_note: Number
+      net: Net
+      profit_amount: Profit (Amt)
+      profit_percentage: Profit (%)
+      quantity: Qty/Hrs
+      quote_exp_date: Exp. Date
+      search: Search
+      summary_detailed:
+        detailed: Detailed report
+        summary: Summary report
+      title: Profit Analysis Report
+      title_detailed: Profit Analysis Detailed Report
+      title_summary: Profit Analysis Report
+      to_date: To
+      total: TOTAL
+    journal:
+      journal_title: Journal
+    ledger_entries:
+      fields:
+        artefact_number: Artefact Number
+        auxiliary_account: Auxiliary Account
+        base_currency_code: Currency
+        cr: Credit
+        credit: Credit
+        date: Date
+        debit: Debit
+        dr: Debit
+        journal_code: Journal Code
+        nominal_code: Nominal Code
+        reference: Reference
+        transaction_number: Trx No
+      filename: ledger_entries
+      ledger_entries: Ledger Entries
+    legal_certificate:
+      antifraud:
+        filename: certificate_antifraud
+    management:
+      aged_creditors_title: Aged Creditors
+      aged_debtors_title: Aged Debtors
+      auxiliary_balance_title: Auxiliary Balance
+      balance_sheet_title: Balance Sheet
+      balance_statement_title: Balance Sheet
+      description: For you and your accountant, to understand the current state of
+        your business.
+      income_statement_title: Income Statement
+      profit_and_loss_title: Profit and Loss
+      title: ESSENTIAL REPORTS
+      trial_balance_title: Trial Balance
+    new_report_version_feeback_link: We'd love your feedback <span class='link_grey_part'>on
+      this beta report.</span>
+    new_report_version_link: We are working on improvements - try the <span class='beta_version'>BETA</span>
+      version.
+    nominal_activity:
+      category: Category
+      closing_balance: Closing Balance
+      description: This is where you can view your Nominal Activity Report.
+      filename: nominal_activity
+      ledger_account: Ledger Account
+      opening_balance: Opening Balance
+      other_contact_name: Others
+      period_variance: Period Variance
+      status:
+        active: Exclude deleted
+        all: All
+        deleted: Deleted only
+        status: Status
+      title: Nominal Activity Report
+      totals: Totals
+      transaction_type: Transaction Type
+    nominal_activity_detail:
+      filename: nominal_activity_detail
+    nominal_activity_transaction:
+      credit: Credit
+      date: Date
+      debit: Debit
+      description: Description
+      filename: nominal_activity_detailed
+      invoice_number: Inv No
+      journal_code_code: Jrn Code
+      name: Name
+      reference: Reference
+      running_total: Running Total
+      transaction_number: Trx
+      transaction_type: Type
+    online_payment:
+      description: From Paya
+      index_description: Which payments took place using Paya?
+      index_sub_description: Links you to credit card reports in the Paya Virtual
+        Terminal.
+      title: ONLINE PAYMENT REPORTS
+    overseas_goods:
+      purchases:
+        columns:
+          charged_vat: Charged VAT
+          date: Date
+          estimated_vat: Estimated VAT
+          invoice_total: Total
+          name: Name
+          net: Net
+          rate: VAT Rate
+          reference: Reference
+          transaction_id: Trx No
+          type: Type
+        eu_section_header: EU Purchases
+        filename: overseas_purchase_goods
+        import_invoices_section_header: Import Invoices
+        row_section_header: Rest of World Purchases
+      sales:
+        columns:
+          charged_vat: VAT
+          contact_reference: Contact Reference
+          date: Date
+          invoice_total: Total
+          name: Name
+          net: Net
+          rate: VAT Rate
+          reference: Invoice Number
+          transaction_id: Trx No
+          type: Type
+        eu_section_header: EU Sales
+        filename: overseas_sale_goods
+        import_invoices_section_header: Import Invoices
+        row_section_header: Rest of World Sales
+    post_migration_tasks:
+      archiving: Invoices ZIP
+      description: Important information for upgraded businesses
+      pending: Generating reports, please return later...
+      post_migration_tasks_title: Devis-Factures & Compta Simplifiée Reports
+      post_upgrade_tasks: Upgrade Tasks PDF
+      quotes: Quotes ZIP
+      title: Devis-Factures & Compta simplifiée reports
+    products_services_reports:
+      description: Help you understand stock levels.
+      stock_movements_title: Stock Movements
+      title: PRODUCTS & SERVICES REPORTS
+    profit_and_loss:
+      all_analysis_types: All Analysis Types
+      balance_sheet_message:
+        link_text: " Record and Transactions Settings"
+        message: Postings to Profit and Loss Account were included in the Balance
+          Sheet profit calculation. To view this value separately, change the 'Show
+          Profit and Loss Account value' setting in
+        title: Profit and Loss Account included
+      by_month: By Month
+      by_quarter: By Quarter
+      compare_with: Compare with
+      csv:
+        category: Category
+        code: Code
+        cumulative_values: Cumulative Values
+        'false': 'No'
+        name: Name
+        title: Profit and Loss
+        'true': 'Yes'
+        year: Year
+      description: This report shows your business income and expense, giving the
+        profit for your chosen date range.
+      direct_expenses: Direct Expenses
+      direct_expenses_title: Direct Expenses
+      filename: profit_and_loss
+      financial_year: Financial Year %{financial_year}
+      gross_pl: GROSS PROFIT / LOSS
+      hide_percentage: Show No %
+      net_pl: NET PROFIT / LOSS
+      overheads: Overheads
+      overheads_title: Overheads
+      percentage_each_section_tooltip: The value of each row as a percentage of the
+        total for each section
+      percentage_tooltip: Profit as a percentage of Sales Revenue
+      percentage_total_sales_tooltip: The value of each row as a percentage of total
+        sales
+      percentage_totals_footer:
+        each_section: "% Totals is the value of each nominal as a % of the category
+          total YTD."
+        total_sales: "% Sales is the value of each nominal as a % of the total sales
+          YTD."
+      profit_percentage: "% Profit"
+      quarter_title: Quarter
+      rounded_values_note: "<strong>NOTE:</strong> Values have been rounded to whole
+        numbers for clarity."
+      sales: Sales
+      sales_title: Sales
+      selector:
+        comparison: Comparison
+        financial_year: Financial Year
+      show_each_section_percentage: 'Show %: Profit and Total for Each Section'
+      show_total_sales_percentage: 'Show %: Profit and Total Sales'
+      title: Profit and Loss Report
+      total: Total
+      total_direct_expenses: Total Direct Expenses (%{currency})
+      total_gross_profit_or_loss: GROSS PROFIT/LOSS (%{currency})
+      total_gross_profit_or_loss_tooltip: The value of your sales, minus your expenses
+        (the cost of making a product or providing a service).
+      total_net_profit_or_loss: NET PROFIT/LOSS (%{currency})
+      total_net_profit_or_loss_tooltip: The value of your sales, minus your expenses
+        (the cost of making a product or providing a service), also minus your overheads
+        (like payroll, taxation, and interest). Whether your business earned more
+        than it spent.
+      total_overheads: Total Overheads (%{currency})
+      total_sales: Total Sales (%{currency})
+      totals: Totals
+      use_cumulative_values: Use cumulative values
+      values_up_to: Values up to
+    purchase_day_book:
+      analysis_type: Analysis Type
+      analysis_type_category: Analysis Category
+      description: This report shows purchase transactions for a specified date range.  You
+        can view a certain transaction type, or all of your purchase transactions,
+        listed in date order.
+      filename: purchase_day_book
+      link_to_detailed_report: Detailed
+      title: Purchase Day Book Report
+      transaction_type: Type
+    purchase_day_book_detailed:
+      filename: purchase_day_book_detailed
+      link_to_summary_report: Summary
+      title: Purchase Day Book - Detailed
+    receipts_and_payments_day_book:
+      bank_account: Account
+      description: This report shows receipt or payment transactions for a selected
+        bank account, for a specified date range.
+      filename: receipts_and_payments_day_book
+      payment_type_selector: Incomes/Expenses
+      payment_type_values:
+        expenses: Expenses
+        incomes: Incomes
+      title: Receipts and Payments Day Book Report
+      transaction_type: Type
+      transaction_type_group: Receipt/Payment
+      transaction_type_group_values:
+        all_types: All
+        payments: Payments
+        receipts: Receipts
+    receipts_and_payments_day_book_detailed:
+      no_tax_rate: No tax rate applied
+      title: "%{transaction_type} - Detailed Report"
+      total: Total
+    remote_reports:
+      archive: Archive
+      audit_trail_breakdown: Audit Trail Breakdown
+      audit_trail_summary: Audit Trail
+      auxiliary_balance: Auxiliary balance
+      balance_sheet: Balance Sheet
+      balance_statement: Balance Sheet
+      chart_of_accounts: Chart of Accounts
+      customer_activity: Customer Activity
+      customer_addresses: Customer Address List
+      customer_statement_summary: Customer Statement Summary
+      customer_statements: Customer Statements
+      income_statement: Income Statement
+      ledger_account_export: Chart of Accounts Export
+      ledger_entries: Ledger Entries
+      legal_certificate: Legal Certificate
+      nominal_activity: Nominal Activity
+      nominal_activity_detail: Nominal Activity Detailed
+      nominal_activity_detailed: Nominal Activity Detailed
+      other_expense_payment_detailed_report: Other Payments Detailed
+      other_income_payment_detailed_report: Other Receipts Detailed
+      overseas_purchase_of_goods: Overseas Purchase of Goods
+      overseas_sales_of_goods: Overseas Sale of Goods
+      purchase_day_book: Purchase Day Book
+      purchase_day_book_detailed: Purchase Day Book - Detailed
+      receipts_and_payments_day_book: Receipts and Payments Day Book
+      saft: SAF-T
+      sales_day_book: Sales Day Book
+      sales_day_book_detailed: Sales Day Book - Detailed
+      sales_revenue: Sales Revenue - Products & Services
+      sales_revenue_detailed: Sales Revenue Detailed - Products & Services
+      stock_movements: Stock Movements
+      stock_movements_detailed: Stock Movements Detailed
+      supplier_activity: Supplier Activity
+      supplier_addresses: Supplier Address List
+      tax_return_detailed: Vat Return (Detailed)
+      unallocated_payments: Unallocated Payments
+      unallocated_receipts: Unallocated Receipts
+      url_not_available: Your report has not generated. Please either wait for it
+        to finish or try rerunning the report.
+      vat_return_detailed: Vat Return (Detailed)
+    reporting_period: Period
+    reporting_periods:
+      all_dates: All Dates
+      custom: Custom
+      difference: Difference
+      last_financial_year: Last Financial Year
+      last_month: Last Month
+      last_quarter: Last Quarter
+      last_year: Last Year
+      previous_period: Previous Period
+      previous_year: Previous Year
+      show_year_to_date: Show year-to-date
+      this_financial_year: This Financial Year
+      this_month: This Month
+      this_period: This Period
+      this_quarter: This Quarter
+      this_year: This Year
+      to_date: "%{year}-to-date"
+      year_to_date: Year-to-date
+    saft:
+      errors:
+        missing_ledger_account: DELETED
+      fields:
+        allocation_code: EcritureLet
+        allocation_date: DateLet
+        artefact_reference: Artefact Reference
+        auxiliary_account: CompAuxNum
+        auxiliary_name: CompAuxLib
+        contact_id: IdClient
+        creation_date: Creation Date
+        credit: Credit
+        currency_amount: Montantdevise
+        currency_code: Idevise
+        debit: Debit
+        journal_code: JournalCode
+        journal_name: JournalLib
+        ledger_account_display_name: Account Name
+        ledger_account_nominal_code: Nominal Code
+        payment_date: DateRglt
+        payment_mode: ModeRglt
+        transaction_date: Transaction Date
+        transaction_number: Transaction Number
+        transaction_reference: Transaction Reference
+        transaction_type: NatOp
+        validation_date: Validation Date
+      filename: SAFT
+      saft: Standard Audit File for Tax
+    sage_intelligence_link:
+      link_text: Sage Intelligence
+      text: 'Create your own report like this - preview '
+    sage_pay:
+      description: From Sage Pay
+      sage_pay_ecommerce_payments_title: Ecommerce Payments
+      sage_pay_payments_title: Payments Received
+      title: ONLINE PAYMENTS REPORTS
+    sage_pay_ecommerce_payments:
+      contact: Name
+      date: Date
+      description: This is where you can view imported Sage Pay ecommerce payments.
+      filename: sage_pay_ecommerce_payments
+      net: Net
+      reference: Reference
+      tax: VAT
+      title: Ecommerce Payments
+      total: Total
+      transaction_type: Type
+    sage_pay_payments:
+      allocated_amount: Allocated Amount
+      amount: Payment Amount
+      associated_transaction: Transaction
+      date: Payment Date
+      description: This is where you can view invoice payments received via Sage Pay.
+      filename: sage_pay_payments
+      other_income_payment: Other Income Receipt
+      payment_on_account: Payment On Account
+      reference: Reference
+      title: Payments Received
+    sales_batch_entries:
+      filename: sales_quick_entries
+    sales_day_book:
+      analysis_type: Analysis Type
+      analysis_type_category: Analysis Category
+      description: This report shows sales transactions for a specified date range.  You
+        can view a certain transaction type, or all of your sales transactions, listed
+        in date order.
+      filename: sales_day_book
+      link_to_detailed_report: Detailed
+      title: Sales Day Book Report
+      transaction_type: Type
+    sales_day_book_detailed:
+      filename: sales_day_book_detailed
+      link_to_summary_report: Summary
+      title: Sales Day Book - Detailed
+    sales_invoices_and_credit_notes_batch:
+      filename: sales_invoices_and_credit_notes
+    sales_revenue:
+      access_level_warning: Your access level does not give you permission to view
+        Profit information.
+      all_categories: All Categories
+      all_types: All Types
+      category_name: 'Category: %{category_name}'
+      cost: Cost
+      cost_price_warning: "*Cost price is not available for one or more items, therefore
+        the profit may not be accurate."
+      date: Date
+      detailed: Detailed
+      filename: sales_revenue_products_services
+      invoice_number: Invoice No.
+      item_code: Item Code
+      item_description: Item Description
+      name: Name
+      net: Net
+      profit: Profit
+      profit_percentage: Profit (%)
+      quantity: Qty/Hrs
+      summary: Summary
+      total: Total
+      transaction_number: Trx No.
+      type: Type
+      type_name: 'Type: %{type_name}'
+      unit_price: Unit Price
+    sales_revenue_detailed:
+      access_level_warning: Your access level does not give you permission to view
+        Profit information.
+      all_categories: All Categories
+      all_types: All Types
+      category_name: 'Category: %{category_name}'
+      cost: Cost
+      cost_price_warning: "*Cost price is not available for one or more items, therefore
+        the profit may not be accurate."
+      date: Date
+      detailed: Detailed
+      filename: sales_revenue_detailed_products_services
+      invoice_number: Invoice No.
+      item_code: Item Code
+      item_description: Item Description
+      name: Name
+      net: Net
+      profit: Profit
+      profit_percentage: Profit (%)
+      quantity: Qty/Hrs
+      summary: Summary
+      total: Total
+      transaction_number: Trx No.
+      type: Type
+      type_name: 'Type: %{type_name}'
+      unit_price: Unit Price
+    sales_tax:
+      agency: Agency
+      csv_filename: sales_tax
+      customer: Customer
+      date: Date
+      description: This report shows a summary of your tax liabilities for your chosen
+        date range.
+      detailed_csv_filename: sales_tax_breakdown
+      from: From
+      grand_total: 'Total Liability:'
+      item_description: Description
+      link_to_breakdown: View Detailed
+      link_to_summary: Summary
+      net_output: Net Output
+      number: Number
+      order_id: Order ID
+      origin_city: Origin City
+      origin_line1: Origin Line 1
+      origin_line2: Origin Line 2
+      origin_state: Origin State
+      origin_zip: Origin Zip
+      percentage: Percentage
+      popover_button: Got it
+      reference: Reference
+      sales: Sales
+      sales_tax: Sales Tax
+      shipping: Shipping
+      shipping_city: Shipping City
+      shipping_line1: Shipping Line 1
+      shipping_line2: Shipping Line 2
+      shipping_state: Shipping State
+      shipping_tax: Shipping Tax
+      shipping_zip: Shipping Zip
+      tax: Tax
+      tax_authority: Tax Authority
+      tax_exempt: Tax Exempt
+      tax_output: Tax Output
+      tax_rate: Tax Rate
+      taxable_sales: Taxable Sales
+      title: Sales Tax Report
+      total: TOTALS
+      totals_tax_authorities: 'TOTAL: ALL AUTHORITIES'
+      type: Type
+      until: Until
+    stock_movements:
+      all_categories: All Categories
+      category_name: 'Category: %{category_name}'
+      cost_price_warning: "*Cost price is not available for one or more items, therefore
+        the value out may not be accurate."
+      filename: stock_movements
+      id: Id
+      item_code: Item Code
+      item_description: Item Description
+      quantity_in: Quantity In
+      quantity_out: Quantity Out
+      total: Total
+      value_in: Value In
+      value_out: Value Out
+    stock_movements_detailed:
+      adjustment_in: Adj In
+      adjustment_out: Adj Out
+      cost_price_warning: "*Cost price is not available for this item, therefore the
+        value out may not be accurate."
+      date: Date
+      details: Details
+      filename: stock_movements_detailed
+      goods_in: In
+      goods_out: Out
+      invoice_number: Invoice No.
+      quantity_in: Quantity In
+      quantity_out: Quantity Out
+      reference: Reference
+      total: Total
+      type: Type
+      value_in: Value In
+      value_out: Value Out
+    summary:
+      cashflow_forecast:
+        title: Cash Flow Forecast
+      cashflow_statement:
+        title: Cash Flow Statement
+      current_account:
+        acc_number: Account Number
+        balance: Current Balance
+      customers_by_invoices:
+        add_new_sales_invoice: Add a new sales invoice.
+        all_other_customers: All other customers...
+        report_types:
+          outstanding: Outstanding
+          overdue: Overdue
+      customers_by_outstanding_invoices:
+        no_data_message: No customers have outstanding balances.
+        title: Customers by outstanding invoices
+      customers_by_overdue_invoices:
+        no_data_message: No customers have overdue balances.
+        title: Customers by overdue invoices
+      day: Day
+      due_in: Due in
+      expenses: Expenses
+      general:
+        days: Days
+        due: Due
+        from_before_this_period: From before this period
+        loading: Fetching data...
+        more: more...
+        no_vat_return: A VAT return has not yet been run.
+        overdue: Overdue
+        payable: Payable
+        reclaimable: Reclaimable
+        run_vat_return: Run VAT Return
+        so_far_this_period: So far this period
+        vat_period_ends_in: VAT period ends in
+        vat_returns: VAT Returns
+      getting_started:
+        bank_accounts:
+          link: Set up and connect your online bank accounts
+          title: Connect bank accounts
+        chart_of_accounts:
+          opening_balances: Enter opening account balances
+          results: Review the Trial Balance report
+          title: Set up chart of accounts
+          view: Review the standard chart of accounts
+        check_figures:
+          aged_creditors:
+            link: Aged creditors report
+            tooltip: View outstanding supplier transactions.
+          aged_debtors:
+            link: Aged debtors report
+            tooltip: 'View outstanding customer transactions. '
+          nominal_activity:
+            link: Nominal activity report
+            tooltip: View transactions on your ledger accounts.
+          title: 'Check your figures:'
+          trial_balance:
+            link: Trial balance report
+            tooltip: View the balance on your ledger accounts.
+        customers:
+          import: Create or import customers
+          money: Enter money customers owe to you
+          results: Review the Aged Debtors report
+          title: Set up customers
+        hide_getting_started:
+          link_text: Hide Getting Started
+          text: Don't want to see this 'getting started' panel anymore?
+        optional_extras:
+          about_your_business:
+            subtext: Record key pieces of information about your business
+            text: Enter information about your business
+          analysis_types:
+            link: Set your Analysis Categories
+            tooltip: Set up Analysis Types and categories to analyse your information.
+          business_logo:
+            subtext: Add your logo and payment terms
+            text: Want to customise your invoices?
+          colleagues:
+            subtext: Invite others to work with your information.
+            text: Do you work with colleagues?
+          default_settings:
+            link: Choose your default settings and preferences
+            subtext: Maximise your productivity
+            text: Review default settings and preferences
+            tooltip: Choose preferences to apply when creating records and transactions.
+          foreign_currency:
+            subtext: Enable foreign currency transactions
+            text: Do you buy or sell in foreign currencies?
+          products_services:
+            subtext: Create or import details for super fast sales
+            text: Do you sell products, or services?
+          projects:
+            subtext: Set them up, for powerful business analysis
+            text: Do you have departments, cost codes, or projects?
+          title:
+            subtext: More customisation settings.
+            text: Optional extras
+          user_managements:
+            link: Set up users
+            tooltip: Create and manage the users you want to access Accounting.
+        setup_opening_balances:
+          bank_opening_balances:
+            link: Enter bank account opening balances
+            tooltip: Enter bank account balances from your previous accounting system.
+          nominal_opening_balances:
+            link: Enter nominal account opening balances
+            tooltip: Record the balances of your ledger accounts from your previous
+              accounting system.
+          outstanding_customer:
+            link: Enter outstanding customer transactions
+            tooltip: Record outstanding customer transactions from your previous accounting
+              system.
+          outstanding_supplier:
+            link: Enter outstanding supplier transactions
+            tooltip: Record supplier transactions from your previous accounting system.
+          title: 'Setting up opening balances:'
+        setup_records:
+          bank_accounts:
+            icon: pound
+            link: Set up bank accounts
+            tooltip: Create records for the bank accounts, including credit card and
+              loan accounts that your business holds.
+          customer_records:
+            link: Set up customer records
+            tooltip: Create records for the customers who buy from you regularly.
+          products_services:
+            link: Set up your products and services
+            tooltip: Set up records for the products and services you sell.
+          supplier_records:
+            link: Set up supplier records
+            tooltip: Create records for the suppliers you use regularly.
+          title: 'Setting up your records:'
+        suppliers:
+          import: Create or import suppliers
+          money: Enter money you owe to suppliers
+          results: Review the Aged Creditors report
+          title: Set up suppliers
+        title: Getting Started
+      index:
+        your_summary_screen: This is your summary screen
+      micro:
+        bank_balance: Bank Balance
+        banking: Banking
+        email_us: E-mail us
+        expense: Expenses
+        income: Sales
+        loss: Loss
+        need_some_help: Need some help?
+        new_expense: New Expense
+        new_income: New Sales
+        on_last_period: on last %{period}
+        period:
+          month: this month
+          year: this year
+        profit: Profit
+        read_helpful_articles: Read helpful articles
+        sage_one_balance: Balance
+        this_month: This month
+        this_period: this %{period}
+        this_year: This year
+        view: View
+      overdue: Overdue
+      profit: Profit
+      purchases:
+        analysis_graph:
+          net_total: Net Purchases
+        ledger_account_breakdown:
+          footnote: For last 30 days
+          other: Other
+          title: Breakdown by Ledger Account
+        outstanding_invoices: Outstanding Purchase Invoices
+        overdue_invoices:
+          link: Create new purchase invoice
+          text: No overdue purchase invoices
+          title: Overdue Purchase Invoices
+        title: Purchases
+        top_creditors:
+          text: You do not have any creditors at the moment.
+          title: Top 5 Creditors
+        top_suppliers:
+          footnote: For last 30 days
+          link: Create new supplier
+          text: You have not made any purchases in the last 30 days.
+          title: Top 5 Suppliers
+      quotes:
+        conv: Conversion in invoice
+        count: Number of open quotes and estimates
+        expire_in_1: Expire tomorrow
+        expire_in_n: Expire in
+        sum: Total net amount
+        title: Quotes and Estimates
+        top_5_open_quotes: Top 5 Open Quotes and Estimates
+      sales:
+        analysis_graph:
+          net_total: Net Sales
+        expired: Expired
+        lost: Lost
+        outstanding_invoices: Outstanding Sales Invoices
+        overdue_invoices:
+          link: Create new sales invoice
+          text: No overdue sales invoices
+          title: Overdue Sales Invoices
+        pending: Pending
+        quotes: Quotes & Estimates
+        title: Sales
+        top_customers:
+          footnote: For last 30 days
+          link: Create new customer
+          text: You have not had any sales in the last 30 days.
+          title: Top 5 Customers
+        top_debtors:
+          text: You do not have any debtors at the moment.
+          title: Top 5 Debtors
+        won: Won
+      sales_invoices_by_status:
+        no_invoices_message_1: 'As soon as you '
+        no_invoices_message_2: |-
+          ,
+           a breakdown of invoices will be shown here.
+        no_invoices_message_link: add an invoice
+        status:
+          current: Current
+          draft: Draft
+          overdue: Overdue
+        subtitle:
+          one: In %{count} invoice owed to you
+          other: In %{count} invoices owed to you
+      top_5_unpaid_sales_invoices: Top 5 Unpaid Sales Invoices
+      ytd: Year to Date
+    supplier_activity:
+      filename: supplier_activity
+      no_records: No activity for the selected date range
+      report_name: supplier_activity
+      title: Supplier Activity Report
+    supplier_addresses:
+      filename: supplier_addresses
+      no_records: No addresses for the selected suppliers and address types
+      report_name: supplier_addresses
+      title: Supplier Address List
+    switch_back_old_report: Switch back to the old report.
+    tax_reports:
+      datev_export_title: DATEV Export
+      description: Help you export, create VAT returns and EC Sales Lists.
+      ec_sales_title: EC Sales Analysis
+      ledger_entries_title: Ledger Entries Export
+      overseas_purchase_of_goods_title: Overseas Purchase of Goods
+      overseas_sales_of_goods_title: Overseas Sale of Goods
+      saft_title: SAF-T Export
+      sales_tax_title: Sales Tax Report
+      tax_return_title: VAT Return
+      title: VAT REPORTS AND EXPORTS
+      vendors_title: 1099 Vendor Report
+    tax_return_detail:
+      box_detail:
+        adjustment: Adjustment Amount
+        adjustment_reason: 'Adjustment Reason: '
+        amount: Amount
+        box_total: Total
+        category: Ledger Account
+        date: Date
+        name: Name
+        rate: Rate
+        reference: Reference
+        reverse_charge_total: Reverse Charge VAT
+        tax_rate_subtotal: 'Total for %{tax_rate}: '
+        titles:
+          box_1: Box 1 - VAT due in this period on sales and other outputs
+          box_2: Box 2 - VAT due in this period on acquisitions from other EC Member
+            States
+          box_3: Box 3 - Total VAT due (the sum of boxes 1 and 2)
+          box_4: Box 4 - VAT reclaimed in this period on purchases and other inputs
+            (including acquisitions from the EC)
+          box_5: Box 5 - Net VAT to be paid to Customs or reclaimed by you (Difference
+            between boxes 3 and 4)
+          box_6: Box 6 - Total value of sales and all other outputs excluding any
+            VAT. Include your box 8 figure
+          box_7: Box 7 - Total value of purchases and all other inputs excluding any
+            VAT. Include your box 9 figure
+          box_8: Box 8 - Total value of all supplies of goods and related services,
+            excluding any VAT, to other EC Member States
+          box_9: Box 9 - Total value of all acquisitions of goods and related services,
+            excluding any VAT, from other EC Member States
+        total: 'Total for Box '
+        transaction: TrxID
+        transaction_number: Number
+        transaction_type: Type
+        unadjusted_total: Transaction Total
+        vca_scheme_change_clearup: Prior Scheme Transfer
+        vca_scheme_change_clearup_flat_rate: Prior Scheme Transfer (Standard Liability
+          Shown - Box total will reflect your flat rate %)
+      box_name: BOX
+      from_date: 'VAT Detailed Report for Period '
+      include_prior_transactions: 'Note: This report includes transactions from prior
+        periods'
+      migrated: This VAT return is based on data migrated from your old accounting
+        system.
+      not_applicable: N/A
+      title: VAT Report (Detailed)
+      to_date: " to "
+    tax_return_detailed:
+      report_name: vat_return_detailed
+    tax_return_summary:
+      draft_tax_return: This is a draft VAT return and has yet to be submitted.
+      flat_rate_information:
+        flat_rate_difference: "%{difference_key} %{difference}"
+        flat_rate_difference_note: 'Note: These figures do not include any adjustments'
+        flat_rate_vat: Based on a flat rate of %{rate}% the actual VAT due is %{flat_rate_vat}
+        net_vat: On a Standard Scheme your VAT due would have been %{net_vat}
+        not_saved_money_using_flat_rate: Using a flat rate VAT scheme has cost you
+        saved_money_using_flat_rate: Using a flat rate VAT scheme has saved you
+        title: Flat Rate
+      from_date: 'From: '
+      include_prior_transactions: 'Includes prior transactions: '
+      payment_information:
+        headers:
+          amount: Amount
+          date: Date
+          reference: Reference
+      payment_summary: Payment Summary
+      reclaim_summary: Reclaim Summary
+      status_summary_tables:
+        payment_summary: Payment Summary
+        refund_summary: Refund Summary
+        submit_by_whom: " by %{submit_by}"
+        submit_date: Submitted %{submit_date}
+        title: Submission Summary
+      submission_information:
+        correlation_id: 'Correlation ID: %{correlation_id}'
+        status: "%{status} on "
+        title: Submission Summary
+      summary_report_period: 'VAT Return From: %{start_date} To: %{end_date}'
+      tax_registration_number: 'VAT Registration Number: %{country_code} %{tax_number}'
+      title: VAT Return
+      to_date: 'To: '
+      total_uppercased: TOTAL
+    trial_balance:
+      brought_forward:
+        credit: Credit
+        debit: Debit
+        title: Brought Forward
+      credits: Credits
+      debits: Total Debits
+      description: This report displays the balance on your nominal accounts for a
+        specified date range. You can include brought forward values and include current
+        year’s profit and loss values only.
+      filename: trial_balance
+      include_current_year_profit_and_loss: Summarise profit and loss values
+      ledger_account: Name
+      ledger_account_class_subtotal: TOTAL CLASS %{classification}
+      name: Name
+      nominal_code: Nominal Code
+      reporting_period:
+        credit: Credit
+        debit: Debit
+        title: Selected Period
+      show_brought_forward_label: Show Brought Forward values
+      this_period_only: This period only
+      title: Trial Balance
+      total: Total
+      totals:
+        credit: Credit
+        debit: Debit
+        title: Totals
+    unallocated_payments:
+      account_name_and_balance: "%{contact_name}, Account balance: %{balance}"
+      fields:
+        contact_name: Name
+        date: Date
+        reference: Ref
+        tax_rate_name: VAT Rate
+        total_amount: Total amount
+        unallocated_amount: Unallocated amount
+      payments: Unallocated payments
+      payments_filename: unallocated_payments
+      receipts: Unallocated receipts
+      receipts_filename: unallocated_receipts
+    unreconciled_bank_transactions:
+      account_balance: Account Balance
+      balance: Balance
+      bank_account: Bank
+      date: Date
+      description: This report shows all unreconciled bank transactions. You can view
+        these transactions by bank account up to a specified date.
+      end_date: To
+      filename: unreconciled_bank_transactions
+      name: Name
+      payment: Payment
+      receipt: Receipt
+      reconciled_balance: Reconciled Balance
+      reference: Reference
+      search: Search
+      title: Unreconciled Bank Transactions Report
+      total: Total
+      type: Type
+    vat_returns:
+      calculation_running: A VAT Return calculation is already running and should
+        be complete shortly. Please try again in a few minutes.
+      filename: summary_report
+    vendors:
+      buttons:
+        apply: Calculate
+        csv: CSV
+        export: Export
+        pdf: PDF
+      columns:
+        address: Address
+        business_name: Business Name
+        tax_id: Vendor Tax ID
+        total_payments: Total Payments
+      filename: 1099_vendors
+      filter:
+        search: Type to search
+        year: Calendar Year
+        year_label: "%{year} Calendar Year"
+  resource_suggest_create:
+    contacts:
+      create: Add a contact
+      label: Contact
+      search: Search for a Contact
+    customers:
+      create: Add a customer
+      label: Customer
+      search: Search for a Customer
+    new:
+      ledger_account: Create Ledger Account
+    products_services:
+      create: Create item
+      label: Product / Service
+      search: ''
+    suppliers:
+      create: Add a supplier
+      label: Supplier
+      search: Search for a Supplier
+  s1_artefacts:
+    errors:
+      view_in_new_window:
+        message: Please logout of Sage Accounting to view this %{type}.
+        title: Logout to view this %{type}
+  saft_export:
+    export: Export
+    financial_year: Financial year
+    financial_year_detailed: From %{fy_start_date} to %{fy_end_date}.
+    lockdown_checkbox: Lock Transactions before %{lockdown_date}
+    lockdown_extra_info: Useful if your report is for audit. Change this in settings.
+    message_title: Generating your report may take a few minutes.
+    report_end_date: You can change your report end date.
+    report_end_date_date: End Date
+    report_end_date_range: Must be inside financial year limits.
+    title: SAF-T Export
+  sales_artefact:
+    delivery_address_not_filled: Delivery Address is required.
+    discount_amount: Amount
+    discount_percentage: "%"
+    invoice_address_not_filled: Invoice Address is required.
+    issued_false: 'No'
+    issued_true: 'Yes'
+    price_list: Select a price
+  sales_corrective_invoice:
+    confirm:
+      helper_text:
+        confirm_no_vat: |
+          **For example, do not use 'No VAT' for**:
+          &bull; **Overseas sales** - instead, enter the customer's address and any VAT number on their record. This applies a zero rate and keeps your returns and reports correct.
+          &bull; **Customers who aren't VAT-registered.** They can't reclaim VAT, but they should always be charged applicable VAT.
+        confirm_vat_only: "**For example, do not create VAT-only corrective invoices
+          for goods previously sold** if a customer has just become VAT registered."
+      messages:
+        confirm_no_vat: |
+          **'No VAT' has been selected on this corrective invoice.**
+          This is for special situations only - check with an accountant to be sure.
+        confirm_vat_only: |
+          **This corrective invoice only has a VAT value.**
+          This is for special situations only - check with an accountant to be sure.
+        total_zero: |
+          This Corrective Invoice has a value of %{currency_amount}.
+          Would you like to save it anyway, or continue editing?
+      title:
+        confirm_no_vat: Choosing 'No VAT'
+        confirm_vat_only: VAT-only Corrective Invoices
+        total_zero: Zero Value Corrective Invoice
+  sales_credit_note:
+    confirm:
+      helper_text:
+        confirm_no_vat: |
+          **For example, do not use 'No VAT' for:**
+          &bull; **Overseas sales** - instead, enter the customer's address and any VAT number on their record. This applies a zero rate and keeps your returns and reports correct.
+          &bull; **Customers who aren't VAT-registered.** They can't reclaim VAT, but they should always be charged applicable VAT.
+
+          **[Read guidance from HMRC](https://www.gov.uk/guidance/rates-of-vat-on-different-goods-and-services)** on when to select Zero Rated or Exempt instead.
+        confirm_vat_only: "**For example, do not create VAT-only credit notes for
+          goods previously sold** if a customer has just become VAT registered."
+      messages:
+        confirm_no_vat: |
+          **'No VAT' has been selected on this credit note.**
+          This is for special situations only - check with an accountant to be sure.
+        confirm_vat_only: |
+          **This credit note only has a VAT value.**
+          This is for special situations only - check with an accountant to be sure.
+        total_zero: |
+          This Credit Note has a value of %{currency_amount}.
+          Would you like to save it anyway, or continue editing?
+      title:
+        confirm_no_vat: Choosing 'No VAT'
+        confirm_vat_only: VAT-only Credit Notes
+        total_zero: Zero Value Credit Note
+    credit_note_number:
+      draft: DRAFT
+  sales_estimate:
+    confirm:
+      messages:
+        total_zero: |
+          This Estimate has a value of %{currency_amount}.
+          Would you like to save it anyway, or continue editing?
+      title:
+        total_zero: Zero Value Estimate
+  sales_invoice:
+    confirm:
+      helper_text:
+        confirm_no_vat: |
+          **For example, do not use 'No VAT' for**:
+          &bull; **Overseas sales** - instead, enter the customer's address and any VAT number on their record. This applies a zero rate and keeps your returns and reports correct.
+          &bull; **Customers who aren't VAT-registered.** They can't reclaim VAT, but they should always be charged applicable VAT.
+
+          **[Read guidance from HMRC](https://www.gov.uk/guidance/rates-of-vat-on-different-goods-and-services)** on when to select Zero Rated or Exempt instead.
+        confirm_vat_only: "**For example, do not create VAT-only invoices for goods
+          previously sold** if a customer has just become VAT registered."
+      messages:
+        confirm_no_vat: |
+          **'No VAT' has been selected on this invoice.**
+          This is for special situations only - check with an accountant to be sure.
+        confirm_vat_only: |
+          **This invoice only has a VAT value.**
+          This is for special situations only - check with an accountant to be sure.
+        total_zero: |
+          This Invoice has a value of %{currency_amount}.
+          Would you like to save it anyway, or continue editing?
+      title:
+        confirm_no_vat: Choosing 'No VAT'
+        confirm_vat_only: VAT-only Invoices
+        total_zero: Zero Value Invoice
+    header_note: Corresponds to the date of the invoice
+    invoice_number:
+      draft: DRAFT
+      pro_forma: PROFORMA
+  sales_quote:
+    confirm:
+      messages:
+        total_zero: |
+          This Quote has a value of %{currency_amount}.
+          Would you like to save it anyway, or continue editing?
+      title:
+        total_zero: Zero Value Quote
+    quote_number:
+      draft: DRAFT
+    quote_statuses:
+      converted: Invoiced
+      declined: Declined
+      draft: Draft
+      expired: Expired
+      pending: Pending
+    quote_types:
+      all: Estimates & Quotes
+      estimate: Estimates
+      quote: Quotes
+  services:
+    link: "%{name} Settings"
+    service_description: Use this area to manage and make changes to your settings
+      in the %{name} application
+  settings:
+    accounts:
+      invoice:
+      tax:
+        profiles_link_desc: Edit your tax settings
+        sales_tax_link_desc: Edit your tax settings
+        title: Tax Settings
+    default_settings:
+      price_usage:
+        products:
+          message: This price is used by %{count} products, are you sure you want
+            to remove it?
+          title: Delete Price Name
+        services:
+          message: This rate is used by %{count} services, are you sure you want to
+            remove it?
+          title: Delete Rate Name
+    email_defaults:
+      default_messages:
+        corrective_invoice: |
+          Thank you for your business - we're pleased to attach your corrective invoice PDF, which modifies a sales invoice you have already received. Full details, including payment terms are included.
+          If you have any questions, please don't hesitate to contact us.
+          Kind regards,
+          %{business_name}
+          %{telephone}
+        credit_note: |
+          Thank you for your business - we're pleased to attach a credit note for you in PDF.
+          You can use this credit note to count towards future purchases with us.
+          If you have any questions, please don't hesitate to contact us.
+          Kind regards,
+          %{business_name}
+          %{telephone}
+        estimate: |
+          Thank you for your enquiry - we hope you'll like the estimate attached in PDF.
+          Please let us know if you'd like to go ahead and accept it.
+          If you have any questions or would like us to amend the estimate, please just let us know.
+          Looking forward to hearing from you.
+          Kind regards,
+          %{business_name}
+          %{telephone}
+        invoice: |
+          Thank you for your business - we're pleased to attach your invoice in PDF.
+          Full details, including payment terms, are included.
+          If you have any questions, please don't hesitate to contact us.
+          Kind regards,
+          %{business_name}
+          %{telephone}
+        quote: |
+          Thank you for your enquiry - we hope you'll like the quote attached in PDF.
+          Please let us know if you'd like to go ahead and accept it.
+          If you have any questions or would like us to amend the quote, please just let us know.
+          Looking forward to hearing from you.
+          Kind regards,
+          %{business_name}
+          %{telephone}
+        remittance: |
+          I've attached a Remittance Advice in PDF from Sage Business Cloud Accounting for you.
+          If you have any questions, please don't hesitate to contact me.
+          Kind regards,
+          %{business_name}
+          %{telephone}
+        statement: |
+          We're pleased to attach a statement of account for you in PDF, including any recent invoices and payments.
+          If you have any questions, please don't hesitate to contact us.
+          Kind regards,
+          %{business_name}
+          %{telephone}
+        table: |
+          I've attached some data in PDF from Sage Business Cloud Accounting for you.
+          If you have any questions, please don't hesitate to contact me.
+          Kind regards,
+          %{business_name}
+          %{telephone}
+      descriptions:
+        corrective_invoice: When you email Sales Corrective Invoices, we'll put this
+          text in the Message field.
+        credit_note: When you email Sales Credit Notes, we'll put this text in the
+          Message field.
+        customise: " You can then customise it before sending it to the customer."
+        estimate: When you email Sales Estimates, we'll put this text in the Message
+          field.
+        invoice: When you email Sales Invoices, we'll put this text in the Message
+          field.
+        quote: When you email Sales Quotes, we'll put this text in the Message field.
+        remittance: When you email Remittance Advice, we'll put this text in the Message
+          field.
+        statement: When you email Statements, we'll put this text in the Message field.
+        table: You can email selected data from most tables by using the option in
+          the header bar. We'll put this text in the Message field.
+        where: Where is this message used?
+      email_defaults:
+        desc: Save time by setting up default email messages to use when sending documents.
+          You can easily customise these messages whenever you email an invoice, credit
+          note, quote or estimate.
+        title: Email Defaults
+      label: Default Email Message
+      message:
+        placeholder: Define your own default message
+      name: Email Defaults
+      pdf_attached:
+        desc: When sending an email we can automatically include a pdf version of
+          your invoice, quote, credit note or estimate as an attachment. Do you want
+          us to do this?
+        no_do_not_attach: No - I can attach documents to an email when needed.
+        title: Document Attachments
+        yes_attach: Yes - Always attach the document as a PDF
+      reset: Reset to default message
+      send_bcc:
+        desc: When sending a document by email we can send you a copy. Do you want
+          us to do this?
+        no_do_not_send: No - I don't want to receive a copy of that email
+        title: Send me a copy
+        yes_send: Yes - Always send a copy of the email to
+      tabs:
+        corrective_invoice: Corrective Invoice
+        credit_note: Credit Notes
+        estimate: Estimates
+        invoice: Invoices
+        quote: Quotes
+        remittance: Remittance Advice
+        statement: Statements
+        table: Tables of Data
+    services:
+      wizard:
+        selection_empty: Please call 0845 111 66 11 to cancel your subscription
+        success: Your services have been updated successfully
+        summary_help: Please review the details of the changes to your services, including
+          total cost per month to you. If you are happy with the details click submit,
+          otherwise click back to modify.
+    user:
+      pod:
+        title: User Settings
+    user_management:
+      details:
+        title: Details
+      permissions:
+        title: User Permissions
+      pod:
+        title: Advanced Permissions
+  sop_authentication:
+    accept:
+      direct: Accept Invitation
+      providers:
+        azure: Accept with Azure
+        developer: Accept with Developer
+        facebook: Accept with Facebook
+        google: Accept with Google
+    activation:
+      description: Hello %{name}, you have been invited to use Sage Business Cloud
+        Accounting.
+      provider_selection: Please complete your registration using one of the options
+        below.
+      title: Your invitation to %{app_title}
+    blocked:
+      message: Your access has been blocked. Please contact support.
+    signin:
+      already_registered: Already have an account?
+      facebook:
+        existing: Please sign in with your existing user account and we will link
+          it with your Facebook account.
+        link: This will allow you to sign in to your Sage Business Cloud services
+          using your existing credentials or your Facebook account.
+      google:
+        existing: Please sign in with your existing user account and we will link
+          it with your Google account.
+        link: This will allow you to sign in to your Sage Business Cloud services
+          using your existing credentials or your Google account.
+        providers:
+          developer: Sign In (Developer Mode)
+          sageid: Sign In
+      not_registered: Need to sign up for an account?
+      providers:
+        azure: Sign In with Azure
+        azure_html: <i class="icon"></i>Sign In with Azure
+        developer: Sign In (Developer Mode)
+        developer_html: <i class="icon"></i>Sign In (Developer Mode)
+        facebook: Sign In with Facebook
+        facebook_html: <i class="icon"></i>Sign In with Facebook
+        google: Sign In with Google
+        google_html: <i class="icon"></i>Sign In with Google
+        sageid: Sign In with SageID
+        sageid_html: <i class="icon"></i>Sign In with SageID
+      signin: Sign In
+      title: Sign In to %{app_title}
+    signup:
+      already_registered: Already have an account?
+      continue: Continue
+      direct: Sign Up Directly
+      providers:
+        azure: Sign Up with Azure
+        developer: Sign Up (Developer Mode)
+        facebook: Sign Up with Facebook
+        google: Sign Up with Google
+        sageid: Sign Up with SageID
+      signup: Sign Up
+      terms_and_conditions:
+        acceptance: I have read and accepted the %{tc_link}.
+        link: terms and conditions
+      title: Sign Up for %{app_title}
+    sso_activate:
+      expired:
+        header: Email Confirmation Failure
+        message_html: "<p>There has been a problem when we tried to confirm your email
+          address. The link in the email could have expired or you may already have
+          an existing account.</p><p>If you cannot sign in then please email <strong>sagebusinesscloudsupport@sage.com</strong>
+          or call the Sage Customer Service Team on <strong>0845 111 6611 - UK</strong>
+          or <strong>1890 812 811 - Ireland</strong></p>"
+        title: We cannot confirm your email address.
+      failure:
+        button: Continue
+        header: Email Confirmation Failure
+        message_html: "<p>If you cannot sign in then please email <strong>sagebusinesscloudsupport@sage.com</strong>
+          or call the Sage Customer Service Team on <strong>0845 111 6611 - UK</strong>
+          or <strong>1890 812 811 - Ireland</strong></p>"
+        title: There has been a problem
+      success:
+        button: Continue
+        header: Email Confirmation Success
+        message_html: "<p>If you're ready to subscribe to Accounting, you can do this
+          right now; you don’t have to wait for your trial period to expire.</p><p>Go
+          to the Settings area and click on Billing Settings. In this section, you
+          will find the Direct Debit tab. Just click the button and follow the on-screen
+          instructions to set up your subscription.</p><p>But don’t worry, we won’t
+          actually bill you until your trial period has ended.</p>"
+        title: Thank you for confirming your email address
+    sso_password_reset:
+      reset_expired:
+        button: Continue
+        header: Password change confirmation failure
+        message_html: "<p>There has been a problem when we tried to confirm your password
+          change. The link in the email could have expired or you may already have
+          confirmed your password change.</p><p>If you can't sign in then please email
+          <strong><a href='mailto:sagebusinesscloudsupport@sage.com'>sagebusinesscloudsupport@sage.com</a></strong>
+          or call the Sage Customer Service Team on <strong>0845 111 6611 - UK</strong>
+          or <strong>1890 812 811 - Ireland</strong>"
+        title: We cannot confirm your password change.
+      reset_success:
+        button: Continue
+        header: Password change confirmation success
+        message_html: "<p>You can now continue to use your service using your new
+          password.</p><p>If you have any queries about your activation, please email
+          <strong><a href='mailto:sagebusinesscloudsupport@sage.com'>sagebusinesscloudsupport@sage.com</a></strong>
+          or call the Sage Customer Service Team on <strong>0845 111 6611 - UK</strong>
+          or <strong>1890 812 811 - Ireland</strong>"
+        title: Thank you for confirming your password change.
+      success:
+        button: Continue
+        header: Password change confirmation success
+        message_html: "<p>A password activation email has been sent to your email
+          account.</p><p>To continue to use your service using your new password please
+          click the activation link in the email we have sent you.</p><p>If you have
+          any queries about your activation, please email <strong><a href='mailto:sagebusinesscloudsupport@sage.com'>sagebusinesscloudsupport@sage.com</a></strong>
+          or call the Sage Customer Service Team on <strong>0845 111 6611 - UK</strong>
+          or <strong>1890 812 811 - Ireland</strong>"
+        title: Thank you for changing your password
+  sop_settings:
+    about_your_business:
+      link_desc: Decide what information about your business is shown on sales and
+        purchase documents.
+      link_text: About your Business
+    accounts_settings:
+      description: Use this area to manage and make changes to your financial and
+        invoice settings.
+      title: Financial Settings
+    analysis_types:
+      description: Set up Analysis Types to meet your business needs, for example,
+        Departments or Cost Centres.
+      link_desc: Set-up and oversee analysis types to manage your accounts in more
+        detail.
+      link_text: Analysis Types
+      title: Analysis Types
+    bank_opening_balances:
+      link_desc: Enter the balance for each bank account.
+      link_text: Bank
+    business_preferences:
+      description: Customise invoice templates and set up your business to receive
+        online customer payments.
+      title: Invoice & Business Preferences
+    check_settings:
+      link_desc: Make payments by printing directly onto special check paper.
+      link_text: Check Printing Settings
+    connect_settings:
+      title: Connect
+    currency:
+      link_desc: Handle foreign currency transactions and manage your exchange rates.
+      link_text: Currencies
+    customer_opening_balances:
+      link_desc: Enter money owed by each customer.
+      link_text: Customer
+    datev_export_settings:
+      accountants_pod:
+        accountant_number:
+          label: Accountant Number
+          placeholder: e.g. 1234567
+        client_number:
+          label: Client Number
+          placeholder: e.g. 12345
+        title: From the Accountants
+      link_text: Datev Export
+      message_box:
+        description: You haven't entered an accountant number or a client number yet.
+          You can get this information from your accountant.
+        title: Attention
+      missing_attributes_for_datev_export: You haven't saved an accountant number
+        and a client number yet. You need both for the DATEV export!
+      next_numbers_pod:
+        description: These numbers will be handled automatically and shouldn't be
+          changed usually.
+        next_creditor_number:
+          label: Next creditor number
+        next_debtor_number:
+          label: Next debitor number
+        title: Next numbers
+    default_settings:
+      link_desc: Configure the defaults shown on contacts, items and bank transactions.
+      link_text: Record and Transactions Settings
+    email_defaults:
+      link_desc: Customise the default email message when you send an invoice, statement
+        or other document.
+      link_text: Email Messages
+    financial:
+      link_desc: Record VAT scheme details and manage your financial start and year
+        end date.
+      link_text: Accounting Dates & VAT
+    financial_settings:
+      accounts_start_date:
+        warning: An accounts start date is required before adding opening balances
+      currency_settings:
+        custom_exchange_rates_used: Exchange rates are editable
+        live_exchange_rates_used: Live exchange rates enabled
+      lockdown_date:
+        warning:
+          prompt: Setting this lock down date will prevent transactions with an earlier
+            date from being entered or changed. Do you want to continue?
+          title: Year End Lock Down Changed
+      tax_scheme:
+        prompt: Please select a tax scheme
+      tax_scheme_change:
+        warning:
+          cancel: Cancel
+          confirm: Got it!
+          prompt: To ensure we bill you correctly for your subscription, please send
+            us an email at <strong><a href='mailto:sagebusinesscloudsupport@sage.com'
+            target='_blank'>sagebusinesscloudsupport@sage.com</a></strong>
+          title: Changing VAT Scheme
+      tax_scheme_not_set:
+        warning: A tax scheme is required before adding opening balances
+    google_drive:
+      link_desc: Manage the connection to your Google Account.
+      link_text: Google Drive
+    invoice_settings:
+      customer_credit_days: "%{days} days"
+      default_delivery_address:
+        options:
+          delivery_address: Delivery Address
+          delivery_address_same_as_main: Same as invoice address
+          none: No address
+      default_settings_link:
+        text: Terms (from %{link})
+      document_headers:
+        desc: Depending on the <a href='%{logo_and_template_link}'>%{logo_and_template_title}</a>
+          selected, these headings can be shown at the top of each document.
+        title: Document Headings
+      line_item_headers:
+        desc: Rename columns shown on documents.
+        title: Line Items
+      payment_info:
+        bank_account: Bank Account
+        desc: Standard payment infomation you’d like to print on each sales document.
+        none: None
+        title: Payment Collection
+      template:
+        add_logo: Add a logo
+        association_logo: Association Logos
+        association_logo_recommendations: Recommended size 180 x 200 pixels.
+        association_logo_text: Add secondary logos i.e. for accreditations or trade
+          memberships. Logos can be a maximum of 1mb in size. JPG, PNG or GIF formats.
+        auto_entrepreneur:
+          desc: Set information about your business status on a Sales Invoice
+          option_false: "- I'm not registered as an auto-entrepreneur"
+          option_true: "- I'm registered as an auto-entrepreneur"
+          options_desc: Does your business have auto-entrepreneur status?
+          title: Auto-entrepreneur / Micro-entrepreneur
+        breakdown: Tax Display Breakdown
+        business_logo_recommendations: Recommended size 280 x 200 pixels.
+        business_logo_text: Add a business logo that represents your business. Logos
+          can be a maximum of 1mb in size. JPG, PNG or GIF formats.
+        choose_template: Choose Template
+        company_logo: Company Logo
+        contact_details_and_addresses:
+          contact_details:
+            business_name: Business Name
+            checkbox_label: Show <strong>%{element}</strong>
+            email_address: Email Address
+            mobile: Mobile
+            telephone: Telephone
+            title: Contact Details
+            website: Website
+          customer_information:
+            checkbox_label: Show <strong>%{element}</strong>
+            due_date: Due Date
+            title: Customer Information
+          default_delivery_address:
+            title: Default Delivery Address
+          desc: Selected details appear at the top of all types of document. Complete
+            any missing contact details in %{link}.
+          link:
+            text: Edit Business Address
+          title: Contact Details & Addresses
+        default_delivery_address: Default Delivery Address
+        delivery_address:
+          desc: Choose whether to show a delivery address on invoice and quotes.
+          title: Delivery Address
+        document_layout: Select the layout for your documents.
+        eu_sales_description:
+          desc: Descriptions for each EU tax rate.
+          title: EU sales descriptions
+        file_too_big_warning: "%{file} is larger than 1mb"
+        font: Font
+        font_names:
+          large: Large
+          medium: Medium
+          small: Small
+        font_size: Font Size
+        fonts: Fonts
+        footer_details:
+          column_titles:
+            column_1: Column 1
+            column_2: Column 2
+            column_3: Column 3
+          desc: Standard information you'd like to print on each document, such as
+            details of business owner or directors.<br/><br/>You can add up to three
+            columns of information. Only columns you enter details into will appear
+            on your documents.
+          not_available_for_template_html: Footer details are not available for your
+            selected layout. Go to the <a href="%{link}" target="_blank">Logo & Document
+            Template</a> page to choose another layout.
+          title: Footer Details
+        header: Template Settings
+        image_dimensions_too_small: "%{file} ( %{width} x %{height} ) is smaller than
+          recommended"
+        insurance_settings:
+          desc: Information about the professional insurance you want to appear on
+            your documents. Insurers can be added through creating a supplier.
+          title: Professional Insurance
+        invoice_numbering: Invoice Numbering
+        invoice_terms_and_conditions: Invoice Terms and Conditions
+        legacy_based:
+          desc: The latest templates are above and the original templates are still
+            available if you need them.
+          title: Can't find your template?
+        logo_file_ok: "%{file} looks good!"
+        notes:
+          desc: Standard information you'd like to print on each document, such as
+            bank details for payment. You can edit these further when you create each
+            document.
+          tab_titles:
+            credit_note: Credit Note
+            invoice: Invoice
+          title: Notes
+        numbering: Numbering
+        payment_settings:
+          desc: Set the percentage shown on a Sales Invoice for when it’s paid early
+            or late.
+          title: Discount & Penalty Rates
+        percent_total_of_invoice: "% of invoice total"
+        prefixes: Prefixes
+        prefixes_and_numbering:
+          desc: A standard prefix and unique number for each document you create.
+          title: Prefixes & Numbering
+        product_based:
+          desc: Shows product codes, quantities and unit prices.
+          title: Product based
+        quote_options: Estimate & Quote Options
+        select_font: Select a font for your documents.
+        separate_numbering:
+          checkbox: 'Number Invoices and Credit Notes separately:'
+        service_based:
+          desc: Provides space for large amounts of descriptive text, with a VAT rate
+            and amount per line.
+          title: Service based
+        show_contact_on_delivery: Show <strong>contact details</strong>
+        show_days_and_label_overdue: Show days overdue and label overdue invoices
+          in red
+        show_delivery_picked: Show <strong>picked column</strong>
+        show_delivery_signature: Show <strong>signature lines</strong>
+        show_note_on_delivery: Show <strong>document notes</strong>
+        show_overdue_in_statement:
+          desc: Add extra details to customer and supplier statements
+          title: Statements
+        show_table_of_owed_by_age: Show a table of balances owed by age <br/> <span
+          class="invoice-settings-checkbox__label-not-bold">More about this in <a
+          href="/settings/default_settings">Record and Transaction Settings</a> </span>
+        terms_and_conditions:
+          desc: Standard terms of sales for your customers, such as payment due details.
+            You can edit these further when you create each document.
+          tab_titles:
+            delivery_note: Delivery Note
+            estimate: Estimate
+            invoice: Invoice
+            quote: Quote
+          title: Terms & Conditions
+        theme_color:
+          desc: Select an accent colour for your documents
+          example_grid:
+            data:
+            - - PROD001
+              - Item
+              - 1.0
+            - - PROD001
+              - Item
+              - 1.0
+            header:
+            - Code
+            - Description
+            - Quantity
+          feedback_prompt: "**We'd love your feedback** on these new colours."
+          title: Theme Colour
+    invoices_and_quotes:
+      link_desc: Configure the defaults shown on invoices and other sales and purchase
+        forms.
+      link_text: Invoice Form Settings
+    journal_codes:
+      link_desc: Create, view, and manage your journal codes. Journal codes allow
+        you to group your accounting entries.
+      link_text: Journal Codes
+    ledger_accounts:
+      link_desc: Create, view and manage your nominal accounts.
+      link_text: Chart of Accounts
+    logo_and_theme:
+      link_desc: Add your company logo and select your document style to reflect your
+        brand.
+      link_text: Logo & Document Template
+    nominal_opening_balances:
+      link_desc: Enter the balance for each ledger account.
+      link_text: Nominal Ledger
+    opening_balances:
+      description: Use these options to record balances to bring across from your
+        previous accounting system
+      link_text: Opening Balances
+      title: Opening Balances
+    payroll_settings:
+      link_desc: Manage your Payroll Integration.
+      link_text: Payroll Integration
+    sage_integration_cloud_settings:
+      link_desc: Manage connected apps and browse the Sage Business Cloud Marketplace.
+      link_text: Apps
+      popover_button: Got it
+      popover_text: Explore apps from our partners that can improve the productivity
+        of your business through easy to set-up integrations.
+      popover_title: New! Sage Marketplace
+    sage_pay_settings:
+      link_desc: Manage your Sage Pay settings.
+      link_text: Sage Pay
+    stripe_integration:
+      link_desc: Easy card payments straight from customer invoices. Sign up to Stripe
+        or manage your settings.
+      link_text: Card Payments
+    supplier_opening_balances:
+      link_desc: Enter money owed to each supplier.
+      link_text: Supplier
+    user_managements:
+      link_desc: Manage users and permissions
+      link_text: User Management
+    user_preferences:
+      description: Personalise the user interface to suit your style of working, for
+        example, navigation and timezone settings.
+      feeback_link: We'd love your feedback <span class='link_grey_part'>on this beta
+        feature.</span>
+      grid:
+        default_grid_size: Show me
+        description: items in each table unless I override it.
+        help_desc: Set how many rows of data you’d like to see in tables.
+        title: Tables of data
+      link_desc: Make changes to suit your style of working.
+      link_text: Navigation and Data Grids
+      model: User Preferences
+      navigation:
+        advanced: Advanced <span>- Best for accountants (e.g. Contacts and Reports
+          together under Sales and Purchases).</span>
+        help_desc: Choose whether to use standard or advanced navigation.
+        standard: Standard <span>- Best for business users (e.g. Contacts and Reporting
+          in separate sections).</span>
+        title: Navigation
+      show_getting_started:
+        help_desc_1: Choose whether to display the Getting Started panel on the Summary
+          page.
+        help_desc_2: This guide explores Accounting's top features and helps you get
+          things set up quickly and easily.
+        text: Show the Getting Started panel
+        title: Getting Started
+      timezone_settings:
+        adelaide_and_darwin: Adelaide, Darwin
+        alaska: Alaska
+        arizona_and_central_america: Arizona, Chihuahua, La Paz, Mazatlan
+        astana_dhaka_central_russia: Astana, Dhaka, Novosibirsk
+        australian_east_coast_and_vladivostok: Brisbane, Canberra, Guam, Hobart, Melbourne,
+          Sydney, Vladivostok
+        baja_california: Baja California
+        cape_verde: Cabo Verde Is.
+        caracas: Caracas
+        carribean_and_atlantic_time: Asuncion, Atlantic Time, Cuiaba, Georgetown,
+          San Juan
+        central_asia: Ashgabat, Islamabad, Karachi, Tashkent
+        central_europe_and_pretoria: Athens, Cairo, Helsinki, Istanbul, Pretoria
+        central_time_us_canada: Central Time (US & Canada)
+        coordinated_universal_time_11: Co-ordindated Universal Time-11
+        coordinated_universal_time_2: Co-ordinated Universal Time-2
+        eastern_europe_and_gulf_states: Baghdad, Kuwait, Minsk, Moscow, Nairobi
+        eastern_standard_time_us_canada: Eastern Standard Time (US & Canada)
+        far_east_and_western_australia: Beijing, Chongqing, Hong Kong, Kuala Lumpur,
+          Perth, Singapore, Taipai
+        hawaii: Hawaii
+        help_desc: Affects the date and time printed on PDF reports, for example.
+        india_and_sri_lanka: Chennai, Kolkata, Mumbai, New Delhi, Sri Jayawardenepura
+        international_date_line_west: International Date Line West
+        japan_and_far_east_russia: Osaka, Seoul, Tokyo, Yakutsk
+        kabul: Kabul
+        kathmandu: Kathmandu
+        kiritimati: Kiritimati Island
+        mexico_and_saskatchewan: Guadalajara, Mexico City, Monterrey, Saskatchewan
+        middle_east_and_yerevan: Abu Dhabi, Baku, Muscat, Port Louis, Tbilisi, Yerevan
+        mountain_time: Mountain Time (MST)
+        new_zealand: Auckland, Fiji, Wellington
+        newfoundland: Newfoundland
+        nukualofa: Nuku'alofa
+        pacific_islands_solomon_islands: Chokurdakh, New Caledonia, Solomon Islands
+        pacific_time_us_canada: Pacific Time (US & Canada)
+        selected_timezone: Selected Timezone
+        south_america_central_and_indiana_east: Bogota, Lima, Quito, Indiana (East)
+        south_america_east_coast: Brasilia, Buenos Aires, Cayenne, Fortaleza, Greenland,
+          Salvador
+        tehran: Tehran
+        thailand_vietnam_indonesia: Bangkok, Hanoi, Jakarta, Krasnoyarsk
+        timezone: "%{offset_text} - %{identifier}"
+        title: Timezone
+        uk_ireland_and_portugal: Dublin, Edinburgh, Lisbon, London
+        western_europe: Amsterdam, Berlin, Madrid, Paris
+      title: Customise
+    year_end:
+      link_desc: Lock the previous financial year, post the necessary journals, and
+        open a new one.
+      link_text: Financial year end
+  sop_settings/default_settings:
+    product:
+      global_pricing_labels:
+      - Sales Price
+      - Trade
+      - Wholesale
+    service:
+      global_pricing_labels:
+      - Rate
+  sop_settings/manage_businesses:
+    switch:
+      success: You have successfully switched businesses
+      switching_to_current_business: You are already in %{business_name}
+  statement:
+    contact:
+      activity: Activity
+      addresses: Addresses
+      ageing_summary:
+        days_owed_more_than_x: More than %{number_from} days
+        days_owed_up_to_x: Up to %{number_to} days
+        days_owed_x_to_y: "%{number_from}-%{number_to} days"
+        how_long_have_i_owed: How long have I owed this money?
+      amount: Amount
+      amount_multi_currency: Amount<span data-currency="%{currency_symbol}">&nbsp;</span>
+      as_of: As of %{end_date}
+      at: At %{end_date}
+      balance: Balance
+      balance_multi_currency: Balance<span data-currency="%{currency_symbol}">&nbsp;</span>
+      bbf: Balance brought forward
+      csv_filename: contact_statement
+      date: Date
+      debt_summary: Debt Summary
+      default_message: Save this message as the default
+      dialog_description: This is where you can send this statement to your customer
+        as a PDF file attachment.
+      dialog_file_description: "%{contact_name} statement"
+      dialog_title: Email Statement
+      discount: Discount
+      due_date: Due Date
+      email_file_description: Statement from %{business} to %{end_date}
+      email_filename: Statement.pdf
+      email_success: Email sent
+      expense: Expense
+      expense_payment: Expense Payment
+      income: Income
+      income_payment: Income Payment
+      invoices: Invoices
+      invoices_multi_currency: Invoices<span data-currency="%{currency_symbol}">&nbsp;</span>
+      overdue: Overdue
+      overdue_multi_currency: Overdue
+      owed: Owed
+      owed_multi_currency: Owed
+      paid: Paid
+      paid_multi_currency: Paid<span data-currency="%{currency_symbol}">&nbsp;</span>
+      payments: Payments
+      payments_multi_currency: Payments<span data-currency="%{currency_symbol}">&nbsp;</span>
+      purchase_corrective_credit_note: Purchase Corrective Credit Note
+      purchase_corrective_invoice: Purchase Corrective Invoice
+      purchase_credit_note: Purchase Credit Note
+      purchase_invoice: Purchase Invoice
+      purchase_invoice_payment: Purchase Invoice Payment
+      purchase_payment: Payment
+      purchase_refund: Refund
+      reference: Reference
+      sales_corrective_credit_note: Sales Corrective Credit Note
+      sales_corrective_invoice: Sales Corrective Invoice
+      sales_credit_note: Sales Credit Note
+      sales_invoice: Sales Invoice
+      sales_invoice_payment: Sales Invoice Payment
+      sales_receipt: Receipt
+      sales_refund: Refund
+      statement: Statement
+      statement_period:
+        activity: 'Period: %{start_date} to %{end_date}'
+        outstanding: 'Date: %{end_date}'
+      statement_type:
+        activity: All activity
+        outstanding: Outstanding items only
+      summary: Summary
+      supplier_payment: Supplier Payment
+      total_invoiced: Total Invoiced
+      total_invoiced_multi_currency: Total Invoiced<span data-currency="%{currency_symbol}">&nbsp;</span>
+      total_paid: Total Paid
+      total_paid_multi_currency: Total Paid<span data-currency="%{currency_symbol}">&nbsp;</span>
+  states:
+    alabama: Alabama
+    alaska: Alaska
+    alberta: Alberta
+    all: All
+    american_samoa: American Samoa
+    arizona: Arizona
+    arkansas: Arkansas
+    british_columbia: British Columbia
+    california: California
+    colorado: Colorado
+    connecticut: Connecticut
+    delaware: Delaware
+    district_of_columbia: District of Columbia
+    federated_states_of_micronesia: Federated States of Micronesia
+    florida: Florida
+    georgia: Georgia
+    guam: Guam
+    hawaii: Hawaii
+    idaho: Idaho
+    illinois: Illinois
+    indiana: Indiana
+    iowa: Iowa
+    kansas: Kansas
+    kentucky: Kentucky
+    louisiana: Louisiana
+    maine: Maine
+    manitoba: Manitoba
+    marshall_islands: Marshall Islands
+    maryland: Maryland
+    massachusetts: Massachusetts
+    michigan: Michigan
+    minnesota: Minnesota
+    mississippi: Mississippi
+    missouri: Missouri
+    montana: Montana
+    nebraska: Nebraska
+    nevada: Nevada
+    new_brunswick: New Brunswick
+    new_hampshire: New Hampshire
+    new_jersey: New Jersey
+    new_mexico: New Mexico
+    new_york: New York
+    newfoundland_and_labrador: Newfoundland and Labrador
+    north_carolina: North Carolina
+    north_dakota: North Dakota
+    northern_mariana_islands: Northern Mariana Islands
+    northwest_territories: Northwest Territories
+    nova_scotia: Nova Scotia
+    nunavut: Nunavut
+    ohio: Ohio
+    oklahoma: Oklahoma
+    ontario: Ontario
+    oregon: Oregon
+    palau: Palau
+    pennsylvania: Pennsylvania
+    prince_edward_island: Prince Edward Island
+    puerto_rico: Puerto Rico
+    quebec: Québec
+    rhode_island: Rhode Island
+    saskatchewan: Saskatchewan
+    south_carolina: South Carolina
+    south_dakota: South Dakota
+    tennessee: Tennessee
+    texas: Texas
+    utah: Utah
+    vermont: Vermont
+    virgin_islands: Virgin Islands
+    virginia: Virginia
+    washington: Washington
+    west_virginia: West Virginia
+    wisconsin: Wisconsin
+    wyoming: Wyoming
+    yukon: Yukon
+  stock_movement:
+    purchase_corrective_credit_note_details: Purchase Corrective Invoice - Credit
+      from %{company}
+    purchase_corrective_invoice_details: Purchase Corrective Invoice - Charge from
+      %{company}
+    purchase_credit_note_details: Purchase Credit Note from %{company}
+    purchase_invoice_details: Purchase Invoice from %{company}
+    sales_corrective_credit_note_details: Sales Corrective Invoice - Credit to %{company}
+    sales_corrective_invoice_details: Sales Corrective Invoice - Charge to %{company}
+    sales_credit_note_details: Sales Credit Note to %{company}
+    sales_invoice_details: Sales Invoice to %{company}
+  stripe_integration:
+    account_name: Account Disconnected
+    invoicing:
+      refund:
+        connected:
+          button: Refund in Stripe
+          message: To give **%{cardholderName}** a refund, you must do this within
+            the Stripe Dashboard.  When viewing the payment in Stripe, click “Refund”,
+            and enter a partial or full refund amount. This will then be automatically
+            updated in Sage.
+        connected_title: Refund Card Payment
+        disconnected:
+          body: "**Important:** Signing into an old account will disconnect any new
+            accounts that have since been connected to Sage."
+          button: Sign In
+          message: You must be signed into the original account that was used for
+            this payment before issuing a refund. This is so that your accounts in
+            Sage can be automatically updated.
+          message_title: Stripe Account Disconnected
+        disconnected_title: Sign into original Stripe Account
+      stripe_transaction_dialog:
+        form:
+          address_one: Address 1
+          address_two: Address 2
+          card: Card Details
+          city: Town/City
+          name: Card Holder
+          part_payment: Take part payment
+          postal_code: Post Code
+          save_text: Charge £%{amount}
+          state: County
+        title: Take a Payment
+    payment:
+      failure: Sorry, there was a problem taking payment. If the problem continues,
+        please contact support.
+      success: Payment taken for this invoice.
+    powered_by_stripe: powered by Stripe
+    refund:
+      success: Stripe Transaction Successfully Refunded
+    sales_invoice:
+      stripe_pay: Take a Payment with Stripe
+    settings:
+      alt_screenshot: stripe payment button screenshot
+      coming_soon:
+        description: Here's a sneak peek at the features we're working on.
+        title: Coming Soon
+      connected:
+        account_failure: The Stripe account that you're trying to connect is already
+          connected to another Accounting business
+        account_name: Account Name
+        description: Choose where your stripe fees will be recorded and disconnect
+          your account if you wish to no longer use Stripe.
+        disconnect: Disconnect Account
+        email: Account Email
+        failure: Sorry, there was a problem connecting Stripe to Sage. Please try
+          connecting again later.
+        ledger: Where will your Stripe fees be recorded?
+        payouts: Where will your payouts be transfered?
+        payouts_help: To change where your money is transfered, please update your
+          bank details in the Stripe Dashboard as well.
+        success: Stripe Account connected to Sage
+        take_payments: Your Stripe account is currently connected with Sage and you
+          can now take card payments from your customers. All your Stripe transactions
+          will appear in this [**Stripe Bank Account**](%{account_url}).
+      disconnect_dialog:
+        body: By disconnecting this account, you will no longer be able to take payment
+          on invoices with Stripe.
+        cancel_label: No, Keep Stripe
+        confirm_label: Yes, Disconnect Stripe
+        confirm_message: Are you sure that you wish to continue?
+        title: Disconnect Stripe
+      disconnected:
+        create_account: Create Account
+        description: Sign up for a new Stripe account, or log in if you already have
+          one.
+        failure: Stripe Account disconnection failed
+        icon_rows:
+          alt_bank_transfer: bank transfer icon
+          alt_coinstack: coin stack icon
+          alt_padlock: padlock icon
+          alt_reconcile: reconcile icon
+          fees_description: |
+            UK and European payments cost 1.4% + 20p
+            Non-European payments cost 2.9% + 20p
+            So, a customer with a UK card paying you £100, would cost £1.60.
+          fees_title: Clear and simple fees, with no surprises
+          payout_description: Payments are collected into your Stripe account, and
+            you choose how often money is automatically transferred to your bank account.
+            This is your
+          payout_schedule: " 'Payout Schedule'"
+          payout_title: Automatic bank account transfers
+          reconcile_description: Get transaction data automatically matched straight
+            to invoices after a scheduled payout. Invoice statuses are always up-to-date,
+            and fees already accounted for.
+          reconcile_title: Automatic Reconciliation
+          secure_payments_description: Sage and Stripe use the same industry-standard
+            security as all the major banks, so your data and money are always safe.
+          secure_payments_title: Secure, safe, and trusted
+        signin: Sign In
+        signin_dialog:
+          message: |-
+            So that we can accurately reconcile your transactions, please make sure that this Stripe account is only used for payments from Sage.
+
+            If your account has payments from another source, please create a new Stripe account.
+          signin_button: Sign In to Stripe
+          title: Sign In to Stripe
+        signin_text: Already have a stripe account?
+        signup_dialog:
+          button: Create Account
+          message: So that we can accurately reconcile your transactions, please make
+            sure that this Stripe account is only used for payments from Sage.
+          title: Create Account
+        success: Stripe Account disconnected from Sage
+        upsale: Customer ready to pay? Take card payments for any invoice in person
+          or over the phone - just enter the customer's details, and Stripe does the
+          rest.
+      failure: Sorry, there was a problem updating your Stripe settings, please try
+        again later or contact Sage support.
+      saved: Saved Stripe settings successfully.
+      title: Manage Connection
+    stripe_label: " (Stripe)"
+    tooltips:
+      foreign_details: There are an additional %{value} of transactions included in
+        this payout that have not been recorded in Sage Business Cloud.
+      manual_payout: Transaction data can only be displayed from an automatically
+        scheduled payout.
+      mixed_after_manual: There are an additional %{value} of transactions included
+        in this payout that have not been recorded in Sage Business Cloud. This total
+        is also impacted by a previous manual payout.
+      payout_after_manual: This payout total is impacted by a previous manual payout.
+        Log in to your Stripe Dashboard for more details.
+    transactions:
+      read_only: Not allowed to update/delete Stripe transaction
+  stripe_payments:
+    credit_card: Credit Card
+    errors:
+      approve_with_id: Payment cannot be authorized, try again. If it still can’t
+        be processed, the customer needs to contact their bank.
+      card_not_supported: The card does not support this type of purchase. The customer
+        needs to contact their bank to make sure their card can be used to make this
+        type of purchase.
+      card_velocity_exceeded: The customer has exceeded the balance or credit limit
+        available on their card. They should contact their bank for more information.
+      currency_not_supported: The card does not support the specified currency. The
+        customer should check with their bank that the card can be used for the type
+        of currency specified.
+      duplicate_transaction: A transaction with identical amount and credit card information
+        was submitted very recently. Check to see if a recent payment already exists.
+      expired_card: The card has expired. You should use another card.
+      incorrect_cvc: The CVC number is incorrect. You should try again using the correct
+        CVC.
+      incorrect_number: The card number is incorrect. You should try again using the
+        correct card number.
+      incorrect_zip: The ZIP/postal code is incorrect. You should try again using
+        the correct billing ZIP/postal code.
+      insufficient_funds: The card has insufficient funds to complete the purchase.
+        The customer should use an alternative payment method.
+      invalid_account: The card, or account the card is connected to, is invalid.
+        The customer needs to contact their bank to check that the card is working
+        correctly.
+      invalid_amount: The payment amount is invalid, or exceeds the amount that is
+        allowed. The customer needs to check with their bank that they can make purchases
+        of that amount.
+      invalid_cvc: The CVC number is incorrect. You should try again using the correct
+        CVC.
+      invalid_expiry_year: The expiration year is invalid. The customer should try
+        again using the correct expiration date.
+      invalid_number: The card number is incorrect. You should try again using the
+        correct card number.
+      issuer_not_available: The card issuer could not be reached, so the payment could
+        not be authorized. The payment should be attempted again. If it still cannot
+        be processed, the customer needs to contact their bank.
+      network_error: Sorry, we couldn't complete your request right now. The problem
+        should be fixed soon, so please try again later.
+      new_account_information_available: The card, or account the card is connected
+        to, is invalid. The customer needs to contact their bank to check that the
+        card is working correctly.
+      not_permitted: The payment is not permitted. The customer needs to contact their
+        bank for more information.
+      pending_trx: The invoice status has not been updated following a previous payment.
+        Please contact support.
+      pickup_card: The card cannot be used to make this payment (it is possible it
+        has been reported lost or stolen). The customer needs to contact their bank
+        for more information.
+      processing_error: An error occurred while processing the card. The payment should
+        be attempted again. If it still cannot be processed, try again later.
+      reenter_transaction: The payment could not be processed by the issuer for an
+        unknown reason. The payment should be attempted again. If it still cannot
+        be processed, the customer needs to contact their bank.
+      restricted_card: The card cannot be used to make this payment (it is possible
+        it has been reported lost or stolen). The customer needs to contact their
+        bank for more information.
+      testmode_decline: A Stripe test card number was used. A genuine card must be
+        used to make a payment.
+      unknown: The card has been declined for an unknown reason. The customer needs
+        to contact their bank for more information.
+      withdrawal_count_limit_exceeded: The customer has exceeded the balance or credit
+        limit available on their card. The customer should use an alternative payment
+        method.
+    errors_for_end_customer:
+      approve_with_id: Payment cannot be authorized, please try again. If it still
+        can’t be processed, you will need to contact your bank.
+      card_not_supported: Your card has been declined for an unknown reason. Please
+        contact your bank for more information.
+      card_velocity_exceeded: You have exceeded the balance or credit limit available
+        on your card. You should contact your bank for more information.
+      currency_not_supported: Your card does not support the specified currency. Please
+        check with your bank that your card can be used for the type of currency specified.
+      duplicate_transaction: A transaction with identical amount and credit card information
+        was submitted very recently. Please check your bank statement to see if the
+        payment already exists.
+      expired_card: Your card has expired. Please pay with an alternative card.
+      incorrect_cvc: Your CVC number is incorrect. Please try again with the correct
+        CVC number.
+      incorrect_number: Your card number is incorrect. Please try again with the correct
+        card number.
+      incorrect_zip: Your ZIP/postal code is incorrect. You should try again using
+        the correct billing ZIP/postal code.
+      insufficient_funds: Your card has insufficient funds to complete the purchase.
+        Please use an alternative payment method.
+      invalid_account: Your card has insufficient funds to complete the purchase.
+        Please use an alternative payment method.
+      invalid_amount: Your payment amount is invalid, or exceeds the amount that is
+        allowed. Please check with your bank that you can make purchases of that amount.
+      invalid_expiry_year: The expiration year is invalid. You should try again using
+        the correct expiration date.
+      issuer_not_available: The card issuer could not be reached, so the payment could
+        not be authorized. The payment should be attempted again. If it still cannot
+        be processed, please contact your bank.
+      new_account_information_available: Your card, or account that the card is connected
+        to is invalid. Please try again with a different card.
+      not_permitted: The payment is not permitted. Please contact your bank for more
+        information.
+      pickup_card: Your card cannot be used to make this payment (it is possible it
+        has been reported lost or stolen). Please contact your bank for more information.
+      reenter_transaction: The payment could not be processed by the issuer for an
+        unknown reason. The payment should be attempted again. If it still cannot
+        be processed, please contact your bank.
+      unknown: Your card has been declined for an unknown reason. Please contact your
+        bank for more information.
+      withdrawal_count_limit_exceeded: Your have exceeded the balance or credit limit
+        available on their card. Please use an alternative payment method.
+    stripe_transaction_dialog:
+      amount_charged: Amount Charged
+      card_details: Card Details
+      card_holder: Card Holder
+      cvc_check: CVC Check
+      date: Date
+      dialog_title:
+        dispute: "**Dispute**"
+        dispute_list: "%{date} **Payout: Disputes**"
+        manual_payout: "**Manual Payout**"
+        payment: "**Payment**"
+        payment_list: "%{date} **Payout: Payments**"
+        payout: "%{date} **Payout**"
+        refund: "**Refund**"
+        refund_list: "%{date} **Payout: Refunds**"
+      disputed: Disputed
+      disputed_on: Disputed On
+      expires: Expires
+      failed: Failed
+      invoice: Invoice
+      linked_transactions: Linked Transactions
+      manual_payout:
+        check: Check to see if you’ve changed your payout schedule or made a manual
+          payout in Stripe.
+        description: We can only display transaction data from an 'automatic' payout.
+        solution: If you have changed your payout schedule, change it back to 'automatic'
+          and we'll get the transaction data for this payout when it's time for your
+          next payout.
+        warning: We can't show transactions
+      no_connection: Card details unavailable as the Stripe account has been disconnected.
+      number: Number
+      origin: Origin
+      paid: Paid
+      partial_refund: Partial Refund
+      passed: Passed
+      payment: Payment
+      payment_details: Payment Details
+      payout: "%{date} Payout"
+      payout_details:
+        amount: Amount
+        count: Count
+        foreign_total: Total
+        foreign_total_title: Transactions taken from another source
+        local_total_title: Transactions taken in Accounting
+        paid: Paid
+        received: Received
+        stripe_fees: Stripe Fees
+        subtotal_title: Subtotal
+        tooltip: There are transactions included in this payout that have not been
+          recorded in Sage Business Cloud.
+        total_amount_title: Total Payout Amount
+        total_paid_title: "**Total Paid** \n (Refunds/Disputes)"
+        total_title: Total Received
+        transaction_type: Transaction type
+        transaction_type_names:
+          dispute: Disputes
+          payment: Payments
+          refund: Refunds
+      payout_page:
+        header_text:
+          cancelled: Payout was expected to arrive on **%{date}** but payment was
+            cancelled.
+          failed: |-
+            Payout was expected to arrive on **%{date}** but payment failed.
+            This can be due to **[multiple reasons](%{help_link})**. Please make sure a **[valid bank account](%{settings_link})** is saved.
+          in_transit: Payout In Transit
+          paid: Payout Transferred
+        payout_summary: Payout Summary
+      received: Received
+      redirect_button: View in Stripe
+      refund_details: Refund Details
+      save: View in Stripe
+      stripe_fee: Stripe Fee
+      total_received: Total Received
+      total_refund: Refunded
+      transferred: Transferred
+      trx_date_time: Transaction Date & Time
+      type: Type
+    stripe_transactions:
+      activity: Activity
+      amount: Amount
+      arrival_date: Arrival Date
+      business_name: Business Name
+      card_holder: Card Holder
+      date: Date
+      date_time: Date & Time
+      feedback_add_text: " on this new feature"
+      ledger_account: Ledger Account
+      next_payout: Next Payout
+      paid: Paid
+      payout_statuses:
+        canceled: Cancelled
+        failed: Failed
+        failed_tooltip: |
+          Review your bank details in Stripe to
+          make sure a valid account is saved.
+        in_transit: In Transit
+        paid_out: Paid Out
+        unknown: Unknown
+      payout_total: Payout Total
+      payouts: Payouts
+      received: Received
+      refund_disputes_header: Refunds / Disputes
+      status: Status
+      stripe_balance: Stripe Balance
+      stripe_fees: Fees
+      transaction_type: Transaction Type
+      view_stripe_dashboard: View Stripe Dashboard
+  suggest:
+    contacts: Search for a Contact
+  summary: Summary
+  supplier_remittance:
+    report:
+      email: Email Remittance
+      headers:
+        currency_paid: Amount Paid
+        currency_paid_multi_currency: Amount Paid<span data-currency="%{currency_symbol}">&nbsp;</span>
+        date: Date
+        extra_reference: Your Ref
+        reference: Our Ref
+        total: Total Amount
+        total_multi_currency: Total Amount<span data-currency="%{currency_symbol}">&nbsp;</span>
+      print: Print Remittance
+      title: Remittance Advice
+      totals:
+        total: 'Total Paid:'
+        total_multi_currency: Total Paid<span data-currency="%{currency_symbol}">&nbsp;</span>
+  table:
+    no_data: No Results To Display
+    titles:
+      account_number: Account Number
+      advanced_uk/analysis_type_category:
+        code: Code
+        in_use?: In use?
+        name: Name
+      advanced_uk/bank_opening_balance:
+        amount: Opening Balance
+      advanced_uk/other_expense_payment_line_item:
+        description: Details
+      advanced_uk/other_expense_payment_refund_line_item:
+        description: Details
+      advanced_uk/other_income_payment_line_item:
+        description: Details
+      advanced_uk/other_income_payment_refund_line_item:
+        description: Details
+      amount: Amount
+      analysis_type_0: ''
+      analysis_type_1: ''
+      analysis_type_2: ''
+      bank_account: Bank Account
+      credit: Credit
+      currency_id: Currency
+      date: Date
+      debit: Debit
+      description: Description
+      details: Details
+      'false': 'No'
+      included_on_vat_return: Include on VAT Return
+      inverse: Inverse
+      journal:
+        code: Journal Code
+        date: Journal Date
+        description: Description
+        entry: Journal Entry
+      ledger_account: Ledger Account
+      rate: Rate
+      sort_code: Sort Code
+      'true': 'Yes'
+      type_id: Type
+  tabs:
+    advanced_uk/customer_receipt:
+      title: Customer Receipt
+    advanced_uk/customer_refund:
+      title: Customer Refund
+    advanced_uk/other_payment:
+      title: Other Payment
+    advanced_uk/other_receipt:
+      title: Other Receipt
+    advanced_uk/supplier_payment:
+      title: Supplier Payment
+    advanced_uk/supplier_refund:
+      title: Supplier Refund
+    fuji_banking/bank_accounts:
+      activity: Activity
+      address_and_contacts: Address & Contacts
+      reconciliations: Reconciliations
+    titles:
+      fuji_contacts/contacts:
+        about: About
+        activity: Activity
+        addresses: Addresses
+        contacts_addresses: Contacts and Addresses
+        details: Details
+        notes: Notes
+        options: Options
+        payment_details: Payment Details
+        transaction_allocation: Transaction allocation
+  tax:
+    tax_return:
+      delete_tax_return_success: Deleted tax return successfully
+      draft_saved: Tax return saved as draft
+      filed: Tax return marked as filed
+      payment_recorded: Tax return payment recorded
+      payment_recorded_failed: We can't record your payment right now, please try
+        again later
+  tax_breakdown:
+    adjust_tax: Adjust VAT
+    adjust_tax_title: Adjust VAT @ %{percentage}%
+    dialog:
+      description: A detailed breakdown of VAT per VAT Rate.
+      description_multi_currency: A detailed breakdown of VAT per VAT Rate in %{currency_code}.
+      title: VAT Analysis
+    equals: equals %{amount}%
+    net_total: Net Total
+    no_rate_selected: No rate selected
+    report:
+      headers:
+        amount: Amount
+        goods: Goods and Related Services
+        net: Net
+        rate: VAT Rate
+        services: Services
+        tax: VAT
+        total: Total
+    tax: VAT
+    tax_breakdown: VAT Breakdown
+    tax_calculation_changed:
+      credit_note: credit note
+      invoice: invoice
+      message_to_cash: Since the original %{type} was created, this supplier's VAT
+        setting has changed from invoice to cash.
+      message_to_invoice: Since the original %{type} was created, this supplier's
+        VAT setting has changed from cash to invoice.
+      title: Tax Calculation Changed
+    tax_calculation_method:
+      cash: VAT due on receipts/payments
+      invoice: VAT due on invoice/debits
+    tax_total: VAT Total
+    view_analysis: View VAT Analysis
+  tax_breakdown_types:
+    combined: Combined Tax Rates
+    individual: Individual Tax Rates
+    summary: One-Line Summary
+  tax_period_rates:
+    valid_for_period_false: 'No'
+    valid_for_period_true: 'Yes'
+  tax_rates_dialog_pattern:
+    add_first_item: Create a combined tax rate
+    add_item: Add component
+    alert_title: Tax rate cannot be deleted
+    combined_tax_rate_title: Combined Tax Rate
+    components_header: Components
+    confirm_message: Are you sure you wish to delete this tax rate?
+    confirm_no: Cancel
+    confirm_title: Delete tax rate?
+    confirm_yes: Delete Tax Rate
+    creating_tax_rate_action: New Tax Rate
+    creating_tax_rate_description: You may need to add a tax rate if you are planning
+      to sell products or services to customers that live in a different region or
+      state. It is possible to create a number of single tax rates or combined tax
+      rates. You can also combine existing single tax rates.
+    creating_tax_rate_title: Creating a New Tax Rate
+    footer_text: Remove all components to revert this tax rate to a single tax rate.
+    new_tax_rate_title: New Tax Rate
+    placeholders:
+      agency: Agency
+      multiple_tax_rates: Multiple
+      name: Name
+    show_tax_rate_description: Showing this tax rate will make it available for use
+      throughout the application
+    tax_rate_details_title: Edit Tax Rate
+    tax_rate_percentage_from: From
+    tax_rate_percentage_rate: Rate
+    tax_rate_percentage_to: through to
+    tax_rate_percentage_update_action: Update Rate
+    title: Tax Rates Management
+  tax_return:
+    adjust: Adjust
+    adjustment_dialog:
+      adjustment: "%{adjustment} adjustment"
+      calculated_figure: Calculated Figure
+      label:
+        amount: Change figure to
+        change_reason: Reason for Change
+      title:
+        MODELO390: Ajuste de IVA Anual
+    button:
+      calculate: Calculate
+      cancel: Cancel
+      content: Provincial sales tax returns are coming soon. Stay Tuned!
+      download_summary_report: Download Summary
+      draft: Save as Draft
+      edit_draft: Edit Draft
+      recalculate: Recalculate
+      record_payment: Record Payment
+      record_refund: Record Refund
+      title: Coming Soon!
+    controller:
+      MODELO390: modelo390
+    corporate_representative:
+      business_number: NIF
+      date_of_power: Fecha Poder
+      description:
+        line_1: El (los) representante(s) legal(es) de la Entidad declarante, manifiesta
+          que todos los datos consignados se corresponden con la
+        line_2: información contenida en los libros oficiales exigidos por la lalegislación
+          mercantil y en la normativa del Impuesto.
+      description_title: Declaración de los Representantes legales de la Entidad
+      empty_row: Esta sección no es necesaria para las empresas cuyo NIF empiece con
+        un número o con las letras 'X', 'Y', 'E' o 'H'.
+      name: Nombre
+      notary: Notaría
+      power_one: Por poder 1
+      power_three: Por poder 3
+      power_two: Por poder 2
+      title: Personas Jurídicas
+      without_legal_responsability_empty_row: Estos detalles no son necesarios para
+        las empresas con un código NIF que comienza con 'A'.
+      without_legal_responsability_empty_row_title: Individuos y entidades sin personalidad
+        jurídica
+    date_range_picker:
+      date_from: Tax period from
+      date_to: Tax period to
+    defaults:
+      tax_frequency: Set a frequency
+      tax_number: Set a tax number
+    deletion_confirmation_dialog:
+      message: Are you sure you wish to delete this tax return?
+      title: Delete Tax Return?
+    dialog:
+      pay:
+        title: Record Payment of VAT Return
+      reclaim:
+        title: Record Reclaim of VAT Return
+      title: VAT Adjustment
+    edit_tax_settings_dialog:
+      button: Edit Your Tax Settings
+      title: Edit your tax settings
+    label:
+      tax_frequency: 'Tax frequency:'
+    modelo130:
+      sections:
+        section1:
+          business_name:
+            row_description: Apellidos y Nombre
+          description: Declarante
+    modelo303:
+      sections:
+        section1:
+          business_name:
+            row_description: Apellidos y Nombre o Razón social o denominación
+          description: Identificación
+    modelo390:
+      boxes:
+        box_1:
+          editable: 'true'
+          line_number: '1'
+          title: Régimen ordinario
+        box_102:
+          editable: 'true'
+          line_number: '102'
+          negative_adjustment: 'true'
+          title: Operaciones realizadas por sujetos pasivos acogidos al régimen especial
+            del recargo de equivalencia
+        box_103:
+          editable: 'true'
+          line_number: '103'
+          negative_adjustment: 'true'
+          title: Entregas intracomunitarias exentas
+        box_104:
+          editable: 'true'
+          line_number: '104'
+          negative_adjustment: 'true'
+          title: Exportaciones y otras operaciones exentas con derecho a deducción
+        box_105:
+          editable: 'true'
+          line_number: '105'
+          negative_adjustment: 'true'
+          title: Operaciones exentas sin derecho a deducción
+        box_106:
+          editable: 'true'
+          line_number: '106'
+          negative_adjustment: 'true'
+          title: Entregas de bienes inmuebles, operaciones financieras y relativas
+            al oro de inversión no habituales
+        box_107:
+          editable: 'true'
+          line_number: '107'
+          negative_adjustment: 'true'
+          title: Entregas de bienes de inversión
+        box_108:
+          line_number: '108'
+          title: Total volumen de operaciones (Art. 121 Ley IVA)
+        box_109:
+          editable: 'true'
+          line_number: '109'
+          negative_adjustment: 'true'
+          title: Adquisiciones intracomunitarias exentas
+        box_110:
+          editable: 'true'
+          line_number: '110'
+          negative_adjustment: 'true'
+          title: Operaciones no sujetas por reglas de localización o con inversión
+            del sujeto pasivo
+        box_112:
+          editable: 'true'
+          line_number: '112'
+          negative_adjustment: 'true'
+          title: Entregas de bienes objeto de instalación o montaje en otros Estados
+            miembros
+        box_190:
+          editable: 'true'
+          line_number: '190'
+          sub_title: IVA deducible en operaciones interiores de bienes y servicios
+          title: 'Operaciones interiores corrientes:'
+        box_190_tax_rate: 4%
+        box_191:
+          editable: 'true'
+          line_number: '191'
+          sub_title: IVA deducible en operaciones interiores de bienes y servicios
+          title: 'Operaciones interiores corrientes:'
+        box_196:
+          editable: 'true'
+          line_number: '196'
+          sub_title: IVA deducible en  operaciones interiores de bienes de inversión
+          title: 'Operaciones interiores de bienes de inversión:'
+        box_196_tax_rate: 4%
+        box_197:
+          editable: 'true'
+          line_number: '197'
+          sub_title: IVA deducible en  operaciones interiores de bienes de inversión
+          title: 'Operaciones interiores de bienes de inversión:'
+        box_1_tax_rate: 4%
+        box_2:
+          editable: 'true'
+          line_number: '2'
+          title: Régimen ordinario
+        box_202:
+          editable: 'true'
+          line_number: '202'
+          sub_title: IVA deducible en importaciones de bienes corrientes
+          title: 'Importaciones y adquisiciones intracomunitarias de bienes y servicios:'
+        box_202_tax_rate: 4%
+        box_203:
+          editable: 'true'
+          line_number: '203'
+          sub_title: IVA deducible en importaciones de bienes corrientes
+          title: 'Importaciones y adquisiciones intracomunitarias de bienes y servicios:'
+        box_208:
+          editable: 'true'
+          line_number: '208'
+          title: IVA deducible en importaciones de bienes de inversión
+        box_208_tax_rate: 4%
+        box_209:
+          editable: 'true'
+          line_number: '209'
+          title: IVA deducible en importaciones de bienes de inversión
+        box_21:
+          editable: 'true'
+          line_number: '21'
+          title: Adquisiciones intracomunitarias de bienes
+        box_214:
+          editable: 'true'
+          line_number: '214'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes corrientes
+        box_214_tax_rate: 4%
+        box_215:
+          editable: 'true'
+          line_number: '215'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes corrientes
+        box_21_tax_rate: 4%
+        box_22:
+          editable: 'true'
+          line_number: '22'
+          title: Adquisiciones intracomunitarias de bienes
+        box_220:
+          editable: 'true'
+          line_number: '220'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes de inversión
+        box_220_tax_rate: 4%
+        box_221:
+          editable: 'true'
+          line_number: '221'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes de inversión
+        box_23:
+          editable: 'true'
+          line_number: '23'
+          title: Adquisiciones intracomunitarias de bienes
+        box_230:
+          editable: 'true'
+          line_number: '230'
+          negative_adjustment: 'true'
+          title: Adquisiciones interiores exentas
+        box_231:
+          editable: 'true'
+          line_number: '231'
+          negative_adjustment: 'true'
+          title: Importaciones exentas
+        box_23_tax_rate: 10%
+        box_24:
+          editable: 'true'
+          line_number: '24'
+          title: Adquisiciones intracomunitarias de bienes
+        box_25:
+          editable: 'true'
+          line_number: '25'
+          title: Adquisiciones intracomunitarias de bienes
+        box_25_tax_rate: 21%
+        box_26:
+          editable: 'true'
+          line_number: '26'
+          title: Adquisiciones intracomunitarias de bienes
+        box_27:
+          editable: 'true'
+          line_number: '27'
+          title: IVA devengado en otros supuestos de inversión del sujeto
+        box_28:
+          editable: 'true'
+          line_number: '28'
+          title: IVA devengado en otros supuestos de inversión del sujeto
+        box_29:
+          editable: 'true'
+          line_number: '29'
+          negative_adjustment: 'true'
+          title: Modificación de bases y cuotas
+        box_3:
+          editable: 'true'
+          line_number: '3'
+          title: Régimen ordinario
+        box_30:
+          editable: 'true'
+          line_number: '30'
+          negative_adjustment: 'true'
+          title: Modificación de bases y cuotas
+        box_31:
+          editable: 'true'
+          line_number: '31'
+          negative_adjustment: 'true'
+          title: Modificación de bases y cuotas por auto de declaración de concurso
+            de acreedores
+        box_32:
+          editable: 'true'
+          line_number: '32'
+          negative_adjustment: 'true'
+          title: Modificación de bases y cuotas por auto de declaración de concurso
+            de acreedores
+        box_33:
+          line_number: '33'
+          subsection_header: 'true'
+          title: Total cuota devengada
+        box_34:
+          line_number: '34'
+          subsection_header: 'true'
+          title: Total cuota devengada
+        box_35:
+          editable: 'true'
+          line_number: '35'
+          title: Recargo de equivalencia
+        box_35_tax_rate: 0,5%
+        box_36:
+          editable: 'true'
+          line_number: '36'
+          title: Recargo de equivalencia
+        box_3_tax_rate: 10%
+        box_4:
+          editable: 'true'
+          line_number: '4'
+          title: Régimen ordinario
+        box_41:
+          editable: 'true'
+          line_number: '41'
+          title: Recargo de equivalencia
+        box_41_tax_rate: 1,75%
+        box_42:
+          editable: 'true'
+          line_number: '42'
+          title: Recargo de equivalencia
+        box_43:
+          editable: 'true'
+          line_number: '43'
+          negative_adjustment: 'true'
+          title: Modificación recargo equivalencia
+        box_44:
+          editable: 'true'
+          line_number: '44'
+          negative_adjustment: 'true'
+          title: Modificación recargo equivalencia
+        box_47:
+          line_number: '47'
+          title: Total cuotas IVA y recargo de equivalencia
+        box_48:
+          line_number: '48'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en operaciones interiores
+            de bienes y servicios corrientes
+        box_49:
+          line_number: '49'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en operaciones interiores
+            de bienes y servicios corrientes
+        box_5:
+          editable: 'true'
+          line_number: '5'
+          title: Régimen ordinario
+        box_50:
+          line_number: '50'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en operaciones interiores
+            de bienes de inversión
+        box_51:
+          line_number: '51'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en operaciones interiores
+            de bienes de inversión
+        box_52:
+          line_number: '52'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en importaciones de bienes
+            corrientes
+        box_523:
+          editable: 'true'
+          line_number: '523'
+          negative_adjustment: 'true'
+          title: Servicios localizados en el territorio de aplicación del impuesto
+            por inversión del sujeto pasivo
+        box_53:
+          line_number: '53'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en importaciones de bienes
+            corrientes
+        box_54:
+          line_number: '54'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en importaciones de bienes
+            de inversión
+        box_545:
+          editable: 'true'
+          line_number: '545'
+          title: Adquisiciones intracomunitarias de servicios
+        box_545_tax_rate: 4%
+        box_546:
+          editable: 'true'
+          line_number: '546'
+          title: Adquisiciones intracomunitarias de servicios
+        box_547:
+          editable: 'true'
+          line_number: '547'
+          title: Adquisiciones intracomunitarias de servicios
+        box_547_tax_rate: 10%
+        box_548:
+          editable: 'true'
+          line_number: '548'
+          title: Adquisiciones intracomunitarias de servicios
+        box_55:
+          line_number: '55'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en importaciones de bienes
+            de inversión
+        box_551:
+          editable: 'true'
+          line_number: '551'
+          title: Adquisiciones intracomunitarias de servicios
+        box_551_tax_rate: 21%
+        box_552:
+          editable: 'true'
+          line_number: '552'
+          title: Adquisiciones intracomunitarias de servicios
+        box_56:
+          line_number: '56'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en adquisiciones intracomunitarias
+            de bienes corrientes
+        box_57:
+          line_number: '57'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en adquisiciones intracomunitarias
+            de bienes corrientes
+        box_58:
+          line_number: '58'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en adquisiciones intracomunitarias
+            de bienes de inversión
+        box_587:
+          editable: 'true'
+          line_number: '587'
+          title: IVA deducible en adquisiciones intracomunitarias de servicios
+        box_587_tax_rate: 4%
+        box_588:
+          editable: 'true'
+          line_number: '588'
+          title: IVA deducible en adquisiciones intracomunitarias de servicios
+        box_59:
+          line_number: '59'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en adquisiciones intracomunitarias
+            de bienes de inversión
+        box_597:
+          line_number: '597'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en adquisiciones intracomunitarias
+            de servicios
+        box_598:
+          line_number: '598'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en adquisiciones intracomunitarias
+            de servicios
+        box_599:
+          editable: 'true'
+          line_number: '599'
+          title: Recargo de equivalencia
+        box_599_tax_rate: 1,4%
+        box_5_tax_rate: 21%
+        box_6:
+          editable: 'true'
+          line_number: '6'
+          title: Régimen ordinario
+        box_600:
+          editable: 'true'
+          line_number: '600'
+          title: Recargo de equivalencia
+        box_601:
+          editable: 'true'
+          line_number: '601'
+          title: Recargo de equivalencia
+        box_601_tax_rate: 5,2%
+        box_602:
+          editable: 'true'
+          line_number: '602'
+          title: Recargo de equivalencia
+        box_603:
+          editable: 'true'
+          line_number: '603'
+          sub_title: IVA deducible en operaciones interiores de bienes y servicios
+          title: 'Operaciones interiores corrientes:'
+        box_603_tax_rate: 10%
+        box_604:
+          editable: 'true'
+          line_number: '604'
+          sub_title: IVA deducible en operaciones interiores de bienes y servicios
+          title: 'Operaciones interiores corrientes:'
+        box_605:
+          editable: 'true'
+          line_number: '605'
+          sub_title: IVA deducible en operaciones interiores de bienes y servicios
+          title: 'Operaciones interiores corrientes:'
+        box_605_tax_rate: 21%
+        box_606:
+          editable: 'true'
+          line_number: '606'
+          sub_title: IVA deducible en operaciones interiores de bienes y servicios
+          title: 'Operaciones interiores corrientes:'
+        box_611:
+          editable: 'true'
+          line_number: '611'
+          sub_title: IVA deducible en operaciones interiores de bienes de inversión
+          title: 'Operaciones interiores de bienes de inversión:'
+        box_611_tax_rate: 10%
+        box_612:
+          editable: 'true'
+          line_number: '612'
+          sub_title: IVA deducible en operaciones interiores de bienes de inversión
+          title: 'Operaciones interiores de bienes de inversión:'
+        box_613:
+          editable: 'true'
+          line_number: '613'
+          sub_title: IVA deducible en operaciones interiores de bienes de inversión
+          title: 'Operaciones interiores de bienes de inversión:'
+        box_613_tax_rate: 21%
+        box_614:
+          editable: 'true'
+          line_number: '614'
+          sub_title: IVA deducible en operaciones interiores de bienes de inversión
+          title: 'Operaciones interiores de bienes de inversión:'
+        box_619:
+          editable: 'true'
+          line_number: '619'
+          sub_title: IVA deducible en importaciones de bienes corrientes
+          title: 'Importaciones y adquisiciones intracomunitarias de bienes y servicios:'
+        box_619_tax_rate: 10%
+        box_62:
+          editable: 'true'
+          line_number: '62'
+          negative_adjustment: 'true'
+          title: Rectificación de deducciones
+        box_620:
+          editable: 'true'
+          line_number: '620'
+          sub_title: IVA deducible en importaciones de bienes corrientes
+          title: 'Importaciones y adquisiciones intracomunitarias de bienes y servicios:'
+        box_621:
+          editable: 'true'
+          line_number: '621'
+          sub_title: IVA deducible en importaciones de bienes corrientes
+          title: 'Importaciones y adquisiciones intracomunitarias de bienes y servicios:'
+        box_621_tax_rate: 21%
+        box_622:
+          editable: 'true'
+          line_number: '622'
+          sub_title: IVA deducible en importaciones de bienes corrientes
+          title: 'Importaciones y adquisiciones intracomunitarias de bienes y servicios:'
+        box_623:
+          editable: 'true'
+          line_number: '623'
+          title: IVA deducible en importaciones de bienes de inversión
+        box_623_tax_rate: 10%
+        box_624:
+          editable: 'true'
+          line_number: '624'
+          title: IVA deducible en importaciones de bienes de inversión
+        box_625:
+          editable: 'true'
+          line_number: '625'
+          title: IVA deducible en importaciones de bienes de inversión
+        box_625_tax_rate: 21%
+        box_626:
+          editable: 'true'
+          line_number: '626'
+          title: IVA deducible en importaciones de bienes de inversión
+        box_627:
+          editable: 'true'
+          line_number: '627'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes corrientes
+        box_627_tax_rate: 10%
+        box_628:
+          editable: 'true'
+          line_number: '628'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes corrientes
+        box_629:
+          editable: 'true'
+          line_number: '629'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes corrientes
+        box_629_tax_rate: 21%
+        box_630:
+          editable: 'true'
+          line_number: '630'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes corrientes
+        box_631:
+          editable: 'true'
+          line_number: '631'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes de inversión
+        box_631_tax_rate: 10%
+        box_632:
+          editable: 'true'
+          line_number: '632'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes de inversión
+        box_633:
+          editable: 'true'
+          line_number: '633'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes de inversión
+        box_633_tax_rate: 21%
+        box_634:
+          editable: 'true'
+          line_number: '634'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes de inversión
+        box_635:
+          editable: 'true'
+          line_number: '635'
+          title: IVA deducible en adquisiciones intracomunitarias de servicios
+        box_635_tax_rate: 10%
+        box_636:
+          editable: 'true'
+          line_number: '636'
+          title: IVA deducible en adquisiciones intracomunitarias de servicios
+        box_637:
+          editable: 'true'
+          line_number: '637'
+          title: IVA deducible en adquisiciones intracomunitarias de servicios
+        box_637_tax_rate: 21%
+        box_638:
+          editable: 'true'
+          line_number: '638'
+          title: IVA deducible en adquisiciones intracomunitarias de servicios
+        box_639:
+          editable: 'true'
+          line_number: '639'
+          negative_adjustment: 'true'
+          title: Rectificación de deducciones
+        box_64:
+          line_number: '64'
+          title: Suma de deducciones
+        box_65:
+          line_number: '65'
+          title: Resultado régimen general
+        box_659:
+          editable: 'true'
+          line_number: '659'
+          title: IVA a la importación liquidado por la Aduana (sólo sujetos pasivos
+            con opción de diferimiento)
+        box_660:
+          editable: 'true'
+          line_number: '660'
+          negative_adjustment: 'true'
+          title: Cuotas deducibles en virtud de resolución administrativa o sentencia
+            firmes con tipos no vigentes
+        box_661:
+          editable: 'true'
+          line_number: '661'
+          negative_adjustment: 'true'
+          title: Cuotas deducibles en virtud de resolución administrativa o sentencia
+            firmes con tipos no vigentes
+        box_662:
+          editable: 'true'
+          line_number: '662'
+          title: Cuotas pendientes de compensación al término del ejercicio
+        box_84:
+          line_number: '84'
+          title: Suma de resultados
+        box_85:
+          editable: 'true'
+          line_number: '85'
+          title: Compensación de cuotas del ejercicio anterior
+        box_86:
+          line_number: '86'
+          title: Resultado de la liquidación
+        box_95:
+          editable: 'true'
+          line_number: '95'
+          title: Total resultados a ingresar en las autoliquidaciones de IVA del ejercicio
+        box_97:
+          editable: 'true'
+          line_number: '97'
+          title: Si el resultado de la autoliquidación del último periodo es a compensar
+            o a devolver
+        box_98:
+          editable: 'true'
+          line_number: '98'
+          title: Si el resultado de la autoliquidación del último periodo es a compensar
+            o a devolver
+        box_99:
+          editable: 'true'
+          line_number: '99'
+          negative_adjustment: 'true'
+          title: Operaciones en régimen general
+      sections:
+        empty_section:
+          default_message: Esta parte de la devolución no está soportada por Sage
+            One. Puedes incorporar esta información en la web de la <a href='http://www.agenciatributaria.es'>Agencia
+            Tributaria</a> si es requerida.
+        section1:
+          business_name:
+            row_description: Apellidos y Nombre o Razón social o denominación
+          description: 1. Sujeto Pasivo + 3. Datos Estadísticos
+          vat_number:
+            row_description: NIF
+        section10:
+          description: 10. Volumen de operaciones
+        section11:
+          description: 11. Operaciones específicas
+          subtitle:
+            title1: Operaciones realizadas en el ejercicio
+            title2: ''
+            title3: ''
+        section12:
+          description: 12. Prorrata
+        section13:
+          description: 13. Actividades con regímenes de deducción diferenciados
+        section3:
+          business_activity:
+            code: Clave
+            description: Descripción
+            option1: Actividades sujetas al IAE (Activ. Empresariales)
+            option2: Actividades sujetas al IAE (Activ. Profesionales y Artísticas)
+            option3: Arrendadores de Locales de Negocios y Garajes
+            option4: Actividades Agrícolas, Ganaderas o Pesqueras, no sujetas al IAE
+            option5: Sujetos pasivos que no hayan iniciado la realización de entregas
+              de bienes o prestaciones de servicios correspondientes a actividades
+              empresariales o profesionales y no estén dados de alta en el IAE
+            option6: Otras actividades no sujetas al IAE
+            row_description: Actividades a las que se refiere la declaración
+        section4:
+          description: 4. Datos del Representante y firma de la declaración
+          message: Si tu empresa necesita completar esta sección, estará disponible
+            en enero, a tiempo para que presentes tu Modelo 390 a fin de mes. Si deseas
+            enviarlo antes, puedes hacerlo a través de la autoridad tributaria o tu
+            asesor.
+        section5_1:
+          description: 5. Operaciones Realizadas en Régimen General
+          subtitle:
+            title1: IVA Devengado
+            title2: Base imponible
+            title3: Tipo %
+            title4: Cuota devengada
+        section5_2:
+          subtitle:
+            title1: IVA Deducible
+            title2: Base imponible
+            title3: Tipo %
+            title4: Cuota devengada
+        section6:
+          description: 6. Operaciones realizadas en régimen simplificado
+        section7:
+          description: 7. Resultado liquidación anual
+          subtitle:
+            title1: Liquidación anual
+            title2: ''
+            title3: ''
+        section8:
+          description: '8. Tributación por razón de territorio '
+        section9:
+          description: 9. Resultado de las liquidaciones
+          radio_button1:
+            label: A Compensar
+          radio_button2:
+            label: A Devolver
+          subtitle:
+            title1: Períodos que no tributan en Régimen especial del grupo de entidades
+            title2: ''
+            title3: ''
+      year_picker:
+        label: Ejercicio
+    paid_false: Not paid
+    paid_true: Paid
+    part_paid: Part paid
+    personal_representative:
+      address: Dirección
+      business_number: NIF
+      door_number: Prta.
+      floor: Piso
+      municipality: Municipio
+      name: Apellidos y Nombre o Razón social o denominación
+      postcode: Código Postal
+      province: Provincia
+      stairs: Esc.
+      street: Calle, Pza., Avda
+      street_name: Vía Pública
+      street_number: Número
+      telephone: Teléfono
+      title: Personas físicas
+    record_payment_dialog:
+      bank_placeholder_payment: Where did this money come from?
+      bank_placeholder_refund: Where will this money go to?
+      label:
+        amount: Amount
+        bank_payment: Bank from
+        bank_refund: Bank to
+        date_payment: Date of Payment
+        date_refund: Date of Refund
+        reference: Reference
+      title_payment: Record Payment of VAT Return
+      title_refund: Record Refund of VAT Return
+      validation_message:
+        lockdown_date: The payment date must be later than the lockdown date of %{date}
+    report:
+      detailed_report: Detailed Report
+      export: Export
+      summary_report: Summary Report
+    report_status:
+      draft: Draft Return
+      filed_not_paid: Submitted manually but not paid
+      filed_not_refunded: Submitted manually but not refunded
+      filed_paid: Submitted manually and paid
+      filed_part_paid: Submitted manually and %{amount} paid
+      filed_part_refunded: Submitted manually and %{amount} refunded
+      filed_refund_carryforward: Filed and refund to carry forward
+      filed_refunded: Submitted manually and refunded
+    settings_dialog:
+      label:
+        tax_frequency: How often do you submit tax returns?
+    step_2_content:
+      button:
+        download_tax_file: Download .Tax File
+      label:
+        final_return: This is my final return for this financial year
+        optional_reference: Optional Reference
+      message:
+        MODELO390: |
+          Para acelerar el proceso de enviar tu modelo 390, puedes descargar una copia en formato .txt.
+          Luego podrás enviársela a la <strong><a target="_blank" href="https://www.agenciatributaria.gob.es/">Agencia Tributaria</a></strong> y el modelo se rellenará automáticamente.
+
+          También puedes rellenar el modelo por otros medios y continuar sin descargártelo
+      title:
+        mark_as_submitted: Mark as Submitted
+    table_header:
+      action: Action
+      date: Date
+      from: From
+      income_tax_expense_contact: Supplier
+      income_tax_revenue_contact: Customer
+      invoice_number: Invoice Number
+      irpf_percentage: IRPF %
+      irpf_value: IRPF Value
+      net: Net
+      net_total: Total
+      nif: NIF
+      reference: Reference
+      return_amount: Return Amount (%{currency_symbol})
+      status: Status
+      tax_type: Tax Type
+      to: To
+      total: Total
+      transaction_no: Trx No
+      type: Type
+      year: Year
+      year_quarter: Settlement Period
+    tax_calculation_on_report:
+      cash: VAT has been calculated based on the payment date.
+      invoice: VAT has been calculated based on the date of invoices.
+      mixed: VAT has been calculated using a mixture of invoice and payment dates.
+    tax_settings:
+      button: Set Tax Settings
+      message: Set the tax rates you'll apply to sales and purchases, so we can do
+        the math for you.
+      title: How will you charge sales tax?
+    title:
+      MODELO390: Modelo390
+      calculate_tax: Calculate Tax
+      create_return: Create VAT Return
+      submit: Submit VAT Returns
+      tax_return_type:
+        MODELO390: Annual
+      tax_returns: Your VAT Returns
+    urls:
+      draft:
+        MODELO130: "/reports/income_tax_es/draft"
+        MODELO390: "/reports/modelo390/draft"
+      index:
+        MODELO130: "/reports/income_tax_es#MODELO130"
+        MODELO390: "/reports/modelo390#MODELO390"
+      new:
+        MODELO130: "/reports/income_tax_es/new?tax_return_type=MODELO130"
+        MODELO390: "/reports/modelo390/new?tax_return_type=MODELO390"
+      submit:
+        MODELO130: "/reports/income_tax_es/mark_as_submitted"
+        MODELO390: "/reports/modelo390/mark_as_submitted"
+    vat_adjustment_dialog:
+      header:
+        income: Ingresos
+        trimesters: Trimestrales
+      label:
+        first_trimester: 1er Trimestre
+        fourth_trimester: 4º Trimestre
+        second_trimester: 2º Trimestre
+        third_trimester: 3er Trimestre
+        total: Total
+      title:
+        MODELO390: Ajuste de IVA
+    warnings:
+      adjustment_clear_warn: 'Your dates have changed: Please calculate your tax return
+        again to reflect your changes. Please note that any adjustments will be cleared.'
+      corrective_return_warn: You have already created a VAT return for the selected
+        period, this return will be set as a corrective return.
+      date_changed_warn: 'Your dates have changed: Please calculate your tax return
+        again to reflect your changes.'
+    year_quarter_picker:
+      label: Settlement Period
+  time:
+    formats:
+      date_and_time: "%a %d %b %Y, %R"
+      date_only: "%d %b %Y"
+      short_full_month: "%d %B, %H:%M"
+      short_with_comma: "%d %b, %H:%M"
+      tax_return: "%-d %b %Y %-l:%M%P"
+      time_only: "%H:%M"
+  transaction_types:
+    prompt_all: All
+  two_factor_authentication:
+    error: We could not verify the validity of your entered PIN. Please try again.
+    subject: Authentication required
+    verify:
+      action: Verify
+      description: You are trying to access Sage Business Cloud Accounting from a
+        new device, please use the PIN we have just emailed to you to verify your
+        identity.
+      main_title: Two Step Verification
+      pin: PIN
+      title: Verify Your Identity
+  unknown: Unknown
+  unknown_country: an unknown country
+  updates:
+    updates_button: View updates
+    updates_title: New updates launched
+    view_updates: We have made more improvements to your service.
+  upgrades:
+    notification:
+      long_running:
+        slack_message: |-
+          An upgrade to Sage Business Cloud Accounting took longer than expected.
+
+          Business GUID - %{guid}
+          Business Name - %{name}
+          Migrating for - %{length}
+          Started At - %{started_at}
+          Finished At - %{finished_at}
+        slack_subject: Long Running Upgrade to Sage Business Cloud Accounting - %{business}
+    success:
+      available_anytime_you_need: " is available anytime you need."
+      enjoy_sage_one_accounting: Enjoy Sage Business Cloud Accounting!
+      help_and_support: Help and support
+      mission_complete_html: Mission <b>complete!</b>
+      start_using_sage_one_accounting: Start Using Accounting
+  user_admin:
+    auth_provider:
+      title: Auth Providers
+    chargeable_dates_updated: Chargeable Dates Updated
+    create_user:
+      title: Create User
+    customer_list:
+      title: Customer List
+    emails:
+      activation:
+        subject: Activate Your Account
+    handled_by: Handled by %{name}
+    is_owner: You are viewing the owner of the business.
+    login:
+      errors:
+        blocked: User access is disabled.
+    pending_activations_list:
+      title: Pending Activations
+    search:
+      search_down: There was a problem contacting our search instance. Please search
+        by full email address until this issue has been resolved.
+    service_actions:
+      confirm_message_html: Please insert this string <b>%{rand}</b>
+      restart:
+        button: Reset Service
+        confirm: Are you sure you wish to reset the service for the selected business?  This
+          action is irreversible and will cause data loss.
+        confirm_label: If you wish to reset the service for the selected business,
+          please submit the string. This action is irreversible and will cause data
+          loss.
+        dialog_title: Reset Service Confirmation
+        error: Could not reset service.
+        success: Service has been successfully reset.
+      terminate:
+        additional_businesses_remain: You are attempting to delete the lead business
+          whilst additional businesses remain. Please delete any additional businesses
+          first.
+        button: Terminate Business
+        confirm: Are you sure you wish to terminate this business? This action is
+          irreversible and will cause data loss.
+        confirm_label: If you wish to terminate this business, please submit the string.  This
+          action is irreversible and will cause data loss.
+        dialog_title: Terminate Business Confirmation
+        error: Could not terminate business.
+        success: Business has been successfully terminated.
+      title: Service Actions
+    service_provider:
+      direct:
+        name: N/A
+      reseller: "%{name} (Reseller)"
+    user_actions:
+      block:
+        button: Block User Access
+        prompt: Are you sure you wish to block user access?
+        success: User access has been blocked.
+      chargeable_date: "%{name}: Chargeable Date"
+      chargeable_date_fixed: Chargeable date is fixed in billing system.
+      delink:
+        button: Delink Account
+        prompt: Are you sure you wish to delink this account? This is NOT reversible.
+        success: Account delinked
+      login:
+        button: Login as User
+        prompt: |-
+          All user activity is logged to help us know who has done what.
+
+          Customer data is confidential.  You must have their express permission to sign in.
+
+          Do you have the customer's permission to sign in?
+      resend_email_verification: Resend Activation Email
+      title: Actions
+      unblock:
+        button: Allow User Access
+        prompt: Are you sure you wish to allow user access?
+        success: User access has been allowed.
+      view_activity: View User Activities
+    user_audit:
+      title: User Audit Trail
+    user_details:
+      business_summary: Business Summary
+      contact_details: Contact Details
+      title: User Details
+  validations:
+    country_must_be: Country must be %{value}
+    country_must_be_one_of: Country must be one of %{value}
+    decimal: Must be a decimal
+    digit_length: Must be %{value} digits
+    email: Please enter a valid email address
+    equal_or_larger_than: Must be equal or larger than %{value}
+    integer: Must be an integer
+    integer_length_range: Must be between %{min} and %{max} digits in length
+    invalid_format: Invalid Format
+    length: Must be %{value} characters in length
+    length_greater_or_less: Must be %{value} characters or less
+    length_greater_or_more: Must be %{value} characters or more
+    length_range: Must be between %{min} and %{max} characters in length
+    max_date_range: Choose dates that are less than %{max} days apart
+    postcode_for_country: invalid for the selected country
+    value_between: Must be a value between %{min} and %{max}
+    value_match: "'%{value}' does not match our records."
+  views:
+    fuji_core_accounting/tax_period:
+      show:
+        end_date_nil: To Present
+  warnings:
+    messages:
+      change_affactes_all_records: Changing a pricing label will affect all records.
+      did_you_mean: Did you mean...
+      dirty_artefact: This %{artefact} has unsaved changes.
+      dirty_form: This form contains unsaved data.
+      disable_tax_rate: Deleting this tax rate will make it immediately inaccessible.
+      duplicate_artefact_found_purchases: A similar transaction already exists for
+        this Supplier
+      duplicate_artefact_found_sales: A similar transaction already exists for this
+        Customer
+      has_changed: The value of this field has been changed.
+      high_tax_rate_percentage: This is an abnormally high rate.
+      older_than_start_date: Date selected is prior to your Accounts Start Date of
+        %{date}.
+      verification_failure: We couldn't verify this email address; you can correct
+        it or try sending anyway.
+      verification_failures: 'We couldn''t verify the following email addresses; you
+        can correct them or try sending anyway: %{email_addresses}'
+      zero_tax_rate_percentage: This rate percentage is currently set to 0%.
+    title: 'Warning:'
+  widgets:
+    accounting_type_label:
+      accrual: Accrual
+      cash_based: Cash Based
+      indicator: 'Your current accounting type is: '
+    advanced_filter:
+      refine: Refine
+  withholding_tax:
+    edit:
+      exclude_description: IRPF is not added to the invoice.
+      include_description: Tell us the percentage or value to be withheld.
+      percentage_to_apply: 'Percentage to apply:'
+      purchase_corrective_invoice:
+        exclude: Do not deduct IRPF
+        include: Deduct IRPF
+        title: IRPF to be withheld
+      purchase_invoice:
+        exclude: Do not deduct IRPF
+        include: Deduct IRPF
+        title: IRPF to be withheld
+      sales_corrective_invoice:
+        exclude: Do not include IRPF
+        include: Include IRPF
+        title: Amend IRPF
+      sales_invoice:
+        exclude: Do not include IRPF
+        include: Include IRPF
+        title: Amend IRPF
+      sales_quote:
+        exclude: Do not include IRPF
+        include: Include IRPF
+        title: Amend IRPF
+      value_equals: of **%{value}** equals
+    irpf_withheld: IRPF
+    label: IRPF
+    not_applicable: Not applicable
+  wizards:
+    fuji_banking/bank_reconciliation_wizard:
+      titles:
+        first_step: Define Reconciliation Details
+        second_step: Reconcile Entries
+    multi_page_wizard:
+      buttons:
+        back: Back
+        cancel: Cancel
+        next: Next
+        submit: Submit
+    multi_step_wizard:
+      buttons:
+        back: Back
+        next: Next
+        submit: Mark as Filed
+    sop_authentication/signup_wizard:
+      long_titles:
+        authentication: Sign in to create your account
+        user_details: Enter your user details
+      prompts:
+        financial_settings_tax_scheme: Please select a VAT scheme
+        financial_settings_tax_submission_frequency_type: Please select a Submission
+          frequency
+        user_country: Select a Country
+      titles:
+        authentication: Sign In Details
+        business_address: Business Address
+        business_details: Business Details
+        coa_template_selection: COA Template Selection
+        contact_information: Contact Information
+        identification: Identification
+        services: Services
+        tax_details: VAT details
+        user_details: Contact Details

--- a/spec/data/real_life_sample_normalized.yml
+++ b/spec/data/real_life_sample_normalized.yml
@@ -1,0 +1,14197 @@
+---
+en:
+  SSO:
+    Error:
+      Message: "<p>There has been a problem.</p><p>If you cannot sign in, please email
+        <strong>sagebusinesscloudsupport@sage.com</strong> or call our Customer Service
+        Team on <strong>0845 111 6611 - UK</strong> or <strong>1890 812 811 - Ireland</strong></p>"
+    Password_Change:
+      Button: Continue
+  accounting_premium:
+    promotion_header:
+      button_message: Take the next step
+      message: Good work! Your growing business is ready to take the next step
+    trial_header:
+      button_message: Subscribe Today
+      message: You are currently in a trial
+  accounting_types:
+    accrual: Accrual (Recommended)
+    accrual_plain: Accrual
+    cash: Cash Based
+    description1: The accounting method defines when your business recognizes income
+      and expenses.
+    description2: Your profit, tax liability, and other values on reports are calculated
+      differently based on this selection.
+    help_link_text: Learn more
+    pod_title: Accounting Method
+    suffix:
+      accrual: accrual
+      cash_based: cash_based
+    title: Accounting Type
+  accounts_start_date:
+    non_opening_balance:
+      message: You cannot record entries prior to your Accounts Start Date of %{date}.
+    opening_balance:
+      message: You cannot record entries on or after your Accounts Start Date of %{date}.
+  actions:
+    advanced:
+      apply: Apply
+      bank_account:
+        connect: Connect to Bank
+        download_online: "%{transaction_count} New Transactions"
+        import_statement: Import Statement
+        new: Bank Account
+        reconcile: Reconcile
+        rules: Rules
+      bank_deposit:
+        new: Bank Deposit
+      cheque_register: Cheque Register
+      create: Create
+      create_new: Create New
+      invoicing:
+        add_corrective_invoice: Add Another Corrective Invoice
+        add_purchase_credit_note: Add Another Credit Note
+        add_purchase_invoice: Add Another Invoice
+        add_sales_credit_note: Add Another Credit Note
+        add_sales_estimate: Add Another Estimate
+        add_sales_invoice: Add Another Invoice
+        add_sales_quote: Add Another Quote
+        created_success: Great! %{artefact_type} Created
+        edited_success: Great! %{artefact_type} Edited
+        purchase_corrective_invoice: Corrective Invoice
+        purchase_credit_note: Credit Note
+        purchase_invoice: Invoice
+        sales_corrective_invoice: Corrective Invoice
+        sales_credit_note: Credit Note
+        sales_estimate: Estimate
+        sales_invoice: Invoice
+        sales_quote: Quote
+        settings_message: 'The following settings need to be entered by a user with
+          Full Access to Settings. Please ask your Supervisor or Accountant to enter
+          these: '
+        view_all_credit_notes: View All Credit Notes
+        view_all_estimates: View All Estimates
+        view_all_purchase_corrective_invoices: View All Corrective Invoices
+        view_all_purchase_invoices: View All Invoices
+        view_all_quotes: View All Quotes
+        view_all_sales_corrective_invoices: View All Corrective Invoices
+        view_all_sales_invoices: View All Invoices
+      new: New
+      new_entry: New Entry
+      opening_balances:
+        new: New Opening Balance
+      payment:
+        new: Purchase / Payment
+      quick_entry: New Quick Entry
+      quick_entry_import: Import Quick Entries
+      receipt:
+        new: Sale / Receipt
+      upload: Upload
+    advanced_uk:
+      analysis_type:
+        create: Create Analysis Type
+        delete: Delete Analysis Type
+      customer_opening_balance_entry:
+        new: New Opening Balance
+      journal_code:
+        new: Create Journal Code
+      on_save:
+        confirm_disputed: One or more of the selected items are in dispute. Recording
+          a payment will clear its disputed status.
+        confirm_disputed_and_pay_on_account: You have not allocated the full amount
+          of the receipt/payment and some of the items are disputed. Do you want to
+          save the unallocated amount as a payment on account and clear the disputed
+          status on these records?
+        confirm_pay_on_account: You have not allocated the full amount of the receipt/payment.  Do
+          you want to save the unallocated amount as a payment on account?
+        dialog_title: Confirm
+        edited_analysis: You have edited an analysis category that is in use, this
+          will update any items linked to this analysis type. Would you like to continue?
+        eu_tax_registered: EU VAT registered
+        rest_of_world: outside of the EU
+        vat_cash_mismatch: There is a mismatch between the net/VAT element of the
+          allocated items which may result in inaccuracies on your VAT return. Do
+          you want to save this allocation?
+        vat_cash_poa: To save a payment on account on the VAT Cash Accounting Scheme,
+          you must select the VAT Rate which applies to this receipt/payment.
+        vat_cash_poa_no_tax: VAT is not due on this payment on account as this contact
+          is %{status}.
+      purchase_batch_entry:
+        new: New Quick Entry
+      sales_batch_entry:
+        new: New Quick Entry
+      sales_invoice:
+        tax_inclusive: " [VAT Inclusive]"
+      supplier_opening_balance_entry:
+        new: New Opening Balance
+      tax_return:
+        calculate: Calculate
+        new: Create VAT Return
+        pay: Pay
+        reclaim: Reclaim
+    business_membership:
+      new: Invite User
+    calculate: Calculate
+    cancel: Cancel
+    change: Change
+    clone: Make a copy
+    continue: Continue
+    email: Email
+    export: Export
+    export_detailed: Export Detailed
+    filters: Filters
+    fuji_banking:
+      bank_account:
+        add: Add a new account
+        destroy: Are you sure you wish to delete this bank account?
+        edit: Edit Bank Account
+        manage: Manage Bank Accounts
+        new: New Bank Account
+        new_account_dialog:
+          save_and_connect: Save & Connect Bank
+          save_and_dont_connect: Save
+          title: Add Account
+        pay_into_bank: Pay into Bank
+      bank_transfer:
+        new: Bank Transfer
+      deposits:
+        choose_account: Select Bank Account
+        close: Close
+        select: Select
+      updated_credentials: Credentials updated successfully.
+    fuji_contacts/contact:
+      add_account_name: Add an Account Name
+      add_account_number: Add an Account Number
+      add_bank_transit_number: Add a Transit Number
+      add_bic: Add a BIC/Swift
+      add_iban: Add an IBAN
+      add_institution_number: Add an Institution Number
+      add_sort_code: Add a Sort Code
+      clear: Clear
+      csv: Export to CSV file
+      delete_activity:
+        title: Confirm deletion of Contact Activity
+      delete_address:
+        additional_message: 'This will also delete the following individuals associated
+          with this address: %{namesToDelete}'
+        title: Delete Address
+      delete_contact:
+        message: Are you sure you'd like to delete this contact?
+        title: Delete Contact
+      delete_message: Are you sure you wish to continue?
+      email: Email
+      fr_tax_calculation:
+        options:
+          cash: Payments
+          invoice: Invoices
+        title: VAT is calculated on
+      manage: Manage
+      manage_account_allocation: Account Allocation
+      manage_statement: Manage Statement
+      manage_statements: Statements
+      pdf: Print
+      prompt:
+        none: None
+      recargo:
+        options:
+          disabled: 'No'
+          enabled: 'Yes'
+        title: Equivalence Surcharge
+      send_monthly_statement: Send Monthly Statement
+    fuji_contacts/customer:
+      default_addresses: Statement Addresses/Contacts
+      reports:
+        activity_report:
+          subtitle: Select the date range for your customer activity report
+          title: Activity Report
+        address_list:
+          subtitle: Select the address type(s) to display on this report
+          title: Address List
+        statement_summary:
+          subtitle: Select the date range for your statement summary report
+          title: Statement Summary Report
+        statements_batch:
+          back_button: Back
+          beta_print_limit: "(max %{count} in Beta)"
+          button: Create Statements
+          confirmation_description:
+            one: We'll generate statements for __%{count}__ customer who has more
+              than __%{threshold}__ outstanding. You're owed __%{total_balance} in
+              total__ and the statement date is __%{date}__.
+            other: We'll generate statements for __%{count}__ customers who each have
+              more than __%{threshold}__ outstanding. You're owed __%{total_balance}
+              in total__ and the statement date is __%{date}__.
+          confirmation_email:
+            one: __%{count}__ statement will be emailed.
+            other: __%{count}__ statements will be emailed.
+          confirmation_email_info: __%{count}__ will be emailed to customers.
+          confirmation_print:
+            one: __%{count}__ statement to print & post.
+            other: __%{count}__ statements to print & post.
+          confirmation_print_info: __%{count}__ will be downloadable from the top
+            bar.
+          date: Produce statement as of
+          feedback: Let us know what you think of this feature in the top bar.
+          generate_button: Generate
+          link: Statement Run
+          next_button: Next
+          no_results: As at %{date} there were no customers with an outstanding amount
+            over %{amount}.
+          no_results_description: Based on the previous page's criteria and your customer
+            profile settings; there were no statements to generate.
+          no_results_try_again: Go back and adjust the criteria, or try sending statements
+            another time.
+          popover:
+            body: Send statements to lots of customers in one go. You can choose print
+              or email for each customer in their profile options.
+            button: Got it
+            title: Customer Statements
+          report_in_progress: Please wait until your previous statement run has finished
+            generating before starting a new one.
+          subtitle: 'Generate customer statements for all your customers based on
+            their settings and the following criteria:'
+          threshold_amount: Outstanding amount over
+          title: Customer Statement Run
+          toast_error_message: An unexpected error occurred. Please try again later.
+          toast_error_title: Error generating statements
+          toast_info_message: You can carry on working whilst we're doing this, or
+            even log out and check back later.
+          toast_info_title:
+            one: Generating %{count} statement
+            other: Generating %{count} statements
+          tooltip: Invoices paid after the Statement Date will still be included
+        title: Reports
+      send_monthly_statement: Schedule Monthly Statements
+      statement_delivery_method:
+        statement_delivery_method_email: Sent by email
+        statement_delivery_method_print: By post (PDF Generated)
+      submit: Submit
+    fuji_contacts/supplier:
+      default_addresses: Remittance Addresses
+      new: New Supplier
+      reports:
+        activity_report:
+          subtitle: Select the date range for your supplier activity report
+          title: Activity Report
+        address_list:
+          subtitle: Select the address type(s) to display on this report
+          title: Address List
+        title: Reports
+    fuji_core_accounting/coa_account:
+      new: Create COA Account
+    fuji_core_accounting/coa_templates:
+      edit: Edit Template
+      index:
+        ie: Irish COA Templates
+        uk: UK COA Templates
+        us: US COA Templates
+    fuji_core_accounting/tax_periods:
+      manage_tax_periods: Manage Periods
+      new: Add Period
+    fuji_core_accounting/tax_rates:
+      new: Add Tax Rate
+    fuji_invoicing/purchase_corrective_invoice:
+      clear_dispute: Clear Dispute
+      dispute: Set as Disputed
+      manage_invoice: Manage Corrective Invoice
+    fuji_invoicing/purchase_credit_note:
+      clear_dispute: Clear Dispute
+      dispute: Set as Disputed
+      manage_credit_note: Manage Credit Note
+    fuji_invoicing/purchase_invoice:
+      clear_dispute: Clear Dispute
+      create_corrective_invoice: Create Corrective Invoice
+      create_credit_note: Create Credit Note
+      dispute: Set as Disputed
+      manage_invoice: Manage Invoice
+    fuji_invoicing/sales_corrective_invoice:
+      manage_invoice: Manage Corrective Invoice
+      print_delivery_note: Print Delivery Note
+      refund_dialog:
+        panel:
+          bank_account: Paid from Bank Account
+          reference: Reference (optional)
+          refund_date: Refund Date
+          tax_rate: Tax Rate
+        radio_buttons:
+          refund:
+            text: " - Money is returned to the customer."
+            title: Refund payment
+          unallocate:
+            text: " - Detach the payment from this corrective invoice, and record
+              as a payment on account."
+            title: Unallocate
+        title: 'Amend Customer Receipt: %{paid_amount}'
+      tabs:
+        all: All
+        draft: Draft
+        outstanding: Outstanding
+        overdue: Overdue
+        paid: Paid
+    fuji_invoicing/sales_credit_note:
+      manage_credit_note: Manage Credit Note
+    fuji_invoicing/sales_estimate:
+      create_invoice: Create Invoice
+      decline: Set as Declined
+      manage_quote: Manage Estimate
+      new: New Estimate
+      undecline: Clear Declined
+    fuji_invoicing/sales_invoice:
+      create_corrective_invoice: Create Corrective Invoice
+      create_credit_note: Create Credit Note
+      manage_invoice: Manage Invoice
+      print_delivery_note: Print Delivery Note
+      refund_dialog:
+        panel:
+          bank_account: Paid from Bank Account
+          reference: Reference (optional)
+          refund_date: Refund Date
+          tax_rate: Tax Rate
+        radio_buttons:
+          refund:
+            text: " - Money is returned to the customer."
+            title: Refund payment
+          unallocate:
+            text: " - Detach the payment from this invoice, and record as a payment
+              on account."
+            title: Unallocate
+        title: 'Amend Customer Receipt: %{paid_amount}'
+      tabs:
+        all: All
+        draft: Draft
+        outstanding: Outstanding
+        overdue: Overdue
+        paid: Paid
+    fuji_invoicing/sales_quote:
+      create_invoice: Create Invoice
+      decline: Set as Declined
+      manage_quote: Manage Quote
+      undecline: Clear Declined
+    hide: Hide
+    more: More
+    new_account: New Account
+    new_corrective_invoice_purchase: New Corrective Invoice
+    new_corrective_invoice_sales: New Corrective Invoice
+    new_credit_note_purchase: New Credit Note
+    new_credit_note_sales: New Credit Note
+    new_invoice_purchase: New Invoice
+    new_invoice_sales: New Invoice
+    new_quote_sales: New Quote
+    ok: OK
+    pdf: Print
+    refresh: Refresh
+    remove: Remove
+    reset: Reset
+    save: Save
+    save_add_new: Save & Add New
+    save_artefact_type: Save %{artefact_type}
+    save_as_draft: Save as Draft
+    save_new: Save & New
+    save_pay: Save & Pay Now
+    save_print: Save & Print
+    save_send: Save & Email
+    search: Search
+    send: Send
+    seperator: " | "
+    sop_admin/super:
+      admin:
+        actions: Manage
+        index: Manage tax periods
+        index2:
+          tax_periods:
+            ie: Manage Irish Tax Periods
+            uk: Manage UK Tax Periods
+    sop_settings/user_management:
+      new: Create
+    update: Update
+    user_management:
+      resend_invitation: Resend invitation
+    vat_adjustments: Ajustes del IVA
+    vat_adjustments_button_text: Entendido!
+    vat_adjustments_description_1: Los ajustes no se reflejarán en las transacciones
+      de Sage One.
+    vat_adjustments_description_2: Si aún no te has ocupado de estos ajustes, por
+      ejemplo, no están relacionados con un sistema anterior, debes registrar las
+      entradas de diario manuales para asegurarte de que cualquier aumento o disminución
+      de la obligación de IVA se refleje en tus cuentas.
+    verify: Verify
+    view: view
+    view_all: View All
+    wizard:
+      advanced_uk/quickstart:
+        telephone_help: "<b>Need help?</b><br>Call 0845 1111 6611"
+      fuji_banking/bank_reconciliation:
+        steps:
+          first_step:
+            cancel: Exit Bank Reconciliation
+            next: Reconcile Entries
+          second_step:
+            cancel: Exit Bank Reconciliation
+            finish: Save for Later
+            prev: Change Reconciliation Details
+      mysageone_core/mobile/signup:
+        steps:
+          business_address:
+            finish: Continue
+  activation:
+    resend:
+      message: Would you like to resend the activation email to {{business}}?
+      title: Resend Activation?
+  activemodel:
+    attributes:
+      advanced_uk/quick_start:
+        accounts_start_date: When will you start using Sage Business Cloud Accounting?
+        business_address_registered: The same address is registered with Companies
+          House.
+        business_classification: What does your business do?
+        business_county: County
+        business_name: Business Name
+        business_phone_number: Telephone
+        business_postcode: Postcode
+        business_province: Province
+        business_registered_county: County
+        business_registered_postcode: Postcode
+        business_registered_street_1: Address 1
+        business_registered_street_2: Address 2
+        business_registered_town: Town / City
+        business_start_date: When did your business officially start?
+        business_street_1: Address 1
+        business_street_2: Address 2
+        business_town: Town / City
+        business_type: Type of Business
+        disable_business_start_date: My business hasn't started yet, or I'm not sure
+          of the date.
+        financial_year_end_date: When is the last day of your financial year?
+        flat_rate_scheme: I use the Flat Rate Scheme from HMRC.
+        purchase_tax_calculation_method: Purchases
+        sales_tax_calculation_method: Sales
+        tax_calculation_method: VAT Calculation Method
+        tax_scheme: Tax Scheme
+        vat_number: VAT Number
+        vat_rate: Flat Rate
+      fuji_support/email:
+        send_bcc: Send a copy to myself?
+      sop_authentication/signup:
+        business_name: Business Name
+        business_telephone: Telephone
+        user_email: Email
+        user_first_name: First Name
+        user_last_name: Last Name
+      sop_authentication/signup_full:
+        business_city: City
+        business_country: Country
+        business_county: County
+        business_mobile: Mobile
+        business_name: Business Name
+        business_postcode: Postcode
+        business_street_1: Address 1
+        business_street_2: Address 2
+        business_telephone: Telephone
+        business_website: Website
+        user_email: Email
+        user_first_name: First Name
+        user_last_name: Last Name
+      sop_settings/invitation_signup:
+        user_first_name: First Name
+        user_last_name: Last Name
+    errors:
+      models:
+        fuji_banking/bank_interest_and_charges:
+          attributes:
+            bank_charge_date:
+              before_statement_end_date: must be before the statement end date
+            bank_interest_date:
+              before_statement_end_date: must be before the statement end date
+            bank_interest_earned_date:
+              before_statement_end_date: must be before the statement end date
+            base:
+              cannot_add_transactions_before_accounts_opening_balance: You cannot
+                enter interest or charges dated before the accounts opening balance
+                date
+        fuji_support/email:
+          attributes:
+            message:
+              invalid_message: Contains invalid characters.
+  activerecord:
+    attributes:
+      addresses/models/address:
+        address_type_form_proxy_id: Address Type
+        cc: Cc
+        country_id: Country
+        customer_name: Customer Name
+        delivery_address: Delivery Address
+        end_date: To
+        invoice_address: Invoice Address
+        line_1: Address 1
+        line_2: Address 2
+        line_3: Town/City
+        line_4: County
+        main: Main
+        main_address_name: Main Address
+        message: Message
+        name: Address Name
+        new_address_name: New Address
+        new_contact_name: New Contact
+        postcode: Postcode
+        second_address_name: Address 2
+        start_date: From
+        supplier_name: Supplier Name
+        to: To
+      advanced_uk/address_contact:
+        name: Full Name
+        reference: Reference
+        role: Job Title
+        sort_code: Sort Code
+        supplier_credit_days: Supplier Credit (days)
+        terms_and_conditions: Invoice Terms & Conditions
+      advanced_uk/audit_trail:
+        bank_reconciled: Bank Reconciled
+        by: Created By
+        cr: Credit
+        cr_formatted: Credit
+        created_at: Entry Date
+        date: Trx Date
+        dr: Debit
+        dr_formatted: Debit
+        invoice_number: Invoice Number
+        ledger_account_name: Ledger Account
+        name: Name
+        reference: Ref
+        removed: Deleted
+        tax_reconciled: VAT Reconciled
+        transaction_type: Type
+        who: User
+      advanced_uk/audit_trail_summary:
+        bank_reconciled: Bank Reconciled
+        business_accrual_transaction_id: Trans ID
+        business_cash_based_transaction_id: Trans ID
+        by: Created By
+        created_at: Entry Date
+        date: Trx Date
+        invoice_number: Invoice Number
+        name: Name
+        net: Net
+        reference: Ref
+        removed: Deleted
+        retailer_tax_amount: Recargo
+        tax: VAT
+        tax_reconciled: VAT Reconciled
+        total: Total
+        transaction_type_id: Type
+        who: User
+      advanced_uk/bank_opening_balance:
+        account_number: Account Number
+        amount: Opening Balance
+        bank_account_id: Bank Account
+        base: ''
+        date: Date
+        reference: Reference
+        sort_code: Sort Code
+      advanced_uk/batch:
+        grand_total: Total Amount
+        net_amount: Total Net Amount
+        tax_amount: Total VAT Amount
+      advanced_uk/batch_entry:
+        batch_entry_details: Details
+        batch_entry_ledger_account_id: Ledger Account
+        batch_entry_number: Transaction Number
+        batch_entry_number_prefix: QE-
+        batch_entry_type_id: Type
+        credit_note:
+          abbr_type: QE-Crn
+        credit_note_opening_balance:
+          abbr_type: OB-Crn
+        currency_total: Total
+        currency_total_net_amount: Net
+        currency_total_tax_amount: VAT
+        customer: Customer
+        date: Date
+        details: Details
+        invoice:
+          abbr_type: QE-Inv
+        invoice_opening_balance:
+          abbr_type: OB-Inv
+        is_purchase_for_resale: Resale
+        opening_balance:
+          artefact_number_prefix: OB-
+        reference: Reference
+        tax_rate_id: VAT Rate
+        total: Total
+        total_for_grid: Total
+        total_net_amount: Net
+        total_net_amount_for_grid: Net
+        total_tax_amount: VAT
+        total_tax_amount_for_grid: VAT
+        trade_of_asset: Outside Flat Rate
+      advanced_uk/catalog_item:
+        active: Active
+        adjust:
+          below_reorder_level: This takes your stock below re-order level
+          cost_price: Cost Price
+          date: Date
+          decrease_by: Decrease By
+          decrease_quantity: Decrease Quantity
+          default_reasons:
+            item_damaged: Item damaged
+            item_returned: Item returned
+            item_written_off: Item written off
+            other: Other
+            stock_take: Stock take adjustment
+          delete_disabled_accounts_lockdown_date: You can't delete this Adjustment
+            as it is dated on or before your year-end lock date.
+          delete_disabled_inactive: You can't delete this Adjustment as your stock
+            item is inactive.
+          delete_disabled_negative_stock: You can't delete this Adjustment as it would
+            result in negative stock.
+          increase_by: Increase By
+          increase_quantity: Increase Quantity
+          item: Stock Item
+          new_quantity_in_stock: New Quantity in Stock
+          quantity_in_stock: Quantity in Stock
+          reason: Reason
+          reference: Stock Adjustment
+          stock_below_zero: You can't adjust your stock level below zero
+          subtitle: Increase or decrease your stock levels without buying or selling.
+          subtitle_edit: Make a change to an existing stock adjustment.
+          successful: Stock level adjusted successfully
+          title: Adjust Stock Level
+          title_edit: Edit Adjustment
+          type: Type
+        analysis_type_0_formatted: Analysis Type 1
+        analysis_type_1_formatted: Analysis Type 2
+        analysis_type_2_formatted: Analysis Type 3
+        category: Category
+        category_as_string: Category
+        cost_price: Cost Price
+        create:
+          additional_information: Additional Information
+          as_of_date: As of Date
+          barcode: Barcode
+          category: Category
+          cost_price: Cost Price
+          cost_price_at_date: Cost Price at Date
+          create: New Item
+          default_measurement_unit_copy: We'll set this as your default measurement
+            unit. You can change it in Settings.
+          default_purchase_copy: We'll set this as your default purchase account.
+            You can change it in Settings.
+          errors:
+            messages:
+              item_type: Please select an item type.
+          existing_stock_on_hand: I have existing stock on hand
+          i_buy_this_item: I Buy This Item
+          i_sell_this_item: I Sell This Item
+          inactive: Inactive
+          includes_vat_question: Includes VAT?
+          item: Item
+          item_code: Item Code
+          item_description: Item Description
+          item_information: Item Information
+          item_tracking: Item Tracking
+          location: Location
+          no_category_copy: You can create Categories from the Products & Services
+            list.
+          none: None
+          notes: Notes
+          opening_balance: Opening Balance
+          opening_balance_failed: Item created successfully but there was a problem
+            saving your Opening Balance. Please reenter your Opening Balance via a
+            manual adjustment.
+          please_select: Please select
+          price: Price (%{currency_symbol})
+          price_name: Price Name
+          product:
+            heading: Non-stock
+            info: Quantities are not tracked
+          purchase_account: Purchase Account
+          purchase_description: Purchase Description
+          quantity_on_hand: Quantity on Hand
+          rate: Rate (%{currency_symbol})
+          rate_frequency: Frequency
+          rate_name: Rate Name
+          rates: Rates
+          reorder_level: Reorder Level
+          reorder_quantity: Reorder Quantity
+          sales_account: Sales Account
+          sales_prices: Sales Prices
+          select_type: Select a Type
+          service:
+            heading: Service
+            info: Services you buy and sell
+          stock: Stock
+          stock_item:
+            heading: Stock
+            info: Quantities in and out are tracked
+          subtitle: Create any items that your business buys or sells.
+          successful: Item Created
+          supplier_part_number: Supplier Item Code
+          title: Create an Item
+          unsuccessful: Item not created
+          usual_supplier: Usual Supplier
+          vat_rate: VAT Rate
+          weight: Weight
+        dashboard:
+          items:
+            one: Item
+            other: Items
+        description: Description
+        edit:
+          subtitle: Make changes to this item's details or values
+          title: Edit Item
+        item_code: Code
+        item_code_taken: This code is already taken. Please try another.
+        ledger_account_id: Ledger Account
+        movement:
+          cost_price: Cost Price
+          date: Date
+          details: Details
+          end_date: To
+          movement_number: No.
+          quantity_in: In
+          quantity_out: Out
+          reference: Reference
+          sales_price: Sales Price
+          start_date: From
+          transaction_type: Transaction Type
+          type: Type
+        object_type_formatted: Type
+        period_rate_price: Rate
+        period_rate_price_2: Rate 2
+        period_rate_price_3: Rate 3
+        period_type: Rate Frequency
+        product: Non-stock
+        purchase_ledger_account_id: Purchase Ledger Account
+        purchase_tax_rate_id: Purchase VAT Rate
+        quantity_in_stock: Quantity in Stock
+        reorder_level: Reorder Level
+        reorder_warning: Item is below reorder level
+        sales_price: Sales Price
+        sales_price_2: Sales Price 2
+        sales_price_3: Sales Price 3
+        service: Service
+        stock_item: Stock
+        tax_rate_id: VAT Rate
+        type: Type
+        view:
+          activity: Activity
+          adjust: Adjust Stock Level
+          average_cost: Average Cost
+          barcode: Barcode
+          category: Category
+          cost_price: Cost Price
+          includes_vat: Includes VAT
+          item_code: Item Code
+          item_description: Item Description
+          item_details: Item Details
+          item_information: Item Information
+          last_cost_price: Last Cost Price
+          last_purchase: Last Purchase
+          last_sale: Last Sale
+          location: Location
+          notes: Notes
+          prices: Prices (%{unit})
+          purchase_account: Purchase Account
+          purchase_description: Purchase Description
+          purchases: Purchases
+          quantity_in_stock: Quantity In Stock
+          rates: Rates (%{unit})
+          reorder_level: Reorder Level
+          reorder_quantity: Reorder Quantity
+          sales: Sales
+          sales_account: Sales Account
+          sales_and_purchases: Sales and Purchases
+          sales_price: Sales Price
+          stock_levels: Stock Levels
+          supplier: Supplier
+          supplier_code: Supplier Item Code
+          usual_supplier: Usual Supplier
+          vat_rate: VAT Rate
+          weight: Weight
+      advanced_uk/category:
+        category_name: Category Name
+        name: Name
+        subcategory: Make a sub-category
+      advanced_uk/contact_activity:
+        csv_download: CSV of List
+        date: Date
+        discount_amount: Discount
+        exchange_variance: Variation Change
+        exchange_variance_abbr: Exch. Variance
+        net: Net
+        outstanding_amount: Outstanding
+        pdf_download: PDF of Invoices
+        pdf_email: Email PDF of Invoices
+        pdf_print: Print List
+        reference: Number
+        tax: VAT
+        total_amount: Total
+        type: Type
+        user_reference: Reference
+      advanced_uk/customer_allocation:
+        display: Display
+        left_to_allocate: Left to Allocate
+      advanced_uk/customer_income_payment:
+        bank_account: Paid into Bank Account
+        bank_account_id: Paid into Bank Account
+        contact_balance: This customer has %{value} outstanding.
+        currency_charge: Currency Charges
+        currency_total_amount: Amount Received
+        date: Date Received
+        display: Display
+        exchange_rate: Exchange Rate
+        is_cheque: Paid by cheque
+        left_to_allocate: Left to allocate
+        name: Customer
+        reference: Reference (optional)
+      advanced_uk/customer_opening_balance_entry:
+        exchange_rate: Exchange Rate
+      advanced_uk/customer_refund_payment:
+        bank_account_id: "Paid from \n Bank Account"
+        contact_balance: This customer has %{value} outstanding.
+        currency_charge: Currency Charges
+        currency_total_amount: Amount Refunded
+        date: Date Refunded
+        display: Display
+        left_to_allocate: Left to allocate
+        name: Customer
+        print: Print Remittance
+        reference: Reference (optional)
+        voided_by: Voided payments
+      advanced_uk/data_import:
+        data_import_format_id: CSV Format
+      advanced_uk/datev_export_settings:
+        name: Datev Export Settings
+        next_creditor_number: Creditor Number
+        next_debtor_number: Debtor Number
+      advanced_uk/day_book_entry:
+        contact_name: Name
+        date: Date
+        description: Description
+        ledger_account: Ledger Account
+        net: Net
+        reference: Ref
+        tax: VAT
+        tax_number: Vat No.
+        total: Total
+        transaction_number: Trx No
+        transaction_type: Type
+        vat_rate: VAT Rate
+      advanced_uk/default_settings:
+        customer_credit_days: Days before invoices overdue
+        invoice_purchase_discount_ledger_account: Purchase Discount Ledger Account
+        invoice_purchase_ledger_account: Purchase Ledger Account
+        invoice_sales_discount_ledger_account: Sales Discount Ledger Account
+        invoice_sales_ledger_account: Sales Ledger Account
+        name: Record and Transactions Settings
+        supplier_credit_days: Days before invoices overdue
+      advanced_uk/email_defaults:
+        message: Default Email Message
+      advanced_uk/journal_code:
+        code: Code
+        country_journal_type_id: Journal Type
+        name: Name
+      advanced_uk/journal_opening_balance:
+        date: Date
+      advanced_uk/journal_opening_balance_line:
+        credit: Credit
+        debit: Debit
+        ledger_account_id: Ledger Account
+        line_detail: Details
+      advanced_uk/monthly_statement:
+        cc: Cc
+        day_of_month: Email statements monthly on day
+        email_enabled: Enable Monthly Statement
+        exclude_zero_balances: Exclude zero balances
+        message: Message
+        to: To
+      advanced_uk/nominal_activity:
+        cr: Credit
+        display_name: Ledger Account
+        dr: Debit
+        invoice_number: Invoice Number
+        ledger_account_formatted: Ledger Account
+        running_total: Running Total
+        total: Total
+        transaction_type: Type
+      advanced_uk/other_expense_payment:
+        calculated_total_amount: Total
+        contact_balance: You owe this supplier %{value}.
+        currency_total_amount: Amount Paid
+        date: Date Paid
+        left_to_allocate: Left to record
+        name: Supplier (optional)
+        net_value: Total Net
+        reference: Reference (optional)
+        tax_value: Total VAT
+        voided_by: Voided payments
+      advanced_uk/other_expense_payment/line_items:
+        tax_rate_id: VAT Rate
+      advanced_uk/other_expense_payment_refund:
+        bank_account: Paid into Bank Account
+        bank_account_id: Paid into Bank Account
+        contact_balance: You owe this supplier %{value}.
+        currency_total_amount: Amount Received
+        date: Date Received
+      advanced_uk/other_income_payment:
+        bank_account: Paid into Bank Account
+        bank_account_id: Paid into Bank Account
+        calculated_total_amount: Total
+        contact_balance: This customer has %{value} outstanding.
+        currency_total_amount: Amount Received
+        customer_name: Name
+        date: Date Received
+        is_cheque: Paid by cheque
+        left_to_allocate: Left to record
+        name: Customer (optional)
+        net_value: Total Net
+        reference: Reference (optional)
+        tax_value: Total VAT
+      advanced_uk/other_income_payment/line_items:
+        tax_rate_id: VAT Rate
+      advanced_uk/other_income_payment_refund:
+        bank_account: Paid from Bank Account
+        bank_account_id: Paid from Bank Account
+        contact_balance: You owe this supplier %{value}.
+        currency_total_amount: Amount Paid
+        date: Date Paid
+      advanced_uk/payment:
+        bank_account: Paid from Bank Account
+        bank_account_balance: Balance
+        bank_account_id: Paid from Bank Account
+        contact_balance: Owed
+      advanced_uk/payment_line_item:
+        description: Details
+        is_purchase_for_resale: Resale
+        ledger_account_id: Ledger Account
+        tax_rate_id: VAT Rate
+        total_amount: Total
+        total_net_amount: Net
+        total_tax_amount: VAT Amount
+        trade_of_asset: Outside Flat Rate
+      advanced_uk/payment_on_account:
+        abbr_type: On Acct
+      advanced_uk/payroll_settings:
+        bank_account: Default Payroll Bank Account
+        bank_account_id: Default Payroll Bank Account
+        name: Payroll Integration Settings
+        post_net_wages_to_liability: 'Post Employee Net Wages:'
+      advanced_uk/product:
+        active: Active
+        analysis_type_0_formatted: Analysis Type 1
+        analysis_type_1_formatted: Analysis Type 2
+        analysis_type_2_formatted: Analysis Type 3
+        cost_price: Cost Price
+        description: Description
+        item_code: Code
+        ledger_account: Ledger Account
+        ledger_account_id: Ledger Account
+        purchase_defaults: Purchase Defaults
+        purchase_ledger_account: Purchase Ledger Account
+        purchase_ledger_account_id: Purchase Ledger Account
+        purchase_tax_rate_id: Purchase VAT Rate
+        sales_defaults: Sales Defaults
+        sales_price: Sales Price
+        sales_price_2: Sales Price 2
+        sales_price_3: Sales Price 3
+        tax_rate_id: VAT Rate
+      advanced_uk/product_price:
+        in_use: In Use
+        name: Price Name
+        name_with_message: Price Name* (last entry cannot be deleted/inactive)
+        price: Price
+        price_includes_tax: Includes VAT?
+      advanced_uk/purchase_artefact:
+        artefact_status: Status
+        artefact_status_id: Status
+        contact_name: Supplier
+        contact_reference: Contact Reference
+        corrective: Corrective
+        currency_code: Currency
+        currency_outstanding: Outstanding
+        currency_outstanding_with_sign: Outstanding
+        currency_total_net_amount_with_sign: Net Amount
+        currency_total_tax_amount_with_sign: VAT Amount
+        date: Date
+        due_date: Due Date
+        extra_reference: Supplier Reference
+        main_address_postcode: Postcode
+        main_contact_email: Email
+        main_contact_name: Contact Name
+        main_contact_telephone: Telephone
+        outstanding: Outstanding
+        overdue: Overdue
+        purchase_artefact_currency_total_formatted: Total
+        raised_by_user: Who
+        raised_by_user_id: Created By
+        raised_by_user_initials: User
+        reference: Reference
+        total: Total
+      advanced_uk/purchase_batch/entries:
+        tax_rate_id: VAT Rate
+      advanced_uk/purchase_batch_entry:
+        contact_id: Supplier
+        contact_name: Supplier
+      advanced_uk/purchase_day_book_entry:
+        contact_name: Name
+        contact_name_for_csv: Contact Name
+        contact_reference: Contact Reference
+        date: Date
+        details: Details
+        invoice_no: Invoice No.
+        invoice_number: Invoice Number
+        name: Name
+        net: Net
+        reference: Ref
+        tax: VAT
+        tax_number: VAT Registration No
+        total: Total
+        transaction_number: Trx No
+        transaction_type: Type
+      advanced_uk/purchase_payable_artefact:
+        abbr_type: Type
+        amount_paid: Paid
+        currency_discount: Discount
+        currency_outstanding_with_sign: Outstanding
+        date: Date
+        exchange_rate: Exchange Rate
+        exchange_rate_formatted: Exchange Rate
+        extra_reference: Number
+        max_records_warning: There are more than 1000 unallocated items for this contact
+          - the oldest are listed below. Allocate payments to the items shown, save
+          your changes, and view this page again to work through more.
+        purchase_artefact_currency_total_formatted: Total
+        reference: Reference
+      advanced_uk/sage_pay_vendor:
+        bank_account: Bank A/C
+        bank_account_id: Bank A/C
+        contact_id: Default Customer
+        default_contact: Default Customer
+        default_ledger_account_id: Default Ledger Account
+        default_surcharge_ledger_account_id: Surcharge Ledger Account
+        enable_ecommerce: Ecommerce Enabled?
+        enable_moto: MOTO Payments Enabled?
+        enable_pay_now: Pay Now Payments Enabled?
+        encryption_password: Encryption Password
+        name: Sage Pay Settings
+        password: Password
+        user_name: User Name
+        vendor_name: Vendor Name
+      advanced_uk/sales_artefact:
+        artefact_number_formatted: Number
+        artefact_status_id: Status
+        contact_name: Customer
+        contact_reference: Contact Reference
+        corrective: Corrective
+        currency_code: Currency
+        currency_outstanding: Outstanding
+        currency_outstanding_with_sign: Outstanding
+        currency_total_net_amount_with_sign: Net Amount
+        currency_total_tax_amount_with_sign: VAT Amount
+        date: Date
+        discount: Discount
+        due_date: Due Date
+        issued: Issued
+        main_address_postcode: Postcode
+        main_contact_email: Email
+        main_contact_name: Contact Name
+        main_contact_telephone: Telephone
+        outstanding: Outstanding
+        overdue: Overdue
+        paid: Paid
+        raised_by_user: Who
+        raised_by_user_id: Created By
+        raised_by_user_initials: User
+        reference: Reference
+        sales_artefact_currency_total_formatted: Total
+        total: Total
+      advanced_uk/sales_batch/entries:
+        tax_rate_id: VAT Rate
+      advanced_uk/sales_batch_entry:
+        contact_id: Customer
+        contact_name: Customer
+      advanced_uk/sales_day_book_entry:
+        contact_name: Name
+        contact_name_for_csv: Contact Name
+        contact_reference: Contact Reference
+        date: Date
+        details: Details
+        invoice_number: Invoice Number
+        net: Net
+        reference: Ref
+        retailer_amount: RE
+        tax: VAT
+        tax_number: VAT Registration No
+        total: Total
+        transaction_number: Trx No
+        transaction_type: Type
+      advanced_uk/sales_payable_artefact:
+        abbr_type: Type
+        amount_paid: Paid
+        artefact_number_formatted: Number
+        currency_discount: Discount
+        currency_outstanding_with_sign: Outstanding
+        date: Date
+        exchange_rate: Exchange Rate
+        exchange_rate_formatted: Exchange Rate
+        reference: Reference
+        sales_artefact_currency_total_formatted: Total
+      advanced_uk/service:
+        active: Active
+        analysis_type_0_formatted: Analysis Type 1
+        analysis_type_1_formatted: Analysis Type 2
+        analysis_type_2_formatted: Analysis Type 3
+        description: Description
+        item_code: Code
+        ledger_account: Ledger Account
+        ledger_account_id: Ledger Account
+        period_rate_price: Rate
+        period_rate_price_2: Rate 2
+        period_rate_price_3: Rate 3
+        period_rate_price_includes_tax: Rate Includes VAT
+        period_type: Rate Frequency
+        period_type_id: Rate Frequency
+        tax_rate_id: VAT Rate
+      advanced_uk/service_rate:
+        in_use: In Use
+        name: Rate Name
+        name_with_message: Rate Name (last entry cannot be deleted/inactive)
+        period_type_id: Rate Frequency
+        price: Rate
+        price_includes_tax: Includes VAT?
+      advanced_uk/supplier_allocation:
+        display: Display
+        left_to_allocate: Left to allocate
+      advanced_uk/supplier_expense_payment:
+        bank_account: Paid from Bank Account
+        bank_account_id: Paid from Bank Account
+        contact_balance: You owe this supplier %{value}.
+        currency_charge: Currency Charges
+        currency_total_amount: Amount Paid
+        currency_total_amount_multi_currency: Amount Paid<span data-currency="%{currency_symbol}">&nbsp;</span>
+        date: Date Paid
+        display: Display
+        exchange_rate: Exchange Rate
+        left_to_allocate: Left to allocate
+        name: Supplier
+        payment_type: Method
+        print: Print Remittance Advice
+        reference: Reference (optional)
+        reference_pdf: Reference
+        voided_by: Voided payments
+      advanced_uk/supplier_opening_balance_entry:
+        exchange_rate: Exchange Rate
+      advanced_uk/supplier_refund_payment:
+        bank_account: Paid into Bank Account
+        bank_account_id: "Paid into \n Bank Account"
+        contact_balance: You owe this supplier %{value}.
+        currency_charge: Currency Charges
+        currency_total_amount: Amount Refunded
+        date: Date Refunded
+        display: Display
+        is_cheque: Paid by cheque
+        left_to_allocate: Left to allocate
+        name: Supplier
+        reference: Reference (optional)
+      advanced_uk/tax_return:
+        adjustment_clear_warn: Your adjustments have been cleared
+        from_date: Date From
+        paid_formatted: Paid
+        reference_text: VAT Return
+        return_date: Return Date
+        submitted_date: Submitted Date
+        tax_return_number: Number
+        tax_return_status_id: Status
+        to: to
+        to_date: Date To
+        total_amount: Amount
+      advanced_uk/tax_return_box:
+        calculated_amount: Calculated Figure
+      advanced_uk/tax_return_form_uk:
+        adjustment_amount: Change VAT figure by
+        adjustment_reason: Reason for change
+        box_1: VAT due in this period on <strong>sales</strong> and other outputs
+        box_2: VAT due in this period on <strong>acquisitions</strong> from other
+          <strong>EC Member States</strong>
+        box_3: Total VAT due <strong>(the sum of boxes 1 and 2)</strong>
+        box_4: VAT reclaimed in this period on <strong>purchases</strong> and other
+          inputs (including acquisitions from the EC)
+        box_5: Net VAT to be paid to HMRC or reclaimed by you. <br>(<strong>Difference
+          between boxes 3 and 4</strong>)
+        box_6: Total value of <strong>sales</strong> and all other outputs excluding
+          any VAT. <strong>Include your box 8 figure</strong>
+        box_6_flat: Total value of <strong>sales</strong>, including VAT. <strong>Include
+          your box 8 figure</strong>
+        box_7: Total value of <strong>purchases</strong> and all other inputs excluding
+          any VAT. <strong>Include your box 9 figure</strong>
+        box_8: Total value of all <strong>supplies</strong> of goods and related costs,
+          excluding any VAT, to other <strong>EC Member States</strong>
+        box_9: Total value of all <strong>acquisitions</strong> of goods and related
+          costs, excluding any VAT, from other <strong>EC Member States</strong>
+        company_name: Company Name
+        company_vat: Company VAT No
+        date_changed_info: Please calculate your VAT return again to reflect your
+          changes.
+        date_changed_warn: 'Your dates have changed: '
+        flat_net_vat: Flat scheme VAT
+        flat_rate: Flat Rate (%)
+        flat_rate_difference: "%{difference_key}: £%{difference}"
+        flat_rate_negative: Using a flat rate VAT scheme has cost you
+        flat_rate_notice: 'Note: These figures do not include any adjustments.'
+        flat_rate_positive: Using a flat rate VAT scheme has saved you
+        flat_rate_vat: Based on a flat rate of %{rate}% the actual VAT due is
+        from_date: VAT Period From
+        hmrc_password: HMRC Password
+        hmrc_user: HMRC User ID
+        label_box_1: "[1]"
+        label_box_2: "[2]"
+        label_box_3: "[3]"
+        label_box_4: "[4]"
+        label_box_5: "[5]"
+        label_box_6: "[6]"
+        label_box_7: "[7]"
+        label_box_8: "[8]"
+        label_box_9: "[9]"
+        non_flat_net_vat: Standard scheme VAT
+        non_flat_rate_vat: On a Standard Scheme your VAT due would have been
+        tax_registration_number: 'VAT Registration Number: %{country_code} %{tax_number}'
+        tax_scheme: VAT Scheme
+        tax_submission_frequency_type: VAT Return Frequency
+        to_date: To
+      advanced_uk/vat_expense_payment:
+        bank_account: Bank From
+      advanced_uk/vat_income_payment:
+        bank_account: Bank To
+      business:
+        auxiliary_accounts_visible: Use auxiliary accounts for customers and suppliers
+        business_type: Type of business
+        business_type_city: City/Town
+        business_type_country_id: Country
+        business_type_county: County
+        business_type_postcode: Postcode
+        business_type_street_1: Address 1
+        business_type_street_2: Address 2
+        city: City/Town
+        country: Country
+        county: County
+        name: Business name
+        postcode: Postcode
+        registered_address: Registered Address
+        registered_at_business_address: Same as business address
+        registered_country: Registered Country
+        registered_number: Registration Number
+        street_1: Address 1
+        street_2: Address 2
+      business_membership:
+        business_telephone: Telephone
+        is_owner?: Owner
+        primary: System Manager
+        user_email: Email
+        user_last_logged_in: Last logged in
+      core_accounting/taxes/models/tax_rate:
+        name: Display Name
+        visible: Show this tax rate
+      fuji_banking/bank_account:
+        account_name: Account Name
+        account_number: Account Number
+        account_type: Account Type
+        account_type_id: Account Type
+        balance: Balance
+        bic: BIC/Swift
+        credit_card_last_four_digits: Last 4 digits of your credit card number
+        date: Date
+        iban: IBAN
+        last_reconciled_date: Last Reconciled Date
+        main_address_postcode: Postcode
+        main_contact_email: Email
+        main_contact_name: Contact Name
+        main_contact_telephone: Main Contact Telephone
+        nominal_code_formatted: Ledger Account
+        opening_balance_credit: Credit
+        opening_balance_date: Opening Balance Date
+        opening_balance_debit: Debit
+        payment_type: Default Transaction Method
+        sort_code: Sort Code
+        starting_balance_credit: Credit
+        starting_balance_date: Opening Balance Date
+        starting_balance_debit: Debit
+        starting_balance_source_id: Transfered from
+        user_nominal_code: Ledger Account
+      fuji_banking/bank_activity:
+        category: Type
+      fuji_banking/bank_interest_and_charges:
+        bank_charge_amount: Bank Charge
+        bank_charge_amount_date: Date
+        bank_interest_amount: Interest Charge
+        bank_interest_amount_date: Date
+        bank_interest_earned_amount: Interest Earned
+        bank_interest_earned_amount_date: Date
+      fuji_banking/bank_reconciliation:
+        apply: Apply
+        bank_account_formatted: Bank Account
+        closing_balance: Closing Balance
+        discrepancy: Difference
+        matched_balance: Reconciled Balance
+        previous_balance: Starting Balance
+        previous_balanced: Previous Balance
+        reference: Reference
+        statement_date: Statement Date
+        statement_end_balance: Statement End Balance
+        target_balance: Target Balance
+        total_paid: Total Paid
+        total_received: Total Received
+        user_formatted: Reconciled By
+      fuji_banking/bank_transfer:
+        amount: Amount Transferred
+        date: Date Transferred
+        description: Description
+        destination_id: Paid into Account
+        payment_type_id: Method
+        reference: Reference (optional)
+        source_id: Paid from Account
+      fuji_banking/cheque:
+        amount: Amount
+        contact_name: Name
+        date: Date
+        grand_total: Total
+        number: Cheque Number
+        number_of_cheques: Number of Cheques
+        reference: Ref (Chq No)
+        statuses:
+          manual: Issued Manually
+          printed: Printed
+          saved: Saved
+          voided: Voided
+      fuji_banking/deposit:
+        bank_account_name: Bank Account
+        cash_amount: Cash
+        cash_remaining: Cash in Hand Remaining
+        cheque_amount: Cheques
+        cheque_count: Cheques [%{count}]
+        date: Date
+        destination_bank_account_id: Bank Account
+        reference: Paying in Reference
+        select: Select
+        total_amount: Total
+      fuji_catalogs/product: Product
+      fuji_catalogs/service: Service
+      fuji_contacts/contact:
+        account_balance: O/S Balance
+        account_details: Account Details
+        account_name: Account Name
+        account_number: Account Number
+        add_a: Add a
+        add_account_default: Add a Account Default
+        add_auxillary_reference: Add a Debtor/Creditor Number
+        add_company: Add a Company Name
+        add_currency: Add a Currency
+        add_locale: Add Language
+        add_product_price: Add a Default Price
+        add_purchase_ledger_account_id: Add a Purchase Ledger Account
+        add_reference: Add a Reference
+        add_registered_number: Add a Registration Number
+        add_sales_ledger_account_id: Add a Sales Ledger Account
+        add_tax_number: Add a VAT Number
+        address_name: Address Name
+        address_type: Address Type
+        all: All
+        analysis_type_0_formatted: Analysis Type 1
+        analysis_type_1_formatted: Analysis Type 2
+        analysis_type_2_formatted: Analysis Type 3
+        analysis_types: Analysis Types
+        automatic_statements: Auto-statements
+        automatic_statements_label: Include in Automatic Statement run
+        auxiliary_account: Auxiliary Account
+        average_purchase: Average Purchase
+        average_sale: Average Sale
+        balance: Balance
+        balance_due: Balance Due
+        balance_owed: Balance Owed
+        bank_details: Bank Details
+        bank_transit_number: Transit Number
+        bic: BIC/Swift
+        business_exchange_rate_id: Currency
+        cc_checkbox_label: Copy emails to this person
+        cc_text: Cc'd into emails
+        company: Company / Name
+        contact_name: Contact Name
+        contact_type: Contact Type
+        contact_type_form_proxy_id: Contact Type
+        credit_limit: Credit Limit
+        credit_set: Set Credit Limit <span class='currencySymbol' data-currency='%{currency}'></span><div
+          class='baseCreditLimit'><span data-currency-base='%{baseCurrencyCode}'></span>%{baseValue}</div>
+        credit_terms: Credit Terms
+        credit_terms_days: "%{count} Days"
+        currencies: Currencies
+        currency: Currency
+        currency_average_purchase: Average Purchase
+        currency_average_sale: Average Sale
+        currency_credit_limit: Credit Limit
+        currency_purchases_this_year: Purchases this year
+        currency_purchases_to_date: Purchases to date
+        currency_sales_this_year: Sales this year
+        currency_sales_to_date: Sales to date
+        customer_credit_days: Customer Credit (days)
+        customise_payment_terms: Customise terms
+        customised_credit_terms: Terms and Conditions
+        date: Date
+        default_customer_credit_days: Default Customer Credit (days)
+        default_payment_terms: Use default terms
+        default_supplier_credit_days: Default Supplier Credit (days)
+        discount: Discount
+        edit_name_and_reference: Edit Name & Reference
+        email: Email
+        fax_number: Fax
+        help: View your customer/suppliers details and account activity. You can view
+          or change addresses and contact information from the Addresses tab.
+        iban: IBAN
+        institution_number: Institution Number
+        is_main_address: Main Address <span>- Print on documents produced by Accounting.</span>
+        is_main_contact: Main Contact <span>- Include on emails produced by Accounting.</span>
+        is_preferred_contact: Copy emails <span>to this person.</span>
+        last_payment_value: Last Payment
+        last_purchase_value: Last Purchase
+        last_receipt_value: Last Receipt
+        last_sale_format: DD MMM YYYY
+        last_sale_value: Last Sale
+        locale: Language
+        main_address: Main Address
+        main_address_country: Country
+        main_address_line_1: Address
+        main_address_line_3: Town
+        main_address_postcode: Postcode
+        main_contact_email: Email
+        main_contact_fax_number: Fax
+        main_contact_mobile: Mobile
+        main_contact_name: Contact Name
+        main_contact_telephone: Telephone
+        mobile: Mobile
+        money_in_to_date: Money in to date
+        money_out_to_date: Money out to date
+        name: Name
+        net: Net
+        never: Never
+        new_individual: New Individual
+        no_notes: There are no notes for this contact
+        none: None
+        notes: Notes
+        number: Number
+        oldest_outstanding_invoice_date: Oldest Inv
+        outstanding: Outstanding
+        over_credit_limit: Over credit limit by %{amount}
+        overdue: Overdue
+        overdue_balance: Overdue Balance
+        payment_terms: Payment Terms
+        product_price: Price Default
+        product_price_id: Price Default
+        purchase_ledger_account: Account Default
+        purchase_ledger_account_id: Account Default
+        purchases_this_year: Purchases this year
+        purchases_to_date: Purchases To Date
+        reference: Reference
+        reference_placeholder: e.g. Account Number
+        reference_short: 'Ref:'
+        registered_number: Registration Number
+        retention_expiry_date: Suggested Removal Date
+        role: Role
+        sales_ledger_account: Account Default
+        sales_ledger_account_id: Account Default
+        sales_this_year: Sales this year
+        sales_to_date: Sales to date
+        save_individual: Save
+        sort_code: Sort Code
+        statement_address: Address
+        statement_contact: Contact to send to
+        statement_contact_email_missing: Contact must have an email address within
+          their record
+        statement_delivery_method: Statement Run
+        statement_runs: Statement Runs
+        statements_enabled: Send Statements
+        statements_enabled_label: Send Statements
+        status: Status
+        switch_on_statements: Switch on?
+        tax_number: VAT Number
+        tax_rate_id: VAT Rate
+        taxable: Taxable
+        telephone: Telephone
+        terms_and_conditions: Terms and conditions
+        total: Total
+        type: Type
+        vat: VAT
+        view_currency_in: View currency in
+      fuji_contacts/customer:
+        analysis_type_0_formatted: Analysis Type 1
+        analysis_type_1_formatted: Analysis Type 2
+        analysis_type_2_formatted: Analysis Type 3
+        aux_reference: Debtor Number
+        default_address_id: Statement Address
+        default_contact_id: Statement Email/Contact
+        help: View your customer details and account activity. You can view or change
+          addresses and contact information from the Addresses tab.
+        is_main_address: Main Address <span>- Print on documents produced by Accounting.</span>
+        is_main_contact: Main Contact <span>- Include on emails produced by Accounting.</span>
+        is_preferred_contact: Copy emails <span>to this person.</span>
+      fuji_contacts/dialog:
+        account_details_tab: Account Details
+        address_tab: Contact Address
+        bank_tab: Bank Details
+        contact_tab: Contact Details
+        notes_tab: Notes
+        vat_details: VAT Details
+      fuji_contacts/supplier:
+        analysis_type_0_formatted: Analysis Type 1
+        analysis_type_1_formatted: Analysis Type 2
+        analysis_type_2_formatted: Analysis Type 3
+        aux_reference: Creditor Number
+        default_address_id: Remittance Address
+        default_contact_id: Remittance Email
+        help: View your supplier details and account activity. You can view or change
+          addresses and contact information from the Addresses tab.
+        is_main_address: Main Address <span>- Print on documents produced by Accounting.</span>
+        is_main_contact: Main Contact
+      fuji_core_accounting/business_retention_settings:
+        gdpr:
+          end_of_tax_year: End of Tax Year
+          help_link: https://help.sageone.com/find_by_tag?language=en&locale=uk&service=accounting&tag=setup_gdpr_retention_period
+          help_title: Help me choose
+          info_text: Accounting records are kept for %{num_year} after the end of
+            your tax year in %{month}.
+          month_prompt: Select month
+          reason: Reason
+          reason_tooltip: Why do you need to retain your business data for this period?
+          retention_duration: Retention Period
+          subtitle: Choose how long you need to keep your accounting records. We’ll
+            use this to calculate how long you should keep your contact’s personal
+            data. This is important for complying with data protection laws.
+          title: BUSINESS DATA RETENTION PERIOD
+          year_prompt: Select duration
+          years: year(s)
+      fuji_core_accounting/coa_account:
+        coa_account_id: COA Account
+        coa_country: Country
+        coa_display_name: Display Name
+        coa_name: Name
+        coa_tax_rate: VAT Rate
+        control_name: Control Account
+        display_name: Display Name
+        ledger_account_type_id: Ledger Account Type
+        nominal_code: Nominal Code
+        small_business: Small Business
+        tax_rate_id: VAT Rate
+        ui_visible: UI Visible
+      fuji_core_accounting/coa_structure:
+        display_name: Display Name
+        ledger_account_type_id: Ledger Account Type
+        nominal_code: Nominal Code
+        tax_rate_id: VAT Rate
+        ui_visible: UI Visible
+      fuji_core_accounting/coa_template:
+        create_coa_template: Create Coa template
+        system?: System Template
+      fuji_core_accounting/financial_settings:
+        accounts_start_date: Accounts Start Date
+        bank_charges_ledger_account_id: Bank Charges Ledger Account
+        current_financial_year_start_date: Current financial year from
+        current_next_financial_year_end_date: to
+        exchange_rate_gains_ledger_account_id: Exchange Rate Gains Ledger Account
+        exchange_rate_losses_ledger_account_id: Exchange Rate Losses Ledger Account
+        financial_year_end_date: Year End Date
+        foreign_currency_enabled: Enable Foreign Currency Transactions
+        hmrc_user_id: HMRC User ID
+        live_exchange_rates_enabled: Use Live Exchange Rates
+        lockdown_date: Year End Lockdown
+        next_financial_year_start_date: Next financial year from
+        purchase_tax_calculation: Purchases
+        sales_tax_calculation: Sales
+        tax_calculation:
+          applicability: The VAT Calculation method will apply to future transactions
+            only.
+          cash:
+            label: On payment
+            text: The VAT collected is due when payment is collected.
+          invoice:
+            label: On invoice
+            text: The VAT collected is due from the date of issue of the invoice.
+          title: VAT Calculation
+        tax_number: VAT Number
+        tax_rate: Flat Rate (%)
+        tax_scheme_id: VAT Scheme
+        tax_submission_frequency_type_id: Submission Frequency
+      fuji_core_accounting/financial_settings/business:
+        business_retention_settings: Business retention settings
+      fuji_core_accounting/ledger_account:
+        add_category: Add Ledger Account
+        closing_balance: Closing Balance
+        coa_group_type: Category Group
+        coa_group_type_id: Category Group
+        display_name: Display Name
+        display_name_for_grid: Ledger Name
+        export_accounts: Export Accounts
+        has_bank_scope: Bank
+        has_journals_scope: Journals
+        has_other_payment_scope: Other Payment
+        has_other_receipt_scope: Other Receipt
+        has_purchasing_scope: Purchases - Invoice / Credit, Product / Supplier defaults
+        has_reporting_scope: Reports
+        has_sales_scope: Sales - Invoice / Credit, Product / Services / Customer defaults
+        import_accounts: Import Accounts
+        is_included: Included in Chart
+        is_purchase_for_resale: Purchase for resale
+        ledger_account_formatted: Ledger Account
+        ledger_account_type: Category
+        ledger_account_type_id: Category
+        name: Ledger Name
+        name_for_grid: Ledger Name
+        new_ledger_account: New Ledger Account
+        nominal_code: Nominal Code
+        nominal_code_formatted: Nominal Code
+        opening_balance: Opening Balance
+        tax_rate: VAT Rate
+        tax_rate_id: VAT Rate
+        total_credits_this_period: Total Credits this period
+        total_debits_this_period: Total Debits this period
+        ui_visibility: Visibility
+        ui_visible: Visible?
+      fuji_core_accounting/ledger_entry:
+        bank_activity_reference: Reference
+        bank_reconciled: Reconciled?
+        bank_reconciled_as_checkbox: Reconciled?
+        category: Category
+        cleared: Cleared
+        contact_name: Name
+        cr: Paid
+        date: Date
+        dr: Received
+        reconciled?: Reconciled?
+        recurrence: Recurrence
+      fuji_core_accounting/transaction:
+        void_reference: Reversal of Trx %{reference}
+      fuji_invoicing/corrective_invoice:
+        created_at: " created on %{date} at %{time}."
+      fuji_invoicing/credit_note:
+        abbr_type: Crn
+      fuji_invoicing/invoice:
+        abbr_type: Inv
+      fuji_invoicing/invoice_settings:
+        associate_logo_1: First Associate Logo
+        associate_logo_2: Second Associate Logo
+        batch_number_prefix: Quick Entries
+        company_logo: Company logo
+        corrective_sales_invoice_number_prefix: Sales Corrective Invoice
+        customer_credit_days: Customer Credit (days)
+        estimate_delay_days: Default Days to Expiry
+        estimate_text: Estimate Terms & Conditions
+        insurance_area: Insurance Area
+        insurance_mention: Insurance Mention
+        insurance_mentioned: Insurance Mentioned
+        insurance_type: Insurance Type
+        insurer_id: Insurer
+        late_payment: Late Payment
+        name: Invoice Form Settings
+        next_corrective_number: Next Corrective Invoice Number
+        next_credit_note_number: Next Credit Note Number
+        next_invoice_and_credit_note_number: Next Invoice or Credit Note Number
+        next_invoice_number: Next Invoice Number
+        next_quote_number: Next Estimate/Quote Number
+        prompt_payment: Prompt Payment
+        quote_delay_days: Default Days to Expiry
+        quote_text: Quote Terms & Conditions
+        sales_credit_note_number_prefix: Sales Credit Note
+        sales_estimate_number_prefix: Estimates
+        sales_invoice_number_prefix: Sales Invoice
+        sales_quote_number_prefix: Quotes
+        supplier_credit_days: Supplier Credit (days)
+        terms_and_conditions: Invoice Terms & Conditions
+      fuji_invoicing/logo_and_theme_settings:
+        name: Logo & Theme settings
+      fuji_invoicing/purchase_corrective_credit_note:
+        abbr_type: Cor-Crn
+      fuji_invoicing/purchase_corrective_invoice:
+        abbr_type: Cor-Inv
+        artefact_status_id: Status
+        contact_formatted: Supplier
+        contact_name: Supplier
+        contact_reference: Contact Reference
+        currency_code: Currency
+        currency_outstanding: Outstanding
+        currency_outstanding_with_sign: Outstanding
+        currency_total: Total
+        currency_total_net_amount: Amount Ex VAT
+        currency_total_net_amount_with_sign: Net Amount
+        currency_total_tax_amount: Total VAT
+        currency_total_tax_amount_with_sign: VAT Amount
+        currency_total_with_sign: Total <span data-currency="%{currency_code}"></span>
+        currency_withholding_tax_amount: IRPF
+        date: Invoice Date
+        due_date: Due Date
+        exchange_rate: Exchange Rate
+        extra_reference: Supplier Reference
+        grand_total: Total
+        main_address_postcode: Postcode
+        main_contact_email: Email
+        main_contact_name: Contact Name
+        main_contact_telephone: Telephone
+        name: Supplier
+        notes: Notes
+        outstanding: Outstanding
+        paid: Paid/Allocated
+        purchase_artefact_currency_total_formatted: Total
+        raised_by_user_id: Who
+        raised_by_user_initials: User
+        reference: Reference
+        total: Total
+        total_net_amount: Net Amount
+        total_tax_amount: VAT Amount
+      fuji_invoicing/purchase_credit_note:
+        artefact_status_id: Status
+        contact_formatted: Supplier
+        contact_name: Supplier
+        contact_reference: Contact Reference
+        currency_code: Currency
+        currency_outstanding: Outstanding
+        currency_total: Total
+        currency_total_net_amount: Amount Ex VAT
+        currency_total_tax_amount: Total VAT
+        currency_withholding_tax_amount: IRPF
+        date: Credit Date
+        due_date: Due Date
+        exchange_rate: Exchange Rate
+        extra_reference: Supplier Reference
+        grand_total: Total
+        invoice_outstanding: Invoice Outstanding
+        main_address_postcode: Postcode
+        main_contact_email: Email
+        main_contact_name: Contact Name
+        main_contact_telephone: Telephone
+        name: Supplier
+        notes: Notes
+        outstanding: Outstanding
+        paid: Paid/Allocated
+        raised_by_user_id: Who
+        raised_by_user_initials: User
+        reference: Reference
+        total: Total
+        total_net_amount: Net Amount
+        total_tax_amount: VAT Amount
+      fuji_invoicing/purchase_credit_note/line_items:
+        tax_rate_id: VAT Rate
+      fuji_invoicing/purchase_credit_note_line_item:
+        currency_discount: Discount
+        currency_net_amount: Net Amount
+        currency_tax_amount: VAT Amount
+        currency_total: Total
+        currency_unit_price: Price/Rate
+        description: Description
+        eu_goods_services_type: EU Goods/Services
+        eu_goods_services_type_id: EU Goods/Services
+        is_purchase_for_resale: Resale
+        ledger_account_id: Ledger Account
+        product_code: Item Code
+        quantity: Qty/Hrs
+        tax_amount: VAT Amount
+        tax_rate_id: VAT Rate
+        trade_of_asset: Outside Flat Rate
+        unit_price: Price/Rate
+      fuji_invoicing/purchase_invoice:
+        artefact_status_id: Status
+        contact_formatted: Supplier
+        contact_name: Supplier
+        contact_reference: Contact Reference
+        currency_code: Currency
+        currency_outstanding: Outstanding
+        currency_total: Total
+        currency_total_net_amount: Amount Ex VAT
+        currency_total_tax_amount: Total VAT
+        currency_withholding_tax_amount: IRPF
+        date: Invoice Date
+        due_date: Due Date
+        exchange_rate: Exchange Rate
+        extra_reference: Supplier Reference
+        grand_total: Total
+        main_address_postcode: Postcode
+        main_contact_email: Email
+        main_contact_name: Contact Name
+        main_contact_telephone: Telephone
+        name: Supplier
+        outstanding: Outstanding
+        paid: Paid/Allocated
+        raised_by_user_id: Who
+        raised_by_user_initials: User
+        reference: Reference
+        total: Total
+        total_net_amount: Net Amount
+        total_tax_amount: VAT Amount
+      fuji_invoicing/purchase_invoice/line_items:
+        tax_rate_id: VAT Rate
+      fuji_invoicing/purchase_invoice_line_item:
+        currency_net_amount: Net Amount
+        currency_tax_amount: VAT Amount
+        currency_total: Total
+        currency_unit_price: Price/Rate
+        eu_goods_services_type: EU Goods/Services
+        eu_goods_services_type_id: EU Goods/Services
+        is_purchase_for_resale: Resale
+        ledger_account_id: Ledger Account
+        net_amount: Net Amount
+        product_code: Item Code
+        quantity: Qty/Hrs
+        tax_amount: VAT Amount
+        tax_percentage: VAT (%)
+        tax_rate_id: VAT Rate
+        trade_of_asset: Outside Flat Rate
+        unit_price: Price/Rate
+      fuji_invoicing/purchase_invoice_payment:
+        amount: Amount Paid
+        bank_account_id: Paid From
+      fuji_invoicing/sales_corrective_credit_note:
+        abbr_type: Cor-Crn
+      fuji_invoicing/sales_corrective_invoice:
+        abbr_type: Cor-Inv
+        add_new_delivery_address: Add a delivery address
+        add_new_main_address: Add a main address
+        artefact_number: Corrective Invoice No.
+        artefact_number_formatted: Corrective Invoice No.
+        artefact_status_id: Status
+        carriage_net_amount: Carriage
+        carriage_tax_rate: Carriage VAT Rate
+        carriage_tax_rate_id: Carriage Tax Rate
+        contact_formatted: Customer
+        contact_name: Customer
+        contact_reference: Contact Reference
+        currency_carriage_net_amount: Carriage
+        currency_code: Currency
+        currency_outstanding: Outstanding
+        currency_outstanding_with_sign: Outstanding
+        currency_total: Total
+        currency_total_discount: Discount
+        currency_total_net_amount: Amount Ex VAT
+        currency_total_net_amount_with_sign: Net Amount
+        currency_total_tax_amount: Total VAT
+        currency_total_tax_amount_with_sign: VAT Amount
+        currency_total_with_sign: Total <span data-currency="%{currency_code}"></span>
+        currency_withholding_tax_amount: IRPF
+        custom_delivery_address: Custom
+        date: Invoice Date
+        delivery_address: Delivery Address
+        delivery_address_label: Delivery Address
+        delivery_address_same_as_main: Same as invoice address
+        delivery_address_selector: Delivery Address
+        due_date: Due Date
+        exchange_rate: Exchange Rate
+        grand_total: Total
+        header_note: Delivery/Performance Date
+        invoice_number: Corrective Invoice No.
+        invoice_number_formatted: Corrective Invoice No.
+        issued: Issued
+        main_address: Invoice Address
+        main_address_postcode: Postcode
+        main_contact_email: Email
+        main_contact_name: Contact Name
+        main_contact_telephone: Telephone
+        name: Customer
+        notes: Notes
+        outstanding: Outstanding
+        paid: Paid/Allocated
+        raised_by_user_id: Who
+        raised_by_user_initials: User
+        reference: Reference
+        sales_artefact_currency_total_formatted: Total
+        terms_and_conditions: Terms and Conditions
+        total: Total
+        total_net_amount: Net Amount
+        total_tax_amount: VAT Amount
+      fuji_invoicing/sales_credit_note:
+        add_new_delivery_address: Add a delivery address
+        add_new_main_address: Add a main address
+        artefact_number: Credit Note Number
+        artefact_number_formatted: Credit Note Number
+        artefact_status_id: Status
+        carriage_net_amount: Carriage
+        carriage_tax_rate: Carriage VAT Rate
+        carriage_tax_rate_id: Carriage Tax Rate
+        contact_formatted: Customer
+        contact_name: Customer
+        contact_reference: Contact Reference
+        credit_note_number: Credit Note Number
+        credit_note_number_formatted: Credit Note Number
+        currency_carriage_net_amount: Carriage
+        currency_code: Currency
+        currency_outstanding: Outstanding
+        currency_total: Total
+        currency_total_discount: Discount
+        currency_total_net_amount: Amount Ex VAT
+        currency_total_tax_amount: Total VAT
+        currency_withholding_tax_amount: IRPF
+        custom_delivery_address: Custom
+        date: Credit Date
+        delivery_address: Delivery Address
+        delivery_address_label: Delivery Address
+        delivery_address_same_as_main: Same as invoice address
+        delivery_address_selector: Delivery Address
+        due_date: Due Date
+        exchange_rate: Exchange Rate
+        grand_total: Total
+        invoice_number: Invoice Number
+        invoice_outstanding: Invoice Outstanding
+        issued: Issued
+        main_address: Address
+        main_address_postcode: Postcode
+        main_contact_email: Email
+        main_contact_name: Contact Name
+        main_contact_telephone: Telephone
+        name: Customer
+        outstanding: Outstanding
+        paid: Paid/Allocated
+        raised_by_user_id: Who
+        raised_by_user_initials: User
+        total: Total
+        total_net_amount: Net Amount
+        total_tax_amount: VAT Amount
+        unpaid: Unpaid
+        void: Void
+      fuji_invoicing/sales_credit_note/line_items:
+        tax_rate_id: VAT Rate
+      fuji_invoicing/sales_credit_note_line_item:
+        currency_discount: Discount
+        currency_net_amount: Net Amount
+        currency_tax_amount: VAT Amount
+        currency_total: Total
+        currency_unit_price: Price/Rate
+        description: Description
+        discount_amount: Discount Amount
+        discount_percentage: Discount (%)
+        ec_sales_description: EU Sales Description
+        ec_sales_description_id: EU Sales Description
+        eu_goods_services_type: EU Goods/Services
+        eu_goods_services_type_id: EU Goods/Services
+        ledger_account_id: Ledger Account
+        net_amount: Net Amount
+        product_code: Item Code
+        quantity: Qty/Hrs
+        tax_amount: VAT Amount
+        tax_percentage: VAT (%)
+        tax_rate_id: VAT Rate
+        trade_of_asset: Outside Flat Rate
+        unit_price: Price/Rate
+      fuji_invoicing/sales_estimate:
+        add_new_delivery_address: Add a delivery address
+        add_new_main_address: Add a main address
+        delivery_address: Delivery Address
+        main_address: Invoice Address
+      fuji_invoicing/sales_invoice:
+        add_new_delivery_address: Add a delivery address
+        add_new_main_address: Add a main address
+        artefact_number: Invoice Number
+        artefact_number_formatted: Invoice Number
+        artefact_status_id: Status
+        carriage_net_amount: Carriage
+        carriage_tax_rate: Carriage VAT Rate
+        carriage_tax_rate_id: Carriage Tax Rate
+        contact_formatted: Customer
+        contact_name: Customer
+        contact_reference: Contact Reference
+        created_from_sales_estimate: From Estimate
+        created_from_sales_quote: From Quote
+        currency_carriage_net_amount: Carriage
+        currency_code: Currency
+        currency_outstanding: Outstanding
+        currency_total: Total
+        currency_total_discount: Discount
+        currency_total_net_amount: Amount Ex VAT
+        currency_total_tax_amount: Total VAT
+        currency_total_with_sign: Total <span data-currency="%{currency_code}"></span>
+        currency_withholding_tax_amount: IRPF
+        custom_delivery_address: Custom
+        date: Invoice Date
+        delivery_address: Delivery Address
+        delivery_address_label: Delivery Address
+        delivery_address_same_as_main: Same as invoice address
+        delivery_address_selector: Delivery Address
+        due_date: Due Date
+        exchange_rate: Exchange Rate
+        grand_total: Total
+        header_note: Delivery/Performance Date
+        invoice_number: Invoice Number
+        invoice_number_formatted: Invoice Number
+        issued: Issued
+        main_address: Invoice Address
+        main_address_postcode: Postcode
+        main_contact_email: Email
+        main_contact_name: Contact Name
+        main_contact_telephone: Telephone
+        name: Customer
+        notes: Notes
+        outstanding: Outstanding
+        paid: Paid/Allocated
+        raised_by_user_id: Who
+        raised_by_user_initials: User
+        reference: Reference
+        terms_and_conditions: Terms and Conditions
+        total: Total
+        total_net_amount: Net Amount
+        total_tax_amount: VAT Amount
+      fuji_invoicing/sales_invoice/line_items:
+        ledger_account: Ledger account
+        tax_rate: Tax rate
+        tax_rate_id: VAT Rate
+      fuji_invoicing/sales_invoice_line_item:
+        currency_discount: Discount
+        currency_net_amount: Net Amount
+        currency_tax_amount: VAT Amount
+        currency_total: Total
+        currency_unit_price: Price/Rate
+        description: Description
+        discount_amount: Discount amount
+        discount_percentage: Discount (%)
+        ec_sales_description: EU Sales Description
+        ec_sales_description_id: EU Sales Description
+        eu_goods_services_type: EU Goods/Services
+        eu_goods_services_type_id: EU Goods/Services
+        ledger_account_id: Ledger Account
+        net_amount: Net Amount
+        product_code: Item Code
+        quantity: Qty/Hrs
+        tax_amount: VAT Amount
+        tax_percentage: VAT (%)
+        tax_rate_id: VAT Rate
+        trade_of_asset: Outside Flat Rate
+        unit_price: Price/Rate
+      fuji_invoicing/sales_invoice_payment:
+        amount: Amount Paid
+        bank_account_id: Paid To
+        is_cheque: Tick if Cheque
+        reference: Ref/Chq Number
+      fuji_invoicing/sales_quote:
+        add_new_delivery_address: Add a delivery address
+        add_new_main_address: Add a main address
+        artefact_number: Number
+        artefact_number_formatted: Number
+        contact_formatted: Customer
+        contact_name: Customer
+        currency_carriage_net_amount: Carriage
+        currency_code: Currency
+        currency_outstanding: Outstanding
+        currency_total: Total
+        currency_total_discount: Discount
+        currency_total_net_amount: Amount Ex VAT
+        currency_total_tax_amount: Total VAT
+        currency_withholding_tax_amount: IRPF
+        date: Created
+        delivery_address: Delivery Address
+        due_date: Expires
+        exchange_rate: Exchange Rate
+        formatted_status: Status
+        grand_total: Total
+        invoice_number_formatted: Invoice Number
+        issued: Sent
+        main_address: Invoice Address
+        main_address_postcode: Postcode
+        main_contact_email: Email
+        main_contact_name: Contact Name
+        main_contact_telephone: Telephone
+        name: Customer
+        quote_number_formatted: 'Quote #'
+        quote_status: Status
+        raised_by_user: Created By
+        raised_by_user_id: Created By
+        raised_by_user_initials: Who
+        reference: Reference
+        sales_quote_number: Number
+        terms_and_conditions: Terms and Conditions
+        total: Total
+        total_net_amount: Amount Ex VAT
+        total_tax_amount: Total VAT
+      fuji_invoicing/sales_quote/line_items:
+        tax_rate_id: VAT Rate
+      fuji_invoicing/sales_quote_line_item:
+        currency_discount: Discount
+        currency_net_amount: Net Amount
+        currency_tax_amount: VAT Amount
+        currency_total: Total
+        currency_unit_price: Price/Rate
+        discount_amount: Discount amount
+        discount_percentage: Discount (%)
+        ec_sales_description: EU Sales Description
+        ec_sales_description_id: EU Sales Description
+        eu_goods_services_type: EU Goods/Services
+        eu_goods_services_type_id: EU Goods/Services
+        ledger_account_id: Ledger Account
+        net_amount: Net Amount
+        product_code: Item Code
+        quantity: Qty/Hrs
+        tax_amount: VAT Amount
+        tax_percentage: VAT (%)
+        tax_rate_id: VAT Rate
+        unit_price: Price/Rate
+      fuji_support/recurrence:
+        expiry_date: Recur Until
+      journal_opening_balance_lines:
+        base: Nominal Opening Balance
+        credit: Nominal Opening Balance Credit
+        debit: Nominal Opening Balance Debit
+        ledger_account_id: Nominal Opening Balance Ledger Account
+      prices:
+        name: Price Name
+      rates:
+        name: Rate Name
+      user:
+        business_telephone: Telephone
+        first_name: First Name
+        last_name: Last Name
+        primary: Primary User
+        user_auths: Authentication details
+    errors:
+      messages:
+        analysis_type_category_code_already_exists: You cannot add duplicate codes
+          for an analysis type, please change and try again
+        bic:
+          invalid_format: Invalid Format
+        can_only_use_bank_ledger_account_type_on_bank_types: Only ledger accounts
+          with a category of Bank or Credit Card can be visible in Bank
+        cannot_create_cheque_unless_from_checking_or_savings: You can't save a cheque
+          payment from this bank account. Please select a current or savings account
+          instead.
+        cannot_delete_payment_with_reconciled_bank_payment: This payment cannot be
+          deleted, an associated bank payment has been reconciled.
+        cannot_destroy_batch_entry_if_migrated: You can't delete this quick entry
+          because it was migrated from your old accounting system.
+        cannot_destroy_credit_note_if_restricted: One or more of the selected items
+          is completed and cannot be deleted.  To keep the sequential numbers for
+          credit notes following HMRC rules, complete credit notes must be voided
+          and your access level does not allow you to do this.  Please speak to your
+          Supervisor.
+        cannot_destroy_if_bank_reconciled: You cannot delete bank reconciled transactions.
+        cannot_destroy_if_cheque_transaction: 'This transaction was paid by cheque
+          - please go to the <a href=''/banking/cheque_register#allCheques'' style=''text-decoration:
+          underline;color: white !important;''>Cheque Register</a> to delete it.'
+        cannot_destroy_if_cleared: You cannot delete transactions that have cleared
+          your bank account.
+        cannot_destroy_if_payments: You cannot delete items which have been allocated.
+        cannot_destroy_if_tax_reconciled: You cannot delete VAT reconciled transactions.
+        cannot_destroy_if_transaction_locked: You cannot delete an allocated transaction
+          created from a third-party integration.
+        cannot_destroy_invoice_if_restricted: One or more of the selected items is
+          completed and cannot be deleted.  To keep the sequential numbers for invoices
+          following HMRC rules, complete invoices must be voided and your access level
+          does not allow you to do this.  Please speak to your Supervisor.
+        cannot_destroy_journal_if_cleared: You cannot delete cleared transactions.
+        cannot_destroy_journal_if_migrated: You cannot delete this journal because
+          it was migrated from your old accounting system.
+        cannot_destroy_opening_balance_artefact: You cannot delete Invoices/Credit
+          Notes entered as an opening balance.
+        cannot_destroy_with_allocations: You cannot delete when credit notes or payments
+          on account are allocated.
+        cannot_download_tax_file_if_missing_tax_number: You must enter the GST/HST
+          account number associated with this tax return to download .tax file.
+        cannot_edit_batch_entry_if_migrated: You can’t edit this quick entry because
+          it was migrated from your old accounting system.
+        cannot_edit_if_bank_reconciled: You cannot edit bank reconciled transactions.
+        cannot_edit_if_cleared: You cannot edit transactions that have cleared your
+          bank account.
+        cannot_edit_if_different_scheme: You cannot update items which were created
+          under a different tax scheme.
+        cannot_edit_if_payments: You cannot update items which have been allocated.
+        cannot_edit_if_tax_reconciled: You cannot edit VAT reconciled transactions.
+        cannot_edit_other_schemes_artefact: You cannot edit Invoices/Credit Notes
+          created on a different VAT scheme.
+        cannot_edit_tax_if_tax_reconciled: This entry has been VAT reconciled, and
+          you cannot save changes which would impact on the previously reconciled
+          VAT return.
+        cannot_expose_bank_ledger_account_type_outside_bank: Ledger accounts with
+          a category of Bank or Credit Card can only be visible in Bank
+        cannot_expose_excluded_ledger_account_in_ui: Excluded ledger accounts cannot
+          be shown in the app
+        cannot_expose_this_control_account: This Control Account cannot be visible
+        cannot_overpay: You cannot overpay
+        cannot_raise_credit_note_on_paid: Someone else may have recorded a payment/credit
+          note against this invoice. Please review the outstanding amount on the invoice.
+        cannot_unallocate_if_transaction_locked: Allocations created by third-party
+          integrations cannot be changed.
+        cannot_update_credit_note_if_restricted: Your access level only allows you
+          to edit draft credit notes.  Please speak to your Supervisor.
+        cannot_update_estimate_if_restricted: Your access level only allows you to
+          edit draft estimates.  Please speak to your Supervisor.
+        cannot_update_iban_if_connected_to_bank_feeds: You cannot update the iban
+          if your bank account is connected.
+        cannot_update_if_transaction_locked: You cannot update a transaction created
+          from a third-party integration.
+        cannot_update_invoice_if_restricted: Your access level only allows you to
+          edit draft invoices.  Please speak to your Supervisor.
+        cannot_update_quote_if_restricted: Your access level only allows you to edit
+          draft quotes.  Please speak to your Supervisor.
+        cannot_void_if_tax_reconciled: You cannot void VAT reconciled transactions.
+        cannot_void_opening_balance_artefact: You cannot void Invoices/Credit Notes
+          entered as an opening balance.
+        cannot_void_with_allocations: You cannot void when credit notes or payments
+          on account are allocated.
+        customer_supplier_overseas_opening_balances_no_tax: Opening Balances for EU
+          VAT registered contacts, or those outside of the EU should be recorded as
+          No VAT.
+        customer_supplier_overseas_opening_balances_row_tax: Opening Balances for
+          EU VAT registered contacts, or those outside of the EU should be recorded
+          as zero rated.
+        ensure_credit_or_debit_only: You must enter either a debit or a credit
+        exchange_and_total_not_zero: This field has errors and can not be zero
+        exchange_rate_invalid_for_equal_currencies: The exchange rate must be 1 if
+          the business and contact currencies are the same.
+        field_value_not_valid: The value supplied is not valid for %{field}
+        iban:
+          invalid_check_sum: Invalid check sum
+          too_long: Too long
+          too_short: Too short
+          unknown_country: Invalid format
+        invalid_measurement_unit: Invalid measurement unit - %{measurement_unit}
+        left_to_allocate_higher: This value cannot be higher than the total amount.
+        left_to_record_not_zero: This field must be zero before saving the record.
+        less_than_zero: This field must not be less than zero
+        must_be_less_than_200_characters: Your text must be 200 characters or less.
+        must_be_no_greater_than: Must be no greater than 99999999.
+        must_be_one_of_allowed_tax_rates: 'You must choose one of the following VAT
+          Rates: %{tax_formatted}'
+        must_be_valid_category: Must be a valid category.
+        must_not_exceed_new_outstanding_amount: Must not exceed new outstanding amount.
+        must_not_exceed_outstanding_amount: Must not exceed outstanding amount.
+        no_such_quote_or_estimate: The quote or estimate to be associated cannot be
+          found.
+        nominal_code_must_be_included: Nominal code must be included in chart of accounts
+        not_a_whole_number: must be a whole number
+        opening_balance_attributes_invalid: As an opening balance date is specified,
+          you must enter either a debit or credit
+        opening_balance_attributes_invalid_balance_overdrawn_balance: As an opening
+          balance date is specified, you must enter either a balance or overdrawn
+          balance
+        opening_balance_attributes_invalid_date: You must enter a date for the opening
+          balance, prior to your accounts start date.
+        opening_balance_attributes_invalid_overpaid_balance_balance_due: As an opening
+          balance date is specified, you must enter either an overpaid balance or
+          a balance due
+        payment_artefacts_artefact_contact_invalid: All allocated items must belong
+          to the same contact.
+        payment_artefacts_cannot_overpay: You cannot overpay invoices.
+        payment_artefacts_must_be_present: There must be at least one item allocated.
+        payment_artefacts_status_invalid: You can only pay unpaid or part-paid invoices.
+        payment_on_account_has_been_allocated: Associated payment on account has been
+          allocated so no update is possible
+        payroll_current_liability_control_account_visibility: Payroll Liability accounts
+          can only be visible in Other Payments and Other Receipt
+        payroll_overheads_control_account_visibility: Payroll Overhead accounts can
+          only be visible in Other Payment
+        prohibited_chars: contains invalid characters
+        prohibited_chars_prefix: The prefix of %{artefact} contains invalid characters
+        quantity_in_stock: 'Qty in stock: %{count}<br>You cannot fulfil this invoice
+          as you do not have enough in stock.'
+        quantity_in_stock_info: 'Qty in stock: %{count}'
+        quantity_in_stock_warning: 'Qty in stock: %{count}<br>You''ve entered a quantity
+          that''s higher than your current stock level.'
+        quick_entries_cross_border_vat: You cannot record Quick Entries for Cross
+          Border contacts.  To correctly deal with VAT when recording cross border
+          transactions, you must use the Invoice or Credit Note Option. Delete these
+          lines and resave.
+        required: This field is required
+        retailer_invoice_non_spain_contact: This invoice cannot be edited. Recargo
+          de Equivalencia has been applied, but the contact is not in Spain.  Create
+          a Corrective Invoice to reverse the invoice.
+        sage_pay_unsupported_currency: Your Sage Pay account does not support payments
+          in %{currency_code}.
+        tax_calculation_not_applicable: Tax calculation is not applicable to this
+          buisness.
+        tax_calculation_not_valid: This is not a valid value for the tax calculation.
+        tax_number_invalid: Invalid tax number.
+        tax_rate_not_visible: The tax rate is not marked as visible and therefore
+          is not available for import.
+        transit_and_institution_number_validation: The transit number should be 5
+          digits and the institution number should be 3 digits.
+        unique_field_constraint: "%{field} must be unique"
+        unknown_value_for_column: The value supplied is not valid for %{field}
+        within_financial_year: You cannot report across financial years
+      mixins:
+        invoice_payment:
+          attributes:
+            amount:
+              less_than_outstanding: Invoice total amount cannot be less than the
+                outstanding amount.
+              must_not_be_greater_than_outstanding: Must not be greater than the outstanding
+                amount of the invoice.
+              zero: Cannot be 0.
+      models:
+        addresses/models/address:
+          attributes:
+            base:
+              can_only_have_one_main_contact: You can only have one main contact for
+                an address.
+              cannot_delete_main_address: Unable to delete main address.
+              contact_deleted: The contact for the address has been deleted.
+            is_main_address:
+              must_have_one_main_address: You must have a main address.
+        advanced_uk/address_contact:
+          attributes:
+            base:
+              cannot_delete_main_contact: Unable to delete main contact.
+            is_main_contact:
+              must_have_one_main_contact: You must have one main contact person.
+        advanced_uk/allocation:
+          attributes:
+            base:
+              cannot_delete_allocation: Unable to delete allocation.
+        advanced_uk/analysis_type:
+          attributes:
+            base:
+              cannot_delete_category_in_use: You cannot delete an Analysis Type Category
+                that is in use.
+              cannot_delete_in_use: You cannot delete an Analysis Type that is in
+                use.
+              invalid_analysis_area: One or more of the selected Analysis Areas is
+                invalid for this Analysis Type.
+        advanced_uk/analysis_type_category:
+          attributes:
+            base:
+              cannot_delete_in_use: You cannot delete an Analysis Type Category that
+                is in use.
+        advanced_uk/bank_opening_balance:
+          attributes:
+            base:
+              cannot_destroy_if_bank_reconciled: You cannot delete bank reconciled
+                transactions.
+              cannot_edit_if_bank_reconciled: You cannot edit bank reconciled transactions.
+              credit_and_debit_not_set: Opening Balance is required.
+              credit_and_debit_set: Debit or Credit must be set, but not both.
+        advanced_uk/batch_entry:
+          attributes:
+            ledger_account:
+              home_customer_invalid: is incorrectly selected - please select a non
+                EU/Export ledger account
+              home_supplier_invalid: is incorrectly selected - please select a non
+                EU/Import ledger account
+            tax_rate_id:
+              ledger_account_based: for ledger account %{ledger_account} must be '%{tax_rate}'.
+            total:
+              unbalanced_transaction: must be equal to Net plus VAT.
+            total_tax_amount:
+              cant_record_tax_amount_for_zero_rate: You cannot record VAT Amount if
+                using a VAT Rate with a Zero %.
+            trade_of_asset:
+              invalid_category: Can only be selected for fixed assets
+              not_applicable: Is not valid for your tax system.
+        advanced_uk/catalog_item:
+          attributes:
+            tax_rate_id:
+              ledger_account_based: for ledger account %{ledger_account} must be '%{tax_rate}'.
+        advanced_uk/category:
+          attributes:
+            base:
+              max_level_error: Category must be at most %{max_levels} levels deep.
+              max_subcategory_level_error: The category and its subcategories must
+                be at most %{max_levels} levels deep.
+        advanced_uk/customer_allocation:
+          attributes:
+            left_to_allocate:
+              left_to_allocate_not_zero: Left to allocate must be zero.
+        advanced_uk/customer_income_payment:
+          attributes:
+            base:
+              cannot_allocate_poa_in_payment_that_created_it: You cannot allocate
+                a payment on account from within the customer receipt that originally
+                created the payment on account.
+              cannot_delete_if_payments_allocated: One or more of the selected items
+                are allocated therefore cannot be deleted.
+              cheque_deposited: This cheque has already been deposited.  You must
+                delete the deposit before editing this transaction.
+            left_to_allocate:
+              left_to_allocate_higher: This value cannot be higher than the total
+                amount.
+        advanced_uk/customer_refund_payment:
+          attributes:
+            base:
+              cannot_delete_if_payments_allocated: One or more of the selected items
+                are allocated therefore cannot be deleted.
+              payment_artefacts_cannot_overpay: You cannot overpay credit notes.
+              payment_artefacts_status_invalid: You can only pay unpaid or part-paid
+                credit notes.
+            left_to_allocate:
+              left_to_allocate_not_zero: Left to allocate must be zero.
+            voided_by:
+              present: can't be edited
+        advanced_uk/data_import:
+          attributes:
+            file:
+              size_too_big: is too big (should be at most %{file_size})
+          base:
+            ledger_account_importer:
+              exceeds_line_limit: You can’t import more than 2,000 ledger accounts.
+            unbalanced_exception: The VAT and Net amounts must add up to the Total.
+            unexpected_error: An unexpected error occurred. Please try again later.
+        advanced_uk/default_settings:
+          attributes:
+            credit_ageing_periods:
+              invalid: must be in ascending order
+            debit_ageing_periods:
+              invalid: must be in ascending order
+            prices:
+              too_few: Last price cannot be deleted/inactive
+              too_many: Too many prices
+            rates:
+              too_few: Last rate cannot be deleted/inactive
+              too_many: Too many rates
+          base:
+            unit_of_measure_with_stock_items: You cannot change your default unit
+              of measure as you have entered a weight on one or more of your stock
+              items.
+        advanced_uk/email_verification:
+          attributes:
+            base:
+              max_attempts: You entered an invalid code too many times. The Email
+                Reply Address has been reset.
+            code:
+              one_attempt_remaining: Wrong code entered<br> %{remaining_attempts}
+                attempt remaining.
+              several_attempts_remaining: Wrong code entered<br> %{remaining_attempts}
+                attempts remaining.
+        advanced_uk/financial_year:
+          attributes:
+            end_date:
+              ensure_start_date_before_end_date: can not be prior to start date.
+        advanced_uk/global_tax_return:
+          attributes:
+            base:
+              cannot_delete_migrated: You cannot delete a migrated VAT Return.
+              cannot_delete_submitted: You cannot delete a submitted VAT Return.
+              cannot_record_refund: You cannot record a refund if it is not a final
+                return of current tax year
+              from_date_after_to_date: From date cannot be after to date.
+              multiple_drafts_not_allowed_on_same_dates: You cannot save more than
+                one draft for the same date range.
+              to_date_before_lockdown_date: Your VAT return "To Date" cannot be on
+                or before your <a href="/settings/financial_settings">year end lockdown
+                date</a> of %{lockdown_date}.
+              to_date_before_start_date: Your VAT return "To Date" cannot be before
+                your <a href="/settings/financial_settings">accounts start date</a>
+                of %{start_date}.
+            total_amount:
+              overpayment: must not be greater than outstanding amount.
+        advanced_uk/hosted_artefact_payment_setting:
+          attributes:
+            base:
+              context_type_is_not_valid: This setting can only be configured for Sales
+                Invoices.
+              object_guid_must_match_object_sageone_guid: The object_guid doesn't
+                match a document for this business. Please check the guid is valid.
+        advanced_uk/journal_code:
+          attributes:
+            base:
+              non_deletable_reason_as_has_transactions: Referred by existing transactions.
+              non_deletable_reason_as_reserved: Reserved.
+        advanced_uk/journal_opening_balance_line:
+          attributes:
+            base:
+              ensure_credit_or_debit_only: Must be either a credit or a debit.
+              invalid_ledger_account: The selected ledger account is invalid.
+        advanced_uk/migration_tax_return:
+          attributes:
+            base:
+              from_date_after_to_date: From date cannot be after to date.
+              to_date_before_lockdown_date: Your VAT return "To Date" cannot be on
+                or before your <a href="/settings/financial_settings">year end lockdown
+                date</a> of %{lockdown_date}.
+              to_date_before_start_date: Your VAT return "To Date" cannot be before
+                your <a href="/settings/financial_settings">accounts start date</a>
+                of %{start_date}.
+        advanced_uk/monthly_statement:
+          attributes:
+            base:
+              enable_first: Use Cancel to discard your changes.
+        advanced_uk/other_expense_payment:
+          attributes:
+            base:
+              line_items_must_be_present: There must be at least one line item.
+            contact:
+              cannot_be_foreign_currency_contact: You cannot create an Other Payment
+                for a foreign currency supplier
+            left_to_allocate:
+              left_to_record_not_zero: You still have payments left to record.
+            voided_by:
+              present: can't be edited
+        advanced_uk/other_expense_payment_line_item:
+          attributes:
+            is_purchase_for_resale:
+              invalid_direct_expense: invalid for this ledger account
+            total_amount:
+              total_amount_not_sum_net_tax_amount: This field must be the sum of Net
+                Amount and VAT Amount
+        advanced_uk/other_expense_payment_refund:
+          attributes:
+            base:
+              cheque_deposited: This cheque has already been deposited.  You must
+                delete the deposit before editing this transaction.
+              line_items_must_be_present: There must be at least one line item.
+            left_to_allocate:
+              left_to_record_not_zero: You still have payments left to record.
+        advanced_uk/other_income_payment:
+          attributes:
+            base:
+              cheque_deposited: This cheque has already been deposited. You must delete
+                the deposit before editing this transaction.
+              line_items_must_be_present: There must be at least one line item.
+            contact:
+              cannot_be_foreign_currency_contact: You cannot create an Other Receipt
+                for a foreign currency customer
+            left_to_allocate:
+              left_to_record_not_zero: You still have receipts left to record.
+        advanced_uk/other_income_payment_refund:
+          attributes:
+            base:
+              cheque_deposited: This cheque has already been deposited.  You must
+                delete the deposit before editing this transaction.
+              line_items_must_be_present: There must be at least one line item.
+            left_to_allocate:
+              left_to_record_not_zero: You still have receipts left to record.
+        advanced_uk/payment:
+          attributes:
+            base:
+              cannot_delete_if_for_another_scheme: You cannot delete Payments created
+                on a different VAT scheme.
+              cannot_edit_if_for_another_scheme: You cannot edit Payments created
+                on a different VAT scheme.
+            payment_type_id:
+              is_invalid: is invalid for business.
+        advanced_uk/payment_line_item:
+          attributes:
+            tax_rate_id:
+              ledger_account_based: for ledger account %{ledger_account} must be '%{tax_rate}'.
+            total_amount:
+              total_amount_not_sum_net_tax_amount: This field must be the sum of Net
+                Amount and VAT Amount
+            total_tax_amount:
+              cant_record_tax_amount_for_zero_rate: You cannot record VAT Amount if
+                using a VAT Rate with a Zero %.
+            trade_of_asset:
+              invalid_category: Can only be selected for fixed assets
+              not_applicable: Is not valid for your tax system.
+        advanced_uk/product:
+          attributes:
+            base:
+              at_least_one_price: Must have at least one price.
+              cannot_convert_to_non_stock: Only stock items can be converted to non-stock
+                items.
+              cannot_convert_with_invalid_code: We can't change this item's type as
+                its item code is longer than 30 characters.
+              cannot_convert_with_invalid_code_action: Change your item code and try
+                again.
+              cannot_convert_with_line_items: We can't change this item's type as
+                it has transactions associated with it.
+              cannot_convert_with_negative_cost: We can't change this item's type
+                as it has a negative cost price. Stock items must have a positive
+                cost price.
+              cannot_convert_with_negative_cost_action: Change your cost price and
+                try again.
+              delete_associated_with_invoice: This non-stock item cannot be deleted
+                as it is associated with a transaction.
+        advanced_uk/product_price:
+          attributes:
+            base:
+              cannot_delete_active_items: Active prices cannot be deleted
+              must_have_at_least_one_active_item: At least one price must be active
+        advanced_uk/purchase_batch_entry:
+          attributes:
+            base:
+              no_eu_contact_without_vat_number_allowed: You selected an EU supplier,
+                thus you have to input your USt-ID.
+            contact:
+              cannot_be_foreign_currency_contact: You cannot create Quick Entries
+                for a foreign currency supplier
+            is_purchase_for_resale:
+              invalid_direct_expense: invalid for this ledger account
+        advanced_uk/quick_start:
+          attributes:
+            business_classification:
+              blank: Try another search and choose a match
+        advanced_uk/sage_pay_vendor:
+          attributes:
+            base:
+              connectivity_issues: There was an issue connecting to Sage Pay
+              does_not_have_view_all_access: The Sage Pay user does not have access
+                to view all transactions
+              invalid_credentials: The supplied Vendor Name, User Name and Password
+                combination do not seem to be valid
+              invalid_encryption_password: The supplied Encryption Password does not
+                seem to be valid
+              not_set_up_to_accept_payments: The Sage Pay account is not set up for
+                Payments
+            default_contact:
+              cannot_be_foreign_currency_contact: cannot be a foreign currency customer.
+        advanced_uk/sales_batch_entry:
+          attributes:
+            base:
+              no_eu_contact_without_vat_number_allowed: You selected an EU customer,
+                thus you have to input your USt-ID.
+            contact:
+              cannot_be_foreign_currency_contact: You cannot create Quick Entries
+                for a foreign currency customer
+        advanced_uk/service:
+          attributes:
+            base:
+              at_least_one_price: Must have at least one rate.
+              cannot_convert_service_items: You cannot convert service items.
+              delete_associated_with_invoice: This service cannot be deleted as it
+                is associated with a transaction.
+        advanced_uk/service_rate:
+          attributes:
+            base:
+              cannot_delete_active_items: Active rates cannot be deleted
+              must_have_at_least_one_active_item: At least one rate must be active
+        advanced_uk/stock_attributes:
+          attributes:
+            base:
+              stock_quantity_invalid: Your item "%{item_code}" does not have enough
+                stock available and will take the quantity in stock to %{quantity_in_stock}.
+              stock_quantity_invalid_on_edit: Adjusting the quantity of your item
+                "%{item_code}" will take the quantity in stock to %{quantity_in_stock}.
+              stock_quantity_invalid_on_void: You can't delete this item as it would
+                result in item "%{item_code}" going into negative stock (%{quantity_in_stock}).
+        advanced_uk/stock_item:
+          attributes:
+            base:
+              cannot_convert_to_stock: Only non-stock items can be converted to stock
+                items.
+              cannot_convert_with_adjustments: We can’t change this item’s type as
+                it has stock adjustments associated with it.
+              cannot_convert_with_adjustments_action: Remove the adjustments from
+                the item’s activity and try again.
+              cannot_convert_with_line_items: We can't change this item's type as
+                it has transactions associated with it.
+              delete_associated_with_activity: This stock item cannot be deleted as
+                it is associated with a stock adjustment.
+              delete_associated_with_invoice: This stock item cannot be deleted as
+                it is associated with a transaction.
+              inactive_when_stock_in_hand: You cannot make this item inactive as it
+                has a quantity in stock.
+          measurement_unit:
+            measurement_unit_invalid: Measurement unit must be in the list of measurement
+              units in the business default settings.
+        advanced_uk/supplier_allocation:
+          attributes:
+            left_to_allocate:
+              left_to_allocate_not_zero: Left to allocate must be zero.
+        advanced_uk/supplier_expense_payment:
+          attributes:
+            base:
+              cannot_allocate_poa_in_payment_that_created_it: You cannot allocate
+                a payment on account from within the supplier payment that originally
+                created the payment on account.
+              cannot_delete_if_payments_allocated: One or more of the selected items
+                are allocated therefore cannot be deleted.
+            left_to_allocate:
+              left_to_allocate_higher: This value cannot be higher than the total
+                amount.
+              present: can't be edited
+        advanced_uk/supplier_refund_payment:
+          attributes:
+            base:
+              cheque_deposited: This cheque has already been deposited.  You must
+                delete the deposit before editing this transaction.
+              payment_artefacts_cannot_overpay: You cannot overpay credit notes.
+              payment_artefacts_status_invalid: You can only pay unpaid or part-paid
+                credit notes.
+            left_to_allocate:
+              left_to_allocate_not_zero: Left to allocate must be zero.
+        advanced_uk/tax_return:
+          attributes:
+            base:
+              cannot_delete_migrated: You cannot delete a migrated VAT Return.
+              cannot_delete_submitted: You cannot delete a submitted VAT Return.
+              cannot_record_refund: You cannot record a refund if it is not a final
+                return of current tax year
+              from_date_after_to_date: From date cannot be after to date.
+              multiple_drafts_not_allowed_on_same_dates: You cannot save more than
+                one draft for the same date range.
+              to_date_before_lockdown_date: Your VAT return "To Date" cannot be on
+                or before your <a href="/settings/financial_settings">year end lockdown
+                date</a> of %{lockdown_date}.
+              to_date_before_start_date: Your VAT return "To Date" cannot be before
+                your <a href="/settings/financial_settings">accounts start date</a>
+                of %{start_date}.
+            total_amount:
+              overpayment: must not be greater than outstanding amount.
+        advanced_uk/tax_return_box:
+          attributes:
+            base:
+              cannot_be_changed: You cannot adjust a Submitted VAT Return.
+        advanced_uk/vat_payment:
+          attributes:
+            amount:
+              overpayment: must not be greater than outstanding amount.
+            tax_return_id:
+              not_submitted: Tax Return is not submitted
+        business:
+          attributes:
+            base:
+              invalid_activity: Activity is not valid.
+              invalid_legal_form: Legal form is not valid.
+            business_retention_settings:
+              invalid: are not valid.
+            registered_country_id:
+              must_be_set_for_business_type: 'must be defined when business_type is
+                ''%{business_type}'' (NOTE: attribute registered_country_id is aliased
+                country_of_registration_id in the API)'
+              required_for_registered_number: is required if you have a registered
+                number.
+            registered_number:
+              invalid_format: Invalid Format
+              length_range: Must be between %{min} and %{max} characters in length
+        core_accounting/taxes/models/tax_rate:
+          attributes:
+            base:
+              can_only_edit_name: Can only edit the name of this tax rate.
+              cant_delete_if_in_transactions: This tax rate has been used on at least
+                one transaction or record.
+              cant_delete_system_tax_rates: This is a default tax rate.
+              cant_delete_tax_rates: Cannot delete tax rates.
+              cant_edit_tax_rate: Cannot edit this tax rate.
+            disabled:
+              ensure_cant_reenable: A disabled tax rate can't be enabled
+            sub_tax_rates:
+              cant_be_combined: Cannot define combined rates from other combined rates.
+              cant_be_the_same: Cannot define combined rates with equal tax rates.
+              cant_have_sub_tax_rates_and_percentage: Cannot define a combined tax
+                rate with a percentage. The percentage is calculated from sub tax
+                rates.
+              cant_have_the_same_name: Cannot define sub tax rates with the same name
+                as the combined tax rate.
+        core_accounting/taxes/models/tax_rate_association:
+          attributes:
+            combined_tax_rate:
+              cant_be_equal_to_sub_tax_rate: The combined tax rate and sub tax rate
+                cannot be the same
+        core_accounting/taxes/models/tax_rate_percentage:
+          attributes:
+            end_date:
+              must_be_greater_than_start_date: The end date must be greater than the
+                start date.
+            percentage:
+              cant_have_more_than_one_present: Please end the previous percentage
+                before adding a new one.
+            start_date:
+              must_be_greater_than_previous_end_date: The start date must be greater
+                than a previous end date
+        currencies/models/business_exchange_rate:
+          attributes:
+            base:
+              delete_base_currency: You can not delete your countries currency.
+              delete_with_contact: You can not delete a currency used by a contact.
+            exchange_rate:
+              change_base_currency: You cannot change the exchange rate of your currency.
+              invalid_exchange_rate: is invalid. Please check.
+        fuji_banking/bank_account:
+          attributes:
+            base:
+              cannot_change_type_of_default_bank_accounts: You cannot change the account
+                type of a default bank account.
+              cannot_change_type_when_transactions_exist: You cannot change the account
+                type because this account has transactions allocated to it.
+              cannot_delete_default_bank_accounts: Bank account %{name} is a default
+                account.
+              cannot_record_after_accounts_start_date: You cannot record entries on
+                or after your Accounts Start Date of %{date}.
+              must_have_accounts_start_date: You must add an accounts start date in
+                financial settings before creating a bank account with an opening
+                balance
+              starting_balance_invalid_date_attribute: Opening Balance must have a
+                date.
+              transactions_allocated: You cannot delete a bank account with transactions
+                allocated.
+            opening_balance_credit:
+              invalid_attributes: Opening Balance must have a debit or credit set.
+            opening_balance_date:
+              invalid: Opening Balance must have a date.
+            opening_balance_debit:
+              invalid_attributes: Opening Balance must have a debit or credit set.
+            starting_balance_credit:
+              invalid_attributes: Opening Balance must have a debit or credit set.
+            starting_balance_debit:
+              invalid_attributes: Opening Balance must have a debit or credit set.
+            starting_balance_source_id:
+              account_not_visible_for_payment: You cannot create a starting balance
+                from the Capital Introduced account because it is not visible for
+                Other Payments
+              account_not_visible_for_receipt: You cannot create a starting balance
+                from the Capital Introduced account because it is not visible for
+                Other Receipts
+              missing_bank_account: Invalid bank account
+            user_nominal_code:
+              already_in_use: already in use.
+              invalid_format: Invalid nominal code
+        fuji_banking/bank_activity:
+          attributes:
+            base:
+              not_allowed_to_destroy_currency_charges: Currency charges cannot be
+                deleted directly. Please remove the currency charge from the related
+                %{payment} to perform this action.
+              not_allowed_to_destroy_journals: Journal transactions must be deleted
+                in Journals. You cannot delete transactions that are bank or VAT reconciled,
+                or cleared. Post a reversal in Journals instead.
+        fuji_banking/bank_reconciliation:
+          attributes:
+            base:
+              cannot_change_completed_reconciliation: This Bank Reconciliation has
+                been completed and cannot be modified.
+              existing_reconciliation: This Bank Reconciliation has been previously
+                started and not completed.
+            statement_date:
+              cannot_be_before_latest_transaction: cannot be before the latest reconciled
+                entry which is %{max_date}
+            warning:
+              date_changed_info: Please apply your changes before you continue.
+              date_changed_warn: 'Your Statement Date and/or Statement End Balance
+                has changed: '
+        fuji_banking/bank_transfer:
+          attributes:
+            base:
+              incorrect_source_payload_type: Incorrect source payload type
+              offset_amount_blank: No offset amount specified
+              offset_ledger_account_blank: No ledger account specified
+              source_and_destination_same: You cannot transfer from and to the same
+                bank account.
+        fuji_banking/deposit:
+          attributes:
+            base:
+              cheque_already_deposited: You cannot deposit a cheque that has already
+                been deposited.
+              not_cash_in_hand: You can only deposit from a cash account.
+              total_amount_greater_than_source_account_balance: Total cash and cheques
+                must not be greater than cash in hand account balance.
+        fuji_contacts/contact:
+          attributes:
+            auxiliary_account:
+              cannot_change_auxiliary_account: changes cannot be saved because there
+                are associated transactions in a closed financial year.
+            base:
+              can_only_have_one_main_address: You can only have one main address.
+              cannot_change_contact_type: There are transactions for this contact
+                type, which prevent it from changing type
+              cannot_delete_an_hmrc_contact: You cannot delete an HMRC contact.
+              cannot_duplicate_auxiliary_account: The account code is already being
+                used by another %{contact_type}.
+              contact_must_be_customer_and_or_supplier: Must specify either customer
+                or supplier
+              contact_obfuscated_cant_be_modified: Obfuscated contact can't be modified.
+              credit_notes: This contact cannot be deleted because there are credit
+                notes assigned to it.
+              currency_credit_limit: Must specify a Credit Limit
+              invoices: This contact cannot be deleted because there are invoices
+                assigned to it.
+              main_address_for_vat_number: Main address must have a country to validate
+                VAT number.
+              must_have_a_main_address: You must have a main address.
+              must_have_a_main_contact: You must have a main contact.
+              sales_quotes: This contact cannot be deleted because there are quotes
+                or estimates assigned to it.
+              uncorrected_transactions: There are transactions for this contact which
+                are preventing it from being deleted
+            business_exchange_rate:
+              cannot_change_hmrc: cannot be changed for a HMRC contact.
+              foreign_currency_disabled: Foreign currency not enabled in Foreign Currencies
+              has_transactions: cannot be changed with transactions for contact.
+            company:
+              cannot_change_hmrc: cannot be changed for a HMRC contact.
+              name_and_company_blank: A Contact or Company Name is required.
+            locale:
+              must_be_one_of: 'Locale must be one of: %{supported_locales}'
+            name:
+              name_and_company_blank: A Contact or Company Name is required.
+            purchase_ledger_account:
+              eu_contact:
+                invalid: is incorrectly selected - please select an EU Purchase ledger
+                  account.
+              home_contact:
+                invalid: is incorrectly selected - please select a non EU/Export Purchase
+                  ledger account.
+              row_contact:
+                invalid: is incorrectly selected - please select ledger account for
+                  an overseas supplier.
+            reference:
+              must_be_unique: must be unique.
+            registered_number:
+              invalid_format: Invalid Format
+              length_range: Must be between %{min} and %{max} characters in length
+            sales_ledger_account:
+              eu_contact:
+                invalid: is incorrectly selected - please select an EU Sales ledger
+                  account.
+              home_contact:
+                invalid: is incorrectly selected - please select a non EU/Export Sales
+                  ledger account.
+              row_contact:
+                invalid: is incorrectly selected - please select an export Sales ledger
+                  account.
+            tax_calculation:
+              non_scheme_support_or_retailers_tax_required: Invalid tax calculation
+                method
+            tax_number:
+              explanation:
+                at: U12345678 (9 characters. The first character is always ‘U’)
+                be: 1234567890 (10 characters. Prefix with zero ‘0’ if the customer
+                  provides a 9 digit VAT number)
+                bg: 123456789, 1234567890 (9 or 10 characters)
+                ca: 123456789XX1234 (15 characters)
+                cy: 12345678X (9 characters. The last character must always be a letter)
+                cz: 12345678, 123456789, 1234567890, (8, 9 or 10 characters. If more
+                  than 10 characters are provided delete the first 3 as these are
+                  a tax code)
+                de: 123456789 (9 characters)
+                dk: 12345678 (8 characters)
+                ee: 123456789 (9 characters)
+                es: X12345678, 12345678X, X1234567X, (9 characters. Includes one or
+                  two alphabetical characters (first or last or first and last.))
+                fi: 12345678 (8 characters)
+                fr: 12345678901, X1234567890, 1X123456789, XX123456789, (11 characters.  May
+                  include alphabetical characters (any except O or I) as first or
+                  second or first and second characters.)
+                gb: 123456789 (9 characters)
+                gr: 123456789 (9 characters)
+                hr: 12345678901 (11 characters)
+                hu: 12345678 (8 characters)
+                ie: 1234567X, 1X23456X, 1234567XX, (8 or 9 characters. Includes one
+                  or two alphabetical characters (last, or second and last, or last
+                  2))
+                it: 12345678901 (11 characters)
+                lt: 123456789, 123456789012, (9 or 12 characters)
+                lu: 12345678 (8 characters)
+                lv: 12345678901 (11 characters)
+                mc: 12345678901, X1234567890, 1X123456789, XX123456789, (11 characters.  May
+                  include alphabetical characters (any except O or I) as first or
+                  second or first and second characters.)
+                mt: 12345678 (8 characters)
+                nl: 123456789B01 (12 characters. The tenth character is always B)
+                pl: 1234567890 (10 characters)
+                pt: 123456789 (9 characters)
+                ro: 12, 123, 1234, 12345, 123456, 1234567, 12345678, 123456789, 1234567890,
+                  (from 2 to 10 characters)
+                se: 123456789012 (12 characters)
+                si: 12345678 (8 characters)
+                sk: 1234567890 (10 characters)
+              format_explanation:
+                at: Format must match 'U12345678 (9 characters. The first character
+                  is always ‘U’)' for country Austria.
+                be: Format must match '1234567890 (10 characters. Prefix with zero
+                  ‘0’ if the customer provides a 9 digit VAT number)' for country
+                  Belgium.
+                bg: Format must match '123456789, 1234567890 (9 or 10 characters)'
+                  for country Bulgaria.
+                ca: Format must match '123456789XX1234 (15 characters)' for country
+                  Canada.
+                cy: Format must match '12345678X (9 characters. The last character
+                  must always be a letter)' for country Cyprus.
+                cz: Format must match '12345678, 123456789, 1234567890, (8, 9 or 10
+                  characters. If more than 10 characters are provided delete the first
+                  3 as these are a tax code)' for country Czech Republic.
+                de: Format must match '123456789 (9 characters)' for country Germany.
+                dk: Format must match '12345678 (8 characters)' for country Denmark.
+                ee: Format must match '123456789 (9 characters)' for country Estonia.
+                es: Format must match 'X12345678, 12345678X, X1234567X, (9 characters.
+                  Includes one or two alphabetical characters (first or last or first
+                  and last.))' for country Spain.
+                fi: Format must match '12345678 (8 characters)' for country Finland.
+                fr: Format must match '12345678901, X1234567890, 1X123456789, XX123456789,
+                  (11 characters.  May include alphabetical characters (any except
+                  O or I) as first or second or first and second characters.)' for
+                  country France.
+                gb: Format must match '123456789 (9 characters)' for country United
+                  Kingdom.
+                gr: Format must match '123456789 (9 characters)' for country Greece.
+                hr: Format must match '12345678901 (11 characters)' for country Croatia.
+                hu: Format must match '12345678 (8 characters)' for country Hungary.
+                ie: Format must match '1234567X, 1X23456X, 1234567XX, (8 or 9 characters.
+                  Includes one or two alphabetical characters (last, or second and
+                  last, or last 2))' for country Ireland.
+                it: Format must match '12345678901 (11 characters)' for country Italy.
+                lt: Format must match '123456789, 123456789012, (9 or 12 characters)'
+                  for country Lithuania.
+                lu: Format must match '12345678 (8 characters)' for country Luxembourg.
+                lv: Format must match '12345678901 (11 characters)' for country Latvia.
+                mc: Format must match '12345678901, X1234567890, 1X123456789, XX123456789,
+                  (11 characters.  May include alphabetical characters (any except
+                  O or I) as first or second or first and second characters.)' for
+                  country Monaco.
+                mt: Format must match '12345678 (8 characters)' for country Malta.
+                nl: Format must match '123456789B01 (12 characters. The tenth character
+                  is always B)' for country Netherlands.
+                pl: Format must match '1234567890 (10 characters)' for country Poland.
+                pt: Format must match '123456789 (9 characters)' for country Portugal.
+                ro: Format must match '12, 123, 1234, 12345, 123456, 1234567, 12345678,
+                  123456789, 1234567890, (from 2 to 10 characters)' for country Romania.
+                se: Format must match '123456789012 (12 characters)' for country Sweden.
+                si: Format must match '12345678 (8 characters)' for country Slovenia.
+                sk: Format must match '1234567890 (10 characters)' for country Slovakia.
+              invalid_format: Format must match '%{explanation}' for country %{country}.
+              must_be_blank: must be blank for countries outside the European Union
+        fuji_contacts/customer:
+          attributes:
+            aux_reference:
+              cannot_be_changed: Debtor number cannot be changed
+        fuji_contacts/supplier:
+          attributes:
+            aux_reference:
+              cannot_be_changed: Creditor number cannot be changed
+          insurer:
+            cannot_be_deleted: A supplier that is an insurer cannot be deleted
+        fuji_core_accounting/coa_account:
+          attributes:
+            base:
+              existing_ledger_accounts: There are existing ledger accounts associated
+                with this account
+              existing_structures: There are existing COA structures associated with
+                this account
+        fuji_core_accounting/coa_template:
+          attributes:
+            base:
+              used_by_businesses: This template is currently in use by one or more
+                businesses
+        fuji_core_accounting/financial_settings:
+          attributes:
+            accounts_start_date:
+              must_be_after_opening_balances_date: must be after all opening balance
+                dates
+              must_be_on_or_before_accounting_object_dates: must be on or before any
+                transactions entered
+              must_be_set_when_opening_balances: must be set when opening balances
+                already exist
+            base:
+              invalid_exchange_rate_delete: You cannot delete exchange rates in use
+              no_vat_number_entered: 'The following settings need to be entered by
+                a user with Full Access to Settings. Please ask your Supervisor or
+                Accountant to enter these: VAT Number'
+              unallocated_credit_notes: You cannot change scheme as you have unallocated
+                Credit Notes
+              unallocated_payments_on_account: You cannot change scheme until you
+                have allocated outstanding payments on account and then ran a VAT
+                return to pick up these allocations
+              unsubmitted_vat_transactions: You must submit a VAT return before changing
+                tax scheme
+              void_future_transactions: Before changing tax scheme you must void any
+                future dated transactions
+            current_financial_year_end_date:
+              can_not_be_changed: can not be changed
+            current_financial_year_start_date:
+              can_not_be_changed: can not be changed
+              no_transactions_allowed_before: no transactions can exist before the
+                first financial year
+            foreign_currency_enabled:
+              cannot_enable: cannot be enabled
+              must_not_have_multi_currency_transactions: cannot be disabled when you
+                have multi currency transactions
+            lockdown_date:
+              must_not_be_before_current_end_date: must not be before current financial
+                year end date
+              must_not_be_before_current_start_date: cannot be earlier than the day
+                before the start of your current financial year
+              must_not_be_in_the_future: must not be in the future
+            next_financial_year_start_date:
+              can_not_be_changed: can not be changed
+              must_be_contiguous: financial years must be contiguous
+            purchase_tax_calculation:
+              not_applicable: not applicable for this business and tax scheme
+              not_taxable: cannot be set for non taxable businesses
+            sales_tax_calculation:
+              not_applicable: not applicable for this business and tax scheme
+              not_taxable: cannot be set for non taxable businesses
+            tax_scheme_id:
+              existing_documents: cannot be changed because there are existing invoice
+                drafts, quotes, or estimates.
+        fuji_core_accounting/ledger_account:
+          attributes:
+            base:
+              cannot_include_deleted_bank: You cannot include a ledger account which
+                belongs to a deleted bank account.
+              combined_2_exclude_ledger_message: Default ledger accounts must be included
+                in your Chart of Accounts. Remember, you may have an account set as
+                default within a customer, supplier, product or service record. Change
+                default accounts at Settings > Record and Transactions Settings and
+                in the relevant record.
+              combined_3_exclude_ledger_message: Default ledger accounts and ledger
+                accounts with transactions must be included in your Chart of Accounts.
+                Remember, you may have an account set as default within a customer,
+                supplier, product or service record. Change default accounts at Settings
+                > Record and Transactions Settings and in the relevant record.
+              has_transactions: Ledger accounts with transactions must be included
+                in your Chart of Accounts.
+              is_control_account: You cannot change the category of a control account.
+              is_default_setting: Default ledger accounts must be included in your
+                Chart of Accounts. Change default accounts at Settings > Record and
+                Transactions Settings.
+              is_not_direct_expense: You can only set "Purchase for resale" for ledger
+                accounts with a direct expense category
+              is_record_default: You cannot remove a ledger account that is set as
+                a default account on a customer, supplier, product or service record. Change
+                default accounts at Settings > Record and Transactions Settings.
+              other_expense_visibility: The default other payment ledger must always
+                be visible. Change default accounts at Settings > Record and Transactions
+                Settings.
+              other_incomes_visibility: The default other receipt ledger must always
+                be visible. Change default accounts at Settings > Record and Transactions
+                Settings.
+              purchases_visibility: The default purchase ledger must always be visible.
+                Change default accounts at Settings > Record and Transactions Settings.
+              sales_visibility: The default sales ledger must always be visible. Change
+                default accounts at Settings > Record and Transactions Settings.
+            control_name:
+              cannot_be_modified: You cannot remove or edit a control name once set.
+              invalid_control_name: This control name is not valid.
+            is_included:
+              is_control_account: You cannot exclude a control account.
+            is_purchase_for_resale:
+              invalid_direct_expense: invalid for this ledger account
+            ledger_account_type_id:
+              cannot_be_modified: You cannot change the category of a bank ledger
+                account.
+              is_control_account: You cannot change the category of a control account.
+              is_invalid: is invalid for business.
+            name:
+              is_control_account: You cannot change the name of a control account.
+            nominal_code:
+              belongs_to_classification: The nominal code must begin with %{count}
+            scope:
+              cannot_modify_bank: You cannot change bank visibility on a bank ledger
+                account.
+            tax_rate:
+              must_be_exempt: Tax rate must be exempt for this ledger.
+              wrong_country: Tax rate must be for the same country as the registered
+                country of the business.
+            trade_of_asset:
+              invalid_category: Can only be selected for fixed assets
+              not_applicable: Is not valid for your tax system.
+        fuji_invoicing/artefact:
+          attributes:
+            base:
+              cannot_discount_sale_of_asset: You cannot apply a discount to the sale
+                of an asset.
+              catalog_item_must_be_active: You cannot create or update a %{type} with
+                an inactive Product or Service.
+              line_items_must_be_present: There must be at least one line item.
+              quantity_and_unit_price_both_negative: Quantity and price cannot both
+                be negative.
+              stock_item_must_have_positive_quantity: Stock item quantity must be
+                greater than 0.
+              stock_item_must_have_positive_value: Stock items can not have a negative
+                value.
+            carriage_tax_rate:
+              eu_tax_invoices_can_only_use_zero_rate: You can only use 'Zero Rated'
+                for EU Tax Registered Customers
+            contact:
+              hmrc_forbidden: must not be an HMRC contact
+        fuji_invoicing/artefact_line_item:
+          attributes:
+            catalog_item:
+              must_be_active: You cannot create a %{type} with an inactive Product
+                or Service.
+            currency_tax_amount:
+              cant_record_tax_amount_for_zero_rate: You cannot record VAT Amount if
+                using a VAT Rate with a Zero %.
+            eu_goods_services_type_id:
+              blank: Please select the EU Goods/Services on each item line.
+            tax_amount:
+              tax_on_non_taxable_business: You cannot add tax, your business is not
+                registered for tax
+            tax_rate_id:
+              ledger_account_based: for ledger account %{ledger_account} must be '%{tax_rate}'.
+            tax_rate_percentage:
+              is_zero: You entered a tax amount but tax rate is zero. Please fix one
+                of them.
+            trade_of_asset:
+              invalid_category: Can only be selected for fixed assets
+              not_applicable: Is not valid for your tax system.
+        fuji_invoicing/corrective_invoice:
+          attributes:
+            base:
+              balance_cannot_be_greater_than_original_outstanding: A Credit Total
+                must not be greater than the outstanding amount of the invoice.
+        fuji_invoicing/credit_note:
+          attributes:
+            base:
+              can_only_release_drafts: You can only release draft credit notes.
+              invoice_must_be_outstanding: You cannot create a Credit Note from an
+                Invoice without an outstanding amount.
+              must_not_be_zero_when_created_from_invoice: You cannot create a Credit
+                Note from an Invoice with a 0.00 value.
+            total:
+              must_not_be_greater_than_outstanding: Must not be greater than the outstanding
+                amount of the invoice.
+        fuji_invoicing/invoice:
+          attributes:
+            base:
+              can_only_release_drafts: You can only release draft invoices.
+              delivery_address_not_filled: Delivery Address is required.
+              invoice_address_not_filled: Invoice Address is required.
+        fuji_invoicing/invoice_settings:
+          attributes:
+            default_delivery_address:
+              invalid_value: Invalid Value
+            document_headers:
+              length: "%{item} heading must be between 1 and 30 characters long"
+              presence: You must supply a heading for %{item}
+            line_item_headers:
+              length: "%{item} heading must be between 1 and 30 characters long"
+              presence: You must supply a heading for %{item}
+            next_credit_note_number:
+              already_taken: is already taken
+            next_invoice_number:
+              already_taken: is already taken
+            next_quote_number:
+              already_taken: is already taken
+            payment_bank_account:
+              cannot_receive_invoice_payment: cannot receive invoice payment
+        fuji_invoicing/purchase_artefact:
+          attributes:
+            currency_total_tax_amount:
+              eu_tax_invoices_can_only_record_zero_amount: You can not record VAT
+                amount for EU Tax Registered Suppliers
+        fuji_invoicing/purchase_artefact_line_item:
+          attributes:
+            currency_tax_amount:
+              eu_tax_invoices_can_only_record_zero_amount: You can not record VAT
+                amount for EU Tax Registered Suppliers
+              rest_of_world:
+                must_be_zero: must be zero for Suppliers outside the EU
+            ledger_account:
+              eu_supplier:
+                invalid: is incorrectly selected - please select an EU ledger account
+              home_supplier:
+                invalid: is incorrectly selected - please select a non EU/Import ledger
+                  account
+              row_supplier:
+                invalid: is incorrectly selected - please select an Import ledger
+                  account
+            tax_rate:
+              rest_of_world_must_be_zero: must be zero for goods and related services
+        fuji_invoicing/purchase_corrective_invoice:
+          attributes:
+            base:
+              cannot_edit_voided_invoice: You cannot edit corrective invoices which
+                have already been voided.
+              cannot_save_already_voided: Corrective invoice already voided.
+              cannot_void_already_voided: Corrective invoice already voided.
+              date_after_due_date: Corrective invoice date cannot be after due date.
+              edit_has_allocations: You must unallocate refunds/payments before editing
+                this corrective invoice.
+              edit_has_payments: You cannot edit corrective invoices where you have
+                recorded a payment.
+              unable_to_copy_artefact: Unable to copy this corrective invoice as a
+                ledger account it uses is no longer available in purchases. Please
+                check the ledger accounts used on the invoice in your chart of accounts
+                to ensure it is available in purchases.
+              void_has_payments: You cannot void corrective invoices where you have
+                recorded a payment.
+        fuji_invoicing/purchase_credit_note:
+          attributes:
+            base:
+              cannot_delete_already_voided: You cannot delete a voided credit note.
+              cannot_edit_migrated_credit_note: You can’t edit this credit note because
+                it was migrated from your old accounting system.
+              cannot_edit_voided_credit_note: You cannot edit credit notes which have
+                already been voided.
+              cannot_save_already_voided: Credit note already voided.
+              cannot_void_already_voided: Credit note already voided.
+              destroy_has_payments: You cannot delete credit note where you have recorded
+                a refund.
+              edit_has_allocations: You must unallocate refunds before editing this
+                credit note.
+              no_eu_contact_without_vat_number_allowed: You selected an EU supplier,
+                thus you have to input your USt-ID.
+              total_must_not_be_negative: Credit note total cannot be negative.
+              unable_to_copy_artefact: Unable to copy this credit note as a ledger
+                account it uses is no longer available in purchases. Please check
+                the ledger accounts used on the credit note in your chart of accounts
+                to ensure it is available in purchases.
+        fuji_invoicing/purchase_credit_note_line_item:
+          attributes:
+            base:
+              asset_purchase_not_service: Credit note line cannot be both an Asset
+                and a Service. Please review the goods / services selection.
+        fuji_invoicing/purchase_invoice:
+          attributes:
+            base:
+              cannot_destroy_already_voided: You cannot delete a voided invoice.
+              cannot_edit_legacy_migrated_invoice: This opening balance invoice cannot
+                be edited, as it was created in your previous Accounts service.
+              cannot_edit_migrated_invoice: You can't edit this invoice because it
+                was migrated from your old accounting system.
+              cannot_edit_voided_invoice: You cannot edit voided invoices.
+              cannot_save_already_voided: Invoice already voided.
+              cannot_void_already_voided: Invoice already voided.
+              date_after_due_date: Invoice date cannot be after due date.
+              destroy_has_payments: You cannot delete invoices where you have recorded
+                a payment.
+              edit_has_allocations: You must unallocate credit notes or payments before
+                editing this invoice.
+              edit_has_credit_notes: You must void any credit notes before editing
+                this invoice.
+              edit_has_payments: You cannot edit invoices where you have recorded
+                a payment.
+              no_eu_contact_without_vat_number_allowed: You selected an EU supplier,
+                thus you have to input your USt-ID.
+              total_must_not_be_negative: Invoice total cannot be negative.
+              unable_to_copy_artefact: Unable to copy this invoice as a ledger account
+                it uses is no longer available in purchases. Please review your chart
+                of accounts.
+              void_has_payments: You cannot void invoices where you have recorded
+                a payment.
+            currency_total_tax_amount:
+              eu_tax_invoices_can_only_record_zero_amount: You can not record VAT
+                amount for EU Tax Registered Suppliers
+        fuji_invoicing/purchase_invoice_line_item:
+          attributes:
+            base:
+              asset_purchase_not_service: Invoice line cannot be both an Asset and
+                a Service. Please review the goods / services selection.
+            is_purchase_for_resale:
+              invalid_direct_expense: invalid for this ledger account
+        fuji_invoicing/purchase_invoice_payment:
+          attributes:
+            base:
+              invoice_is_voided: Invoice is voided.
+        fuji_invoicing/purchase_line_item:
+          attributes:
+            currency_tax_amount:
+              eu_tax_invoices_can_only_record_zero_amount: You can not record VAT
+                amount for EU Tax Registered Suppliers
+              rest_of_world_must_be_zero: must be zero for Suppliers outside the EU
+            ledger_account:
+              contact_invalid_for_scopes: is incorrectly selected - you can't use
+                this ledger account for this supplier.
+              eu_supplier_invalid: is incorrectly selected - please select an EU ledger
+                account
+              home_supplier_invalid: is incorrectly selected - please select a non
+                EU/Import ledger account
+              row_supplier_invalid: is incorrectly selected - please select an Import
+                ledger account
+            tax_rate:
+              rest_of_world_must_be_zero: must be zero for goods and related services
+        fuji_invoicing/sales_artefact:
+          attributes:
+            base:
+              artefact_number_must_be_unique: Artefact number must be unique
+              both_artefact_number_fields_must_be_present: Both artefact_number and
+                artefact_number_prefix must be present or blank
+        fuji_invoicing/sales_corrective_invoice:
+          attributes:
+            base:
+              cannot_edit_voided_invoice: You cannot edit corrective invoices which
+                have already been voided.
+              cannot_save_already_voided: Corrective invoice already voided.
+              cannot_void_already_voided: Corrective invoice already voided.
+              date_after_due_date: Corrective invoice date cannot be after due date.
+              edit_has_allocations: You must unallocate refunds/payments before editing
+                this corrective invoice.
+              edit_has_credit_notes: You must void any credit notes before editing
+                this corrective invoice.
+              edit_has_payments: You cannot edit corrective invoices where you have
+                recorded a payment.
+              unable_to_copy_artefact: Unable to copy this corrective invoice as a
+                ledger account it uses is no longer available in sales. Please check
+                the ledger accounts used on the invoice in your chart of accounts
+                to ensure it is available in sales.
+              void_has_payments: You cannot void corrective invoices where you have
+                recorded a payment.
+        fuji_invoicing/sales_credit_note:
+          attributes:
+            base:
+              cannot_edit_issued_credit_note: You cannot edit credit notes which have
+                already been issued.
+              cannot_edit_migrated_credit_note: You can’t edit this credit note because
+                it was migrated from your old accounting system.
+              cannot_edit_voided_credit_note: You cannot edit credit notes which have
+                already been voided.
+              cannot_save_already_voided: Credit note already voided.
+              cannot_void_already_voided: Credit note already voided.
+              edit_has_allocations: You must unallocate refunds before editing this
+                credit note.
+              no_eu_contact_without_vat_number_allowed: You selected an EU customer,
+                thus you have to input your USt-ID.
+              total_must_not_be_negative: Credit note total cannot be negative.
+              unable_to_copy_artefact: Unable to copy this credit note as a ledger
+                account it uses is no longer available in sales. Please check the
+                ledger accounts used on the credit note in your chart of accounts
+                to ensure it is available in sales.
+        fuji_invoicing/sales_estimate:
+          attributes:
+            base:
+              no_eu_contact_without_vat_number_allowed: You selected an EU customer,
+                thus you have to input your USt-ID.
+              total_must_not_be_negative: Sales Estimate unit price cannot be negative.
+              unable_to_copy_artefact: Unable to copy this estimate as a ledger account
+                it uses is no longer available in sales. Please check the ledger accounts
+                used on the estimate in your chart of accounts to ensure it is available
+                in sales.
+        fuji_invoicing/sales_invoice:
+          attributes:
+            base:
+              cannot_edit_issued_invoice: You cannot edit issued invoices.
+              cannot_edit_legacy_migrated_invoice: This opening balance invoice cannot
+                be edited, as it was created in your previous Accounts service
+              cannot_edit_migrated_invoice: You can’t edit this invoice because it
+                was migrated from your old accounting system.
+              cannot_edit_voided_invoice: You cannot edit invoices which have already
+                been voided.
+              cannot_save_already_voided: Invoice already voided.
+              cannot_void_already_voided: Invoice already voided.
+              date_after_due_date: Invoice date cannot be after due date.
+              edit_has_allocations: You must unallocate credit notes or receipts before
+                editing this invoice.
+              edit_has_credit_notes: You must void any credit notes before editing
+                this invoice.
+              edit_has_payments: You cannot edit invoices where you have recorded
+                a payment.
+              no_eu_contact_without_vat_number_allowed: You selected an EU customer,
+                thus you have to input your USt-ID.
+              tax_on_non_taxable_business: You cannot add tax, your business is not
+                registered for tax
+              total_must_not_be_negative: Invoice total cannot be negative.
+              unable_to_copy_artefact: Unable to copy this invoice as a ledger account
+                it uses is no longer available in sales. Please check the ledger accounts
+                used on the invoice in your chart of accounts to ensure it is available
+                in sales.
+              void_has_payments: You cannot void invoices where you have recorded
+                a payment.
+        fuji_invoicing/sales_invoice_payment:
+          attributes:
+            base:
+              cheque_deposited: This cheque has already been deposited into a bank
+                account. Delete the deposit before editing this transaction.
+              invoice_is_voided: Invoice is voided.
+        fuji_invoicing/sales_line_item:
+          attributes:
+            base:
+              product_xor_service: Cannot assign both product and service
+            ledger_account:
+              contact_invalid_for_scopes: is incorrectly selected - you can't use
+                this ledger account for this customer.
+              eu_customer_invalid: is incorrectly selected - please select an EU ledger
+                account.
+              home_customer_invalid: is incorrectly selected - please select a non
+                EU/Export ledger account.
+              row_customer_invalid: is incorrectly selected - please select an Export
+                ledger account.
+            tax_rate:
+              eu_tax_invoices_can_only_use_zero_rate: You can only use 'Zero Rated'
+                for EU Tax Registered Customers.
+              rest_of_world_must_use_zero_rate: must be 'Zero Rated' for Customers
+                outside the EU.
+        fuji_invoicing/sales_quote:
+          attributes:
+            base:
+              no_eu_contact_without_vat_number_allowed: You selected an EU customer,
+                thus you have to input your USt-ID.
+              total_must_not_be_negative: Sales Quote unit price cannot be negative.
+              unable_to_copy_artefact: Unable to copy this quote as a ledger account
+                it uses is no longer available in sales. Please check the ledger accounts
+                used on the quote in your chart of accounts to ensure it is available
+                in sales.
+        inventory/models/stock_movement:
+          attributes:
+            base:
+              catalog_item_inactive_delete: You cannot delete this item as it contains
+                one or more stock items that are marked as inactive.
+              catalog_item_must_be_active: One or more items are marked as inactive.
+                You cannot make changes to inactive items.
+              date_before_accounts_start: The adjustment date must be later than the
+                accounts start date of %{date}. Change the adjustment date or the
+                accounts start date and try again.
+              date_before_accounts_start_compact: The date must be later than the
+                accounts start date of %{date}.
+              date_before_lockdown_date: The adjustment date must be later than the
+                year-end lock date of %{date}. Change the adjustment date or <a href="%{help_url}/find_by_tag?language=%{help_language}&locale=%{help_locale}&service=accounts_extra&tag=extra_financial_year_end"
+                target="_">change the year-end lock down date</a> and try again.
+              date_before_lockdown_date_compact: The date must be later than the year-end
+                lock date of %{date}.
+              original_date_before_lockdown_date: You can't edit this Adjustment as
+                it's dated %{original_date} which is on or before the year end lock
+                date of %{date}. <a href="%{help_url}/find_by_tag?language=%{help_language}&locale=%{help_locale}&service=accounts_extra&tag=extra_financial_year_end"
+                target="_">Change the year-end lock down date</a> and try again.
+        user:
+          attributes:
+            base:
+              activated_user_cannot_be_deleted: You cannot delete activated users.  Please
+                set their access permissions to 'No Access'.
+            email:
+              email_cannot_be_changed: Email cannot be changed
+            user_auths:
+              invalid: are invalid.
+    models:
+      advanced_uk/analysis_type: Analysis Type
+      advanced_uk/bank_opening_balance: Bank Opening Balance
+      advanced_uk/bank_opening_balance_batch: Bank Account Opening Balances
+      advanced_uk/bank_payment: Bank Payment
+      advanced_uk/bank_receipt: Bank Receipt
+      advanced_uk/cashflow_forecast: Cash Flow Forecast
+      advanced_uk/catalog_item:
+        one: Product/Service
+        other: Products/Services
+      advanced_uk/category:
+        one: Category
+        other: Categories
+      advanced_uk/customer_allocation: Customer Allocation
+      advanced_uk/customer_income_payment: Customer Receipt
+      advanced_uk/customer_opening_balance_batch: Customer Opening Balance
+      advanced_uk/customer_opening_balance_entry: Customer Opening Balance
+      advanced_uk/customer_refund_payment: Customer Refund
+      advanced_uk/journal_code: Journal Code
+      advanced_uk/journal_opening_balance: Nominal Opening Balance
+      advanced_uk/journal_opening_balance_line: Nominal Opening Balance Line
+      advanced_uk/other_expense_payment: Other Payment
+      advanced_uk/other_expense_payment_refund: Other Receipt
+      advanced_uk/other_income_payment: Other Receipt
+      advanced_uk/other_income_payment_refund: Other Payment
+      advanced_uk/product:
+        one: Non-stock
+        other: Non-stock
+      advanced_uk/purchase_artefact: Purchase Item
+      advanced_uk/purchase_batch: Purchase Batch
+      advanced_uk/purchase_batch_entry: Purchase Quick Entry
+      advanced_uk/sales_artefact: Sales Item
+      advanced_uk/sales_batch: Sales Batch
+      advanced_uk/sales_batch_entry: Sales Quick Entry
+      advanced_uk/service:
+        one: Service
+        other: Services
+      advanced_uk/stock_item:
+        one: Stock
+        other: Stock
+      advanced_uk/supplier_allocation: Supplier Allocation
+      advanced_uk/supplier_expense_payment: Supplier Payment
+      advanced_uk/supplier_opening_balance_batch: Supplier Opening Balance
+      advanced_uk/supplier_opening_balance_entry: Supplier Opening Balance
+      advanced_uk/supplier_refund_payment: Supplier Refund
+      advanced_uk/tax_return: VAT Return
+      advanced_uk/vat_expense_payment: VAT Payment
+      advanced_uk/vat_income_payment: VAT Reclaim
+      business_membership: User
+      fuji_banking/bank_account: Bank Account
+      fuji_banking/bank_activity: Bank Activity
+      fuji_banking/bank_transfer: Bank Transfer
+      fuji_contacts/contact:
+        one: Contact
+        other: Contacts
+        sar_request:
+          contact:
+            account_details:
+              title: Account Details
+              vat_number: VAT Number
+            addresses:
+              delivery_address:
+                title: Delivery Address
+              main_address:
+                title: Main Address
+              title: Address(es)
+            bank_details:
+              account_name: Account Name
+              account_number: Account Number
+              bic_swift: BIC/Swift
+              iban: IBAN
+              sort_code: Sort Code
+              title: Bank Details
+            contacts:
+              title: Contact(s)
+            email: Email
+            fax: Fax
+            main_contact:
+              title: Main Contact
+            mobile: Mobile
+            notes:
+              title: Notes
+            role: Role
+            telephone: Telephone
+          file:
+            csv:
+              filename: contact_sar_request.csv
+            pdf:
+              filename: contact_sar_request.pdf
+          generated_by: Generated by Sage Business Cloud Accounting
+          personal_data_header: Personal Data
+      fuji_contacts/customer:
+        one: Customer
+        other: Customers
+      fuji_contacts/supplier:
+        one: Supplier
+        other: Suppliers
+      fuji_contacts/vendor:
+        one: Vendor
+        other: Vendors
+      fuji_core_accounting/financial_settings: Financial Settings
+      fuji_core_accounting/ledger_account: Ledger Account
+      fuji_invoicing/credit_note: Credit Note
+      fuji_invoicing/invoice_settings: Invoice Settings
+      fuji_invoicing/purchase_corrective_invoice: Purchase Corrective Invoice
+      fuji_invoicing/purchase_credit_note: Purchase Credit Note
+      fuji_invoicing/purchase_invoice: Purchase Invoice
+      fuji_invoicing/purchase_invoice_payment: Purchase Invoice Payment
+      fuji_invoicing/sales_corrective_invoice: Sales Corrective Invoice
+      fuji_invoicing/sales_credit_note: Sales Credit Note
+      fuji_invoicing/sales_estimate: Estimate
+      fuji_invoicing/sales_invoice: Sales Invoice
+      fuji_invoicing/sales_invoice_payment: Sales Invoice Receipt
+      fuji_invoicing/sales_quote: Quote
+      inventory/adjustment_in: Adjustment In
+      inventory/adjustment_out: Adjustment Out
+      inventory/purchase_corrective_credit_note: Goods In
+      inventory/purchase_corrective_invoice: Goods In
+      inventory/purchase_credit_note: Goods In
+      inventory/purchase_invoice: Goods In
+      inventory/sales_corrective_credit_note: Goods Out
+      inventory/sales_corrective_invoice: Goods Out
+      inventory/sales_credit_note: Goods Out
+      inventory/sales_invoice: Goods Out
+      mysageone_core/jwt_reseller: Reseller
+      mysageone_core/message_recipient: message
+    warnings:
+      messages:
+        adding_credit_note_to_disputed_invoice: The original invoice is in dispute.  Applying
+          a credit note to this invoice will clear its disputed status.
+        adding_payment_to_disputed_invoice: This invoice is currently disputed.  Recording
+          a payment on this invoice will clear its disputed status.
+        adding_refund_to_disputed_credit_note: This credit note is currently disputed.  Recording
+          a refund on this credit note will clear its disputed status.
+        bank_account_multiple_opening_balances: This balance includes itemised entries.
+        declined_estimate: This estimate has been declined. Any changes will result
+          in the declined status being removed.
+        declined_quote: This quote has been declined. Any changes will result in the
+          declined status being removed.
+        payment_bank_and_tax_reconciled: This entry or a previous version of it has
+          been bank / VAT reconciled.  You can make limited changes only.
+        payment_bank_reconciled: Part or all of this entry has been bank reconciled.  You
+          can make limited changes only.
+        payment_cannot_be_edited: You can’t edit this transaction as it has an associated
+          payment or refund.
+        payment_cleared: Part or all of this entry has cleared your bank account.  You
+          can make limited changes only.
+        payment_cleared_and_tax_reconciled: This entry or a previous version of it
+          has cleared your bank account / been VAT reconciled.  You can make limited
+          changes only.
+        payment_tax_reconciled: This entry or a previous version of it has been VAT
+          reconciled.  You can make limited changes only.
+        sage_pay_no_surcharge_ledger_selected: If no Surcharge Ledger Account is selected
+          then the Ledger Account of the transaction itself will be applied to the
+          surcharge.
+        tax_return_require_after_scheme_change: You need to produce a VAT Return to
+          cover the outstanding transactions that became due when the business changed
+          to be Not Registered
+      multi_user:
+        limited_access: There may be limited access to one or more areas of the application.
+        no_access: No summary information to display for your access level.
+        read_only: Your access level is set to Read Only, and you cannot make changes
+          or enter data.
+  address:
+    dialog:
+      custom: Custom
+      delivery_address_same_as_main: Same as invoice address
+      help_tag:
+        custom: Use a custom address.
+        delivery_address_same_as_main: Use main invoice address.
+        no_address: There is no delivery address for this invoice.
+      no_address: No Address
+      title: Set %{edited_object}
+    formats:
+      artefact_templates: |-
+        <span class='street_1'>%{street_1}</span>, <span class='street_2'>%{street_2}</span>
+        <span class='city'>%{city}</span>, <span class='county'>%{county}</span>, <span class='postcode'>%{postcode}</span>
+        <span class='country_name'>%{country_name}</span>
+      blankcity: |-
+        %{street_1}
+        %{street_2}
+        %{county}
+        %{postcode}
+        %{country_name}
+      blankcity_no_country: |-
+        %{street_1}
+        %{street_2}
+        %{county}
+        %{postcode}
+      blankcity_non_na: |-
+        %{street_1}
+        %{street_2}
+        %{county} %{postcode}
+        %{country_name}
+      blankcity_non_na_no_country: |-
+        %{street_1}
+        %{street_2}
+        %{county} %{postcode}
+      default: |-
+        %{street_1}
+        %{street_2}
+        %{city}
+        %{county}
+        %{postcode}
+        %{country_name}
+      default_eu: |-
+        %{street_1}
+        %{street_2}
+        %{county}
+        %{postcode} %{city}
+        %{country_name}
+      default_eu_no_country: |-
+        %{street_1}
+        %{street_2}
+        %{county}
+        %{postcode} %{city}
+      default_eu_no_county: |-
+        %{street_1}
+        %{street_2}
+        %{postcode} %{city}
+        %{country_name}
+      default_eu_no_county_simplified: |-
+        %{street_1}
+        %{city}
+        %{postcode}
+        %{country_name}
+      default_na: |-
+        %{street_1}
+        %{street_2}
+        %{city} %{county} %{postcode}
+        %{country_name}
+      default_na_no_country: |-
+        %{street_1}
+        %{street_2}
+        %{city} %{county} %{postcode}
+      default_na_simplified: |-
+        %{street_1}
+        %{city}
+        %{county}
+        %{postcode}
+        %{country_name}
+      default_no_country: |-
+        %{street_1}
+        %{street_2}
+        %{city}
+        %{county}
+        %{postcode}
+      default_simplified: |-
+        %{street_1}
+        %{city}
+        %{postcode}
+        %{country_name}
+      delimiter: "\n"
+      one_line: "%{street_1}, %{street_2}, %{city}, %{county}, %{postcode}, %{country_name}"
+      one_line_eu: "%{street_1}, %{street_2}, %{city}, %{county}, %{postcode}, %{country_name}"
+      one_line_eu_no_country: "%{street_1}, %{street_2}, %{city}, %{county}, %{postcode}"
+      one_line_na: "%{street_1}, %{street_2}, %{city}, %{county}, %{postcode}, %{country_name}"
+      one_line_na_no_country: "%{street_1}, %{street_2}, %{city}, %{county}, %{postcode}"
+      one_line_no_country: "%{street_1}, %{street_2}, %{city}, %{county}, %{postcode}"
+      one_line_non_na: "%{street_1}, %{street_2}, %{city}, %{county}, %{postcode},
+        %{country_name}"
+      one_line_non_na_no_country: "%{street_1}, %{street_2}, %{city}, %{county}, %{postcode}"
+  allocations:
+    dialog:
+      artefact_total: Total
+      artefact_total_multi_currency: Total<span data-currency="%{currency_code}">&nbsp;</span>
+      description: A detailed breakdown of payments and allocations.
+      description_multi_currency: A detailed breakdown of payments and allocations
+        in %{currency_code}.
+      outstanding: Outstanding
+      outstanding_multi_currency: Outstanding <span data-currency="%{currency_code}">&nbsp;</span>
+      title: Payments and Allocations
+      total_paid: Paid/Allocated
+      total_paid_multi_currency: Paid/Allocated <span data-currency="%{currency_code}">&nbsp;</span>
+    report:
+      headers:
+        allocated_amount: Amount
+        date: Date
+        discount_amount: Discount
+        reference: Reference
+        refund: Refund
+        type: Type
+      rows:
+        allocation_type: Allocation - %{type}
+        total: Total Paid/Allocated
+  analysis_types:
+    headers:
+      areas: Active Areas for this Analysis Type
+      categories: Categories for this Analysis Type
+    labels:
+      analysis_type: Analysis Type
+      analysis_type_category: Analysis Category
+    pod:
+      title: Analysis
+    prompt: None
+    prompt_all: All
+  api:
+    errors:
+      destination_bank_account: Destination must be for a valid bank account
+      filter_dates_required: From and To dates are required
+      filter_dates_to_before_from: From Date must be before the To Date.
+      gone:
+        data_code: Gone
+        message: The requested resource is no longer available
+      inaccessible_field: This field cannot be modified by this API
+      invalid_date: invalid_date
+      invalid_dates: Invalid dates.
+      record_not_found:
+        data_code: RecordNotFound
+        message: Record not found
+      runtime_error:
+        data_code: RuntimeError
+        message: Value was not allowed
+      source_bank_account: Source must be for a valid bank account
+      unprocessable_entity:
+        data_code: UnprocessableEntity
+        message: This entity cannot be modified by this API
+      validation_errors:
+        line_items:
+          message: There must be at least one line item.
+  app:
+    accept: Accept
+    azure:
+      user_not_recognised: We haven't recognised your Azure account. Please complete
+        the sign up form to create a new account.
+      user_recognised: We have recognised your account. Please login to your account.
+    change_password: Change Password
+    cobrands:
+      current_image: 'Co-Brand Logo:'
+      manage: Manage Co-Brands
+      upload_new: Upload New
+    coming_soon_dialog:
+      close: Go back
+      message_1: This feature is still in development,
+      message_2: it will be ready when we publicly release the application.
+      title: Feature coming soon
+    connect_provider:
+      link: Connect with %{provider}
+      message:
+        success: You have successfully linked up your %{provider} account.
+      providers:
+        azure: Azure
+        facebook: Facebook
+        google: Google
+        sageid: SageID
+      sage: Provide a username and password
+      sage_intro: Want to create a Sage Login?
+    cost_per_month: Cost per month
+    cost_this_month: Cost this month
+    decline: Decline
+    email_not_verified_error: To verify your email address, please click the link
+      in the email we sent when you signed up. Need some help or can't find the email?
+      Just give us a call on 0845 111 6611.
+    errors:
+      cannot_access_restricted_area: You do not have access to this option.  If you
+        require access, please contact your Supervisor.
+      impersonation_access_denied: You do not have access to the selected area.
+    facebook:
+      missing_email: To sign up or sign in with Facebook, you must allow permission
+        to your email address
+      user_not_recognised: We haven't recognised your Facebook account. Please complete
+        the sign up form to create a new account.
+      user_recognised: We have recognised your account. Please login to your account.
+    google:
+      user_not_recognised: We haven't recognised your Google account. Please complete
+        the sign up form to create a new account.
+      user_recognised: We have recognised your account. Please login to your account.
+    help: Help
+    home_screen:
+      icons:
+        accounts_extra: Accounting
+    jwt_resellers:
+      header:
+        enabled: Enabled
+        endpoint: Endpoint
+        environment: Environment
+        token: Token
+      manage: Manage Resellers
+      messages:
+        blurb_html: This page is available until %{expiry_date}. After this date,
+          this information will not be available. You should store this information
+          in a secure way. <strong>DO NOT</strong> check this information into source
+          control.
+        confirm_disable: Are you sure you wish to deny this third party provider access?
+        confirm_enable: Are you sure you wish to allow this third party provider to
+          have access?
+        disable: Disable
+        disabled: Production endpoint disabled
+        disabled_html: This customer is currently not allowed to use the production
+          endpoint. Which means <strong>login and automatic provisioning</strong>
+          to any of the services is <strong>disabled</strong>.
+        enable: Enable
+        enabled: Production endpoint enabled
+        enabled_html: This customer is currently allowed to use the production endpoint.  Which
+          means <strong>login and automatic provisioning</strong> to any of the services
+          is <strong>enabled</strong>.
+        page_title: Reseller integration details
+        production: 'Once you''ve checked the validity of your token you can integrate
+          with the production endpoint. To integrate with the production endpoint
+          you must use the following details:'
+        production_disabled:
+          text: Please contact us to enable this endpoint.
+          title: Production endpoint not enabled.
+        readme_html: Read the <a href='%{url}'>documentation</a>.
+        resend:
+          action: Resend invitation
+          confirmation: Are you sure you wish to resend an invitation to %{name}?  Any
+            previously issued invitations will be invalid.
+        signatory_html: 'Your signatory is: <strong>%{signatory}</strong>'
+        steps: Steps to integrate
+        test: 'To check the validity of your token we recommend integrating with the
+          test endpoint. You must use the following details:'
+        title: 'Important:'
+    live_chat: Chat
+    mailer:
+      user_invitation:
+        from: example_from@sageone.com
+        subject: "%{user} invites you to use Sage Business Cloud Accounting"
+    manage_services: Manage Services
+    mysageone: My Sage One
+    name: Sage Business Cloud
+    names:
+      accounts_extra: Accounting
+    oauth:
+      review_permissions: Review Permissions
+    oauth_actions:
+      allow: Allow
+      deny: Deny
+    oauth_authorize_1: " would like to request access to your Sage Business Cloud
+      Accounting data."
+    oauth_authorize_2: 'If you would like more information please contact them at '
+    oauth_authorize_access: 'Access:'
+    oauth_authorize_business: 'Business:'
+    oauth_authorize_link: Application URL
+    oauth_scopes:
+      full_access: Full
+      readonly: Read only
+    one: One
+    password_change_success: Password changed successfully
+    roles:
+      custom: Custom
+      full_access: Full Access
+      no_access: No Access
+      owner: Owner
+      read_only: Read Only
+      restricted_access: Restricted Access
+    sage: Sage
+    service: Service
+    service_names:
+      accounting: Accounting
+      micro: Accounting Start
+      micro_invoicing: Accounting
+      service_uid:
+        accounting: Accounting
+        accounts_extra: Accounting
+        micro: Accounting Start
+        micro_invoicing: Accounting Start
+        sage_one: Accounting Standard
+        sage_one_basics: Invoicing
+    subscription_cost_summary: Subscription Cost Summary
+    superadmin: Super Admin
+    title: Accounting
+    title_html: <span class="logo-sage">Sage</span> <span class="logo-one">One</span>
+    total_cost_per_month: Total cost per month
+    total_cost_this_month: Total cost this month
+    user_invitation:
+      accept:
+        message:
+          success: Invitation accepted.
+        signin_with: Sign in With
+        title: Accept Invitation
+      resend:
+        alert:
+          text: 'The invitation has not been accepted yet. Click the following button
+            to resend the invitation email:'
+          title: 'Invitation '
+        message:
+          success: Invitation email has been resent.
+      title: Your Invitation to %{app_title}
+    user_management_create_user: Invite User
+  artefact_form_options:
+    draft_purchases_credit_note: Draft Credit Notes do not update your Accounts
+    draft_purchases_invoice: Draft Invoices do not update your Accounts
+    draft_sales_credit_note: Draft Credit Notes do not update your Accounts
+    draft_sales_invoice: Draft and Pro Forma Invoices do not update your Accounts
+    notes_textarea_title: Notes
+    save_as: 'Save as:'
+    save_as_draft: Save as draft
+  artefact_line_item:
+    tax: VAT
+  artefact_template_121:
+    net_amount: Net Amount
+    retailer: RE
+    tax: Tax
+    tax_type: Type of tax
+    total: Total
+  artefact_template_18:
+    address:
+      deliver_to: Delivery Address
+    line_items:
+      amount: Total
+      code: Item Code
+    reference: Reference / PO Number
+    sales_credit_note:
+      address:
+        invoice_to: Main Address
+    sales_estimate:
+      address:
+        invoice_to: Main Address
+    sales_invoice:
+      address:
+        invoice_to: Main Address
+    sales_quote:
+      address:
+        invoice_to: Main Address
+  artefact_template_21:
+    net_amount: Net Amount
+    retailer: RE
+    tax: Tax
+    tax_type: Type of tax
+    total: Total
+  artefact_template_9:
+    address:
+      deliver_to: Delivery Address
+    line_items:
+      amount: Total
+      code: Item Code
+    reference: Reference / PO Number
+    sales_credit_note:
+      address:
+        invoice_to: Main Address
+    sales_estimate:
+      address:
+        invoice_to: Main Address
+    sales_invoice:
+      address:
+        invoice_to: Main Address
+    sales_quote:
+      address:
+        invoice_to: Main Address
+  artefact_templates:
+    account: Account
+    address:
+      deliver_to: Deliver To
+      invoice_to: To
+    amount_due: Amount Due
+    amount_paid: Amount Paid
+    attn: Attn
+    bic: 'BIC:'
+    carriage: Carriage
+    contact_details:
+      email: Email
+      main_name: Name
+      mobile: Mobile
+      telephone: Telephone
+      title: Contact Details
+    corrective_invoice:
+      title: Corrective Invoice
+    customer: Customer
+    customer_reference: Customer Code
+    delivery_note:
+      title: Delivery Note
+    discount: Discount
+    draft:
+      title: Draft Invoice
+    due_date: Due by
+    email: Email
+    exchange_rate: Exchange rate
+    for: For
+    iban: 'IBAN:'
+    line_item_headers:
+      description:
+        label: Description
+        value: Description
+      discount:
+        label: Discount
+        value: Discount
+      quantity:
+        label: Quantity or Hours
+        value: Qty/Hrs
+      unit_price:
+        label: Price or Rate
+        value: Price/Rate
+    line_items:
+      amount: Amount
+      code: Code
+      cost: Cost
+      description: Description
+      discount: Discount
+      item: Item
+      net_amount: Net Amt
+      picked: Picked
+      quantity: Qty/Hrs
+      tax: VAT
+      total: Total
+      unit_price: Price/Rate
+    mobile: Mobile
+    net_amount: Net Amount
+    not_tax_invoice: This is not a VAT Invoice
+    note: Note
+    notes: Notes
+    pro_forma:
+      title: Pro Forma Invoice
+    reference: Reference
+    registration:
+      address: Registered Address
+      country: Registered in
+      number: No.
+      tax_registration_number: VAT Registration Number
+    remittance_advice:
+      title: Remittance Advice
+    retailer_tax_total: Recargo de equivalencia
+    sage_pay:
+      pay_now_button: Pay Now
+      pay_now_multi_currency_text: Pay Now option will take payment of outstanding
+        value in %{base_currency}. Total outstanding for this invoice %{base_outstanding}
+      pay_now_text: <p>We accept online payments. It's a fast, secure and very easy
+        way to pay.<br />Simply click the "Pay Now" button to pay this invoice using
+        your credit or debit card.</p>
+    sales_corrective_invoice:
+      address:
+        invoice_to: Invoice To
+      artefact_number: Corrective Invoice Number
+      date: Invoice Date
+      delivery_date: Date
+      details: Details
+      due_date: Due Date
+      original_date: Original Date
+      original_number: Original Invoice Number
+      reason: Reason for Correction
+      title: Sales Corrective Invoice
+      total: Total
+    sales_credit_note:
+      address:
+        invoice_to: Credit Note To
+      artefact_number: Credit Note Number
+      date: Credit Note Date
+      due_date: Credit Date
+      title: Sales Credit Note
+      total: Total
+    sales_estimate:
+      address:
+        invoice_to: Issued To
+      artefact_number: Number
+      date: Issue Date
+      delivery_date: Date
+      due_date: Expiry Date
+      title: Sales Estimate
+      total: Total
+    sales_invoice:
+      address:
+        invoice_to: Invoice To
+      artefact_number: Invoice Number
+      date: Invoice Date
+      delivery_date: Date
+      delivery_performance_date: Delivery/Performance Date
+      due_date: Due Date
+      title: Sales Invoice
+      total: Total
+    sales_quote:
+      address:
+        invoice_to: Issued To
+      artefact_number: Number
+      date: Issue Date
+      delivery_date: Date
+      due_date: Expiry Date
+      title: Sales Quote
+      total: Total
+    signature:
+      date: Date
+      name: Name
+      received: Received By
+      signed: Signed
+    sort_code: Sort Code
+    statement:
+      title: Statement
+    tax_amount: VAT Amount
+    telephone: Telephone
+    terms_and_conditions: Terms and Conditions
+    vat_number: VAT Number
+    website: Website
+    witholding_tax_rate: IRPF
+    your_tax_number: Your VAT Number
+  artefacts:
+    artefact_due_date:
+      one: Due in 1 day
+      other: Due in %{count} days
+      zero_days: Due today
+    artefact_overdue:
+      css_class: overdue
+      label: Overdue
+      one: 1 day <span class='overdue'>overdue</span>
+      other: "%{count} days <span class='overdue'>overdue</span>"
+    confirm:
+      buttons:
+        continue_editing: Continue Editing
+        dismiss: Don’t show again
+        save: Save
+    feedback: We'd love your feedback
+    show:
+      credit_note_address: Credit Note Address
+      delivery_address: Delivery Address
+      due_date: Due Date
+      header_note: Delivery/Performance Date
+      invoice_address: Invoice Address
+      issued: " - Issued"
+      not_issued: " - Not Issued"
+      pdf_generation: " (Generating PDF...)"
+      quote_address: Address
+      reference: Reference
+      sending_email: " (Sending Email...)"
+      supplier_name: Supplier
+      supplier_reference: Supplier Reference
+  attachments:
+    errors:
+      file_could_not_be_deleted: File could not be deleted
+      file_count_exceeded: Maximum files for business exceeded. Only %{limit} allowed.
+      invalid_file_size: The file is too big. Try uploading a file %{limit} or less.
+      invalid_storage_limit: Maximum file storage limit of %{limit} exceeded.
+      reached_artefact_limit: Maximum of %{limit} files per artefact reached.
+  attributes:
+    address_type_form_proxy_id: Address Type
+    cc: Cc
+    country_id: Country
+    customer_name: Customer Name
+    end_date: To
+    is_main_contact: Main Contact
+    line_1: Address 1
+    line_2: Address 2
+    line_3: Town/City
+    line_4: County
+    main: Main
+    main_address_name: Main Address
+    message: Message
+    name: Address Name
+    new_address_name: New Address
+    new_contact_name: New Contact
+    notes: Notes
+    postcode: Postcode
+    reference: Reference
+    second_address_name: Address 2
+    start_date: From
+    supplier_name: Supplier Name
+    to: To
+    valid_for_period_formatted: Valid for Period?
+  audits:
+    mysageone_core/messages:
+      destroy: "%{authenticated_user} has deleted message '%{entity}'"
+    sop_admin/users:
+      resend_email_verification: Admin resent activation email.
+  bank_account_card:
+    balance: Balance
+    bank_balance: Bank Balance
+    cancel_bank_account_connection: Cancel Connection
+    connect_your_bank: Connect Bank
+    connect_your_bank_hint: A secure bank connection that reduces data entry by up
+      to 80%
+    delete_account: Delete
+    disconnect_bank: Disconnect bank account
+    edit_signin_info: Edit sign in info
+    failed_to_connect: Connection Failed...
+    imported: imported
+    imported_transactions:
+      one: Imported Transaction
+      other: Imported Transactions
+      zero: Import
+    last_refresh: 'Refresh: %{when}'
+    last_transaction: 'Last entry: %{when}'
+    last_transaction_never: 'Last entry: never'
+    manage_account: Manage account
+    move_label: Move
+    new_transactions: new transactions
+    no_transactions_imported: No transactions imported
+    pending_to_connect: Connection Pending...
+    refresh_account: Refresh account
+    stripe_view_dashboard: View Dashboard
+    transactions:
+      one: Transaction
+      other: Transactions
+      zero: No transactions
+  bank_activity:
+    grid_filter:
+      transaction_type:
+        prompt: All
+  bank_feed:
+    connected_with:
+      bankdrive: Sage Bank Feeds
+      bankin: Bankin
+      barclays: Barclays
+      hbci: HBCI
+      message: Connected with %{provider}
+      yodlee: Yodlee
+    errors:
+      bank_reconciliation_already_started: A bank reconciliation is already in progress
+        for this bank account.
+      bank_transfer_creation_failed: Bank transfer creation failed.
+      business_does_not_exist: Business does not exist
+      create_transaction_failed: There was a problem in processing this transaction,
+        please try again.
+      customer_income_payment_creation_failed: Customer payment on account could not
+        be created.
+      customer_receipt_creation_failed: Customer receipt could not be created.
+      customer_refund_creation_failed: Customer refund could not be created.
+      inaccessible_account_type: Inaccessible account type
+      incomes_not_specified: Incomes not specified
+      invalid_transaction_type: Invalid transaction type
+      ledger_entry_clearing_failed: Ledger entry clearing failed.
+      match_transaction_failed: There was a problem in processing this transaction,
+        please try again.
+      other_expense_payment_creation_failed: Other payment creation failed.
+      other_income_payment_creation_failed: Other receipt creation failed.
+      supplier_expense_payment_creation_failed: Supplier payment on account could
+        not be created.
+      supplier_payment_creation_failed: Supplier payment could not be created.
+      supplier_refund_creation_failed: Supplier refund could not be created.
+      tax_return_payment_creation_failed: VAT Payment could not be created.
+    messages:
+      cleared_entries_reconciled: New cleared entries have automatically been marked
+        as reconciled and included in your Reconciled Balance.
+      customer_income_payment_created_successfully: Customer payment on account created
+        successfully.
+      customer_receipt_created_successfully: Customer receipt created successfully.
+      customer_refund_created_successfully: Customer refund created successfully.
+      expense_transaction_created_successfully: Other payment created successfully.
+      income_transaction_created_successfully: Other receipt created successfully.
+      ledger_entries_cleared: Ledger Entries cleared
+      ledger_entry_already_corrected: Transaction could not be matched, please refresh
+        and try again.
+      ledger_entry_cleared: Ledger Entry cleared
+      other_expense_payment_created_successfully: Other payment created successfully.
+      other_income_payment_created_successfully: Other receipt created successfully.
+      supplier_expense_payment_created_successfully: Supplier payment on account created
+        successfully.
+      supplier_payment_created_successfully: Supplier payment created successfully.
+      supplier_refund_created_successfully: Supplier refund created successfully.
+      tax_return_payment_created_successfully: VAT Payment created successfully.
+      transaction_matched_successfully: This transaction has been successfully processed.
+      transfers_in_created_successfully: Bank transfer created successfully.
+      transfers_out_created_successfully: Bank transfer created successfully.
+    unlink:
+      button: Disconnect Bank Account
+  banking_cloud:
+    error_confirm:
+      cancel_button: Cancel Request
+      confirm_button: Close
+      description: Please give your bank a call.
+      description_bank_name: Please contact %{bank_name} for help.
+      questions: Check out
+      questions_link: " sageone.com/support"
+      questions_link_href: http://sageone.com/support
+      questions_title: Any questions?
+      sorry_message: Sorry, we seem to be having some trouble setting up your connection.
+      title: Unable to Connect
+    error_message:
+      cancel_button: Cancel Connection
+      description: Sorry, we seem to be having some trouble setting up the connection
+        with your bank. Please give your bank a call.
+      description_bank_name: Sorry, we seem to be having some trouble setting up the
+        connection with your bank. Please contact %{bank_name} for help.
+      title: Unable to Connect
+    indirect_downloading:
+      message: It can take up to 30 minutes to download transactions from your bank
+        for the first time.
+      title: We're downloading your transactions
+    pending_confirm:
+      cancel_button: Cancel Connection
+      confirm_button: Wait for Successful Connection
+      description_cancel: If you cancel your connection request, you can set up a
+        fresh connection at any time.
+      description_cancel_title: Changed your mind?
+      direct:
+        description: |
+          Remember to follow the instructions from your bank below.
+          %{direct_text}
+        no_direct_text: You'll be able to see your bank data coming through within
+          a couple of days. If it's been longer, contact your bank for help, or try
+          cancelling the connection and setting it up again.
+      form:
+        description: |
+          Remember to download your personalised form, and follow the instructions written on it.
+          Once the connection is activated your bank transactions will be available.
+          You’ll then see your transactions flowing in - job done!
+        download_link: Download the Form
+      questions: Check out
+      questions_link: " sageone.com/support"
+      questions_link_href: http://sageone.com/support
+      questions_title: Any questions?
+      title: Setting up Connection
+      web:
+        description: |
+          Remember to <a class='UILink carbon-link__anchor' href='%{direct_text}' target='_blank'>visit your Bank’s Website</a>,
+          and follow the instructions.
+          <br />Once the connection is activated your bank transactions will be available.
+        no_direct_text: You'll be able to see your bank data coming through within
+          a couple of days. If it's been longer, contact your bank for help, or try
+          cancelling the connection and setting it up again.
+    pending_message:
+      cancel_button: Cancel Connection
+      direct:
+        description_span_1: Remember to follow the instructions from your bank. %{direct_text}
+        no_direct_text: You'll be able to see your bank data coming through within
+          a couple of days. If it's been longer, contact your bank for help, or try
+          cancelling the connection and setting it up again.
+      form:
+        description_span_1: 'Remember to '
+        description_span_2: ", and follow the instructions written on it. Once the
+          connection is activated your bank transactions will be available."
+        download_link: download your personalised form
+      title: Setting up Connection
+      web:
+        description_span_1: |
+          Remember to <a class='UILink carbon-link__anchor' href='%{direct_text}' target='_blank'>visit your Bank’s Website</a>,
+          and follow the instructions. Once the connection is activated your bank transactions will be available.
+        no_direct_text: You'll be able to see your bank data coming through within
+          a couple of days. If it's been longer, contact your bank for help, or try
+          cancelling the connection and setting it up again.
+  bulk_destroy:
+    messages:
+      migrated: You can't delete one or more of the selected items because it was
+        migrated from your old accounting system.
+      payments_allocated:
+        credit_note: One or more of the selected items are paid, part-paid or already
+          voided and cannot be deleted.
+        invoice: One or more of the selected items are paid, part-paid or already
+          voided and cannot be deleted.
+        purchase_artefact: One or more of the selected items are paid, part-paid or
+          already voided and cannot be deleted.
+        sales_artefact: One or more of the selected items are paid, part-paid or already
+          voided and cannot be deleted.
+      tax_reconciled: One or more of the selected items are VAT reconciled and cannot
+        be deleted.
+      warning:
+        credit_note: 'One or more of the selected items is completed and cannot be
+          deleted. In order to keep the sequential numbers for credit notes following
+          HMRC rules they will be voided instead. If you wish to void the selected
+          item(s), enter a reason below:'
+        invoice: 'One or more of the selected items is completed and cannot be deleted.
+          In order to keep the sequential numbers for invoices following HMRC rules
+          they will be voided instead. If you wish to void the selected item(s), enter
+          a reason below:'
+        purchase_artefact: 'One or more of the selected items is completed and cannot
+          be deleted. In order to keep the sequential numbers for invoices or credit
+          notes following HMRC rules they will be voided instead. If you wish to void
+          the selected item(s), enter a reason below:'
+        sales_artefact: 'One or more of the selected items is completed and cannot
+          be deleted. In order to keep the sequential numbers for invoices or credit
+          notes following HMRC rules they will be voided instead. If you wish to void
+          the selected item(s), enter a reason below:'
+      warning_allocated_credit_note: Deleting an allocated credit note will set the
+        associated invoice as unpaid.
+      warning_draft:
+        credit_note: One or more of the selected items has a Draft status. Draft credit
+          notes will be fully deleted and won't be retained after deletion.
+        purchase_artefact: One or more of the selected items has a Draft status. Draft
+          invoices or credit notes will be fully deleted and won't be retained after
+          deletion.
+        purchases_invoice: One or more of the selected items has a Draft status. Draft
+          invoices will be fully deleted and won't be retained after deletion.
+        sales_artefact: One or more of the selected items has a Draft or Pro Forma
+          status. Draft or Pro Forma invoices or credit notes will be fully deleted
+          and won't be retained after deletion.
+        sales_invoice: One or more of the selected items has a Draft or Pro Forma
+          status. Draft or Pro Forma invoices will be fully deleted and won't be retained
+          after deletion.
+      warning_no_access:
+        default: Your access level does not allow you to void invoices or credit notes,
+          please speak to your Supervisor.
+        sales:
+          quote: Your access level does not allow you to delete sales quotes or estimates,
+            please speak to your Supervisor.
+    titles:
+      access_denied: Access Denied
+      migrated:
+        credit_note: Delete Purchase Credit Note
+        invoice: Delete Purchase Invoice
+        purchase_artefact: Delete Purchase Item
+      payments_allocated_or_voided:
+        credit_note: Payments allocated or voided
+        invoice: Payments allocated or voided
+        purchase_artefact: Payments allocated or voided
+        sales_artefact: Payments allocated or voided
+      tax_reconciled: VAT Reconciled
+  bulk_pay_or_allocate:
+    messages:
+      payments_allocated_or_voided:
+        credit_note: One or more of the selected items are already voided, fully allocated
+          or draft.
+        purchase_artefact: One or more of the selected items are already voided, fully
+          allocated or draft.
+        purchases_invoice: One or more of the selected items are already voided, fully
+          allocated or draft.
+        sales_artefact: One or more of the selected items are already voided, fully
+          allocated, draft or pro forma.
+        sales_invoice: One or more of the selected items are already voided, fully
+          allocated, draft or pro forma.
+    titles:
+      more: More
+      pay_or_allocate: Pay or Allocate
+      payments_allocated_or_voided:
+        credit_note: Payments allocated or voided
+        invoice: Payments allocated or voided
+        purchase_artefact: Payments allocated or voided
+        sales_artefact: Payments allocated or voided
+  bulk_remove_cleared:
+    messages:
+      success: Cleared status has been removed for %{number_cleared} transaction(s).
+    titles:
+      more: More
+      remove_cleared_status: Remove Cleared Status
+  bulk_void:
+    messages:
+      migrated: You can't void one or more of the selected items because it was migrated
+        from your old accounting system.
+    titles:
+      migrated:
+        credit_note: Void Sales Credit Note
+        invoice: Void Sales Invoice
+        sales_artefact: Void Sales Item
+  business_membership:
+    formatted: "%{user} of %{business}"
+  business_membership_admin:
+    customer_list:
+      title: Customer List
+  business_type:
+    description:
+      limited: we're registered at Companies House
+      partner: it's me and my business partner(s)
+      sole: I work for myself
+    name:
+      limited: Limited Company/LLP
+      partner: Partnership
+      sole: Sole Trader or Small Business
+  change_password: Change Password
+  checkbox:
+    advanced_uk/product:
+      label: Sales Price Includes VAT
+    advanced_uk/service:
+      label: Rate Includes VAT
+  cheque_printing:
+    cheque_stub:
+      amount_label: 'Cheque Amount:'
+      continue_message: List continues on the next page...
+      date_label: 'Date:'
+      payee_label: 'To:'
+      reference_label: 'Reference:'
+      stub_title: ''
+      stub_title_label: Cheque Payment
+      summary_label: 'Continued:'
+      summary_value: Cheque to %{payee} on %{date}
+      table_headers:
+        amount_paid: Amount Paid
+        amount_refunded: Amount Refunded
+        balance: Remaining Balance
+        credit_amount: Credit Amount
+        credit_date: Credit Date
+        credit_number: Credit Number
+        details: Details
+        discount: Discount Taken
+        invoice_amount: Invoice Amount
+        invoice_date: Invoice Date
+        invoice_number: Invoice Number
+        tax_rate: Tax Rate
+    delete_dialog:
+      content_line1: "- If the cheque was linked to an invoice, the invoice will show
+        as ‘unpaid’ again."
+      content_line2: "- You can re-use the same cheque number for a new payment if
+        you like."
+      content_title: What else happens when I delete a cheque?
+      save: Delete Cheque
+      title: Delete Cheque
+      warning: Are you sure you’d like to permanently delete this cheque, and the
+        transaction it’s linked to?
+    dummy:
+      amount: XXXXXXXXX
+      amount_with_currency: XXXXXXXXXX
+      date: XXXXXXXXX
+      date_format: XXXXXXXXX
+      payee: XXXXXXXXXXXXXXXXXXXXX
+      payee_with_address: XXXXXXXXXXXXXXX<br>XXXXXXXXXXXXXXX<br>XXXXXXXXXXXXXXX<br>XXXXXXXXXXXXXXX
+      text_amount: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+      text_amount_no_currency: XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+    edit_dialog:
+      cancel: Cancel
+      cheque_number: Cheque Number
+      save: Save
+      title: Edit Cheque Number
+    errors:
+      delete_void: Void payments can't be deleted
+    issue_dialog:
+      cheque_number: Cheque Number (optional)
+      enter: If you don’t want to print a cheque, but still want to issue it to a
+        payee, enter your cheque number below (for example, if you write your cheques
+        manually).
+      optional: optional
+      save: Issue Manually
+      title: Issue Cheque Manually
+    number_label: |
+      **Cheque Number**
+      (optional)
+    presenter:
+      address_line3: "%{line_3} %{line_4} %{postcode}<br>"
+      text_amount: "%{amount_dollars} Pounds and %{amount_cents}/100"
+      text_amount_no_currency: "%{whole_amount} and %{rational_amount}/100"
+    print_dialog:
+      cheque_number: Cheque Number
+      enter: When you’ve successfully printed, enter the pre-printed cheque number
+        below.
+      print: Print Cheque
+      print_for: Print your cheque for **%{amount}** to **%{payee}**.
+      save: All Done!
+      title: Print a Cheque
+    register:
+      actions:
+        balance: Bank Balance
+        bank: Bank Account
+        delete:
+          title: Delete
+        issue:
+          title: Issue Manually
+          tooltip: Issue manual cheque
+        paper: Cheque Paper
+        print:
+          title: Print Cheque
+          tooltip: Print cheque
+        settings: Settings
+        void:
+          title: Void
+      alert_delete_one_cheque: Please select only one cheque to delete at a time.
+      alert_delete_voided_cheque: This cheque has already been voided, and cannot
+        be deleted.
+      alert_issue_one_cheque: Please select only one cheque to issue manually.
+      alert_print_one_cheque: Please select only one cheque to print at a time.
+      alert_print_voided_cheque: Voided cheques can’t be printed.
+      alert_void_one_cheque: Please select only one cheque to void at a time.
+      alert_void_saved_cheque: You can only void cheques that have already been printed/issued
+        manually. Please print the cheque or issue the cheque manually, then void
+        it.
+      alert_void_voided_cheque: This cheque has already been voided.
+      delete_cheque_success: The cheque has been deleted successfully.
+      headers:
+        amount: Amount
+        bank: Bank Account
+        date: Trx Date
+        name: Name
+        number: Cheque Number
+        printed: Date Printed/Issued
+        status: Status
+        type: Type
+        voided: Date Voided
+      identical_number_validation_error: The cheque number entered is identical to
+        the saved number.
+      payment_types:
+        customer_refund: Customer Refund
+        other_expense: Other Payment
+        supplier_expense: Bill Payment
+      sage_cheque: Sage Cheque Paper
+      set_cheque_number_success: The cheque number has been successfully updated.
+      status:
+        manual: Issued Manually
+        printed: Printed
+        saved: Saved
+        voided: Voided
+      tabs:
+        all: All Cheques
+        print: Cheques to Print (%{total})
+      void_cheque_success: The cheque has been successfully voided.
+      void_date_validation_error: The void date must be on or after the transaction
+        date %{start_date}.
+    settings:
+      buy:
+        help_content: Checks are printed in the language chosen in each vendor's profile
+          in the Contacts section.
+        help_title: Print in your Vendor's Language
+        hours: Monday - Friday, 8am - 8pm GMT
+        link: https://www.sagechecks.com/estore/Sage+One/All+Versions+-+Sage+One/SL-MP98/prod1620237_prd.p?_requestid=69534
+        phone: Call 1-800-617-3224
+        url: "**Buy Compatible Cheques**"
+      enable:
+        browser: as your web browser to make printing easier.
+        description: We'll show the Cheque Register under the Banking section, and
+          ask if you'd like to print a cheque when you create payments.
+        label: Enable Cheque Printing
+        latest: and using the latest version of
+        recommend: We recommend installing the latest version of
+        title: Enable Cheque Printing
+      external_links:
+        adobe:
+          name: Adobe Reader
+          url: https://get.adobe.com/reader/
+        chrome:
+          name: Google Chrome
+          url: https://www.google.com/chrome/browser/desktop/
+      setup:
+        button: Print Setup
+        description: Run a test print to help line your printer up perfectly with
+          your cheque paper.
+        title: Print Setup
+      template:
+        description: Select the type of cheque stock you purchased, so we know exactly
+          where to print the details.
+        description_1: We'll print your cheques to line up exactly with this cheque
+          stock.
+        labels:
+          :1: "**Sage Cheque Paper**  \n(SLMP98)"
+          :2: QuickBooks Voucher
+        title: Choose your Cheque Paper
+        title_1: Cheque Paper
+    setup_dialog:
+      adjust:
+        left:
+          minus: Further left
+          plus: Further right
+        line_up: To line up, the printed numbers need to be...
+        measure: Using the square grid printed on **Test Cheque 1**, measure the distance
+          between where the printed numbers are now, and their correct location on
+          the pre-printed cheque paper.
+        squares: squares
+        top:
+          minus: Higher up
+          plus: Lower down
+      adjust_help:
+        read: Read about
+        title: Need some help?
+        topic: aligning your printer for cheque printing.
+      all_done: All Done!
+      back: Back
+      confirm:
+        done:
+          long: the numbers are now in the right place.
+          long_1: the numbers are in the right place.
+          short: 'Yes'
+        hold_up: Place **Test Cheque %{number}** on top of a sheet of pre-printed
+          cheque paper, and hold them up to the light.
+        line_up: Do the printed numbers line up with your cheque paper now?
+        line_up_1: Do the printed numbers line up with your cheque paper?
+        more:
+          long: I'll try again, measuring from **Test Cheque 1**.
+          long_1: I need to adjust where the numbers are printed.
+          short: 'No'
+      continue: Continue
+      done:
+        choose: Select **Cheques to Print** on the **Cheque Register**.
+        ready: You’re now ready to print cheques!
+      intro:
+        browser: as your web browser.
+        install: Install the latest version of
+        read_more: Read more
+        scaling: Make sure your system doesn't add margins or adjust scaling when
+          you print, for example, in Google Chrome, make sure 'Fit to page' is not
+          checked.
+        set_up: To set up your printer, print **Test Cheque 1** on a sheet of blank
+          Letter sized paper.
+        to_print: To print cheques directly on pre-printed cheque paper...
+        use: and use
+      print: Print Test Cheque %{number}
+      reprint:
+        make_sure: To make sure your adjustments worked, print **Test Cheque %{number}**.
+      test_cheque: Test Cheque
+      title: Cheque Printing Setup
+    test_cheque:
+      amount: 218615.37
+      instructions:
+        continue: Try again, measuring from <strong>Test Cheque 1</strong>.
+        continue_1: Using the square grid above, measure the distance between where
+          the printed numbers are now, and their correct location on the pre-printed
+          cheque paper. Enter your adjustments as required.
+        done: 'Yes'
+        main: Place this page on top of a sheet of pre-printed cheque paper, and hold
+          them up to the light.
+        more: 'No'
+        prompt: Do the printed numbers line up with your cheque paper now?
+        prompt_1: Do the printed numbers line up with your cheque paper?
+        ready: You're ready to print cheques!
+        title: Verify your Adjustments
+        title_1: Measure for Alignment
+      payee: VOID Payee VOID
+      payee_with_address: VOID Payee VOID<br>1001 Test Drive<br>Suite 111<br>Atlanta
+        GA 30363<br>United States
+      text_amount: Two Hundred Eighteen Thousand Six Hundred Fifteen Dollars and 37/100
+      text_amount_no_currency: Two Hundred Eighteen Thousand Six Hundred Fifteen and
+        37/100
+      title: Test Cheque
+    transaction_dialog:
+      create: How would you like to create your cheque?
+      message_content: To print from Accounting, remember to choose a supplier. Or,
+        continue without a supplier and write your cheque.
+      message_title: Want to print your cheque?
+      method: You chose 'Cheque' as the payment method for this transaction.
+      radio:
+        later: "**I'll print this cheque later** - I'll go to the Cheque Register
+          in Banking when I'm ready."
+        manual: "**I'll write out a cheque manually** - and enter a cheque number."
+        now: "**I'll print this cheque right now** - take me to the Cheque Register."
+      save_text: Confirm
+      title: Pay by Cheque
+    transaction_fields:
+      optional: " (optional)"
+      vendor: Vendor
+    unable_delete_dialog:
+      line1: This cheque can’t be deleted because the payment has been reconciled.
+      line2: You could enter another transaction to compensate for this cheque’s value
+        if you need to.
+      save: Got it!
+      title: Unable to delete cheque
+    unable_void_dialog:
+      line1: This cheque can’t be voided because the payment has been reconciled.
+      line2: You could enter another transaction to compensate for this cheque’s value
+        if you need to.
+      save: Got it!
+      title: Unable to void cheque
+    void_dialog:
+      content_line1: "- It will still be listed in the Cheque Register, but marked
+        as voided."
+      content_line2: "- We’ll reverse the original transaction - this will show up
+        in your Audit Trail report."
+      content_line3: "- If you still want to make the payment, you can enter a new
+        one."
+      content_title: What happens when I permanently void a cheque?
+      date_label: Date Cheque Voided
+      enter: If you printed a cheque but you don’t want to issue it to a payee, you
+        can permanently void it.
+      link_text: Read more about this
+      message: This cheque was created in a previous month, but voiding the cheque
+        will affect your reports on the date entered here. To avoid this, change the
+        date to the same month that the cheque was created.
+      message_title: Voiding cheques across financial periods
+      save: Void Cheque
+      title: Void Cheque
+  coa:
+    exclude: Exclude
+    include: Include
+  confirm:
+    buttons:
+      include_future_vat_return: Include on Future VAT Return
+      keep_prices: Keep Current Prices
+      replace: Replace
+      transfer: Transfer
+      update_prices: Update Prices
+    messages:
+      advanced_uk/catalog_item:
+        bulk_destroy:
+          error: The selected items could not be deleted as one or more of them are
+            in use
+          one: Are you sure you wish to delete this Product or Service?
+          other: Are you sure you wish to delete these Product and Services?
+        convert:
+          allow: allow
+          cancel: Cancel
+          change_type: Change type
+          confirm:
+            one: Convert Item
+            other: Convert %{no_of_items} Items
+          info: Converting items to %{item_type} will %{allow} you to track quantities
+            in and out.
+          not_allow: not allow
+          one: Are you sure you want to change this item to %{item_type}?
+          other: Are you sure you want to convert %{no_of_items} items to %{item_type}?
+          success:
+            one: Item successfully converted to %{item_type}!
+            other: "%{no_of_items} items successfully converted to %{item_type}!"
+        delete:
+          error: We were unable to delete this Item
+          question: Are you sure you wish to delete this Item?
+          success: Item has been deleted
+        type:
+          non-stock: Non-stock
+          stock: Stock
+        update:
+          error: We were unable to update this Item
+          success: Item updated successfully
+      advanced_uk/category:
+        bulk_destroy:
+          one: |-
+            Are you sure you want to delete this category?
+
+            Deleting this category will remove the category from any products and services associated with it.
+          other: |-
+            Are you sure you want to delete these categories?
+
+            Deleting these categories will remove the category from any products and services associated with them.
+      advanced_uk/transactions:
+        include_transaction_on:
+          future_vat_return: The next time you run a VAT return, we’ll remind you
+            about this transaction. <br><strong>Are you sure you’d like to continue?</strong>
+      copy_clashing_note_confirmation_for_estimate: Do you want to transfer the Notes
+        from this Estimate to the Sales Invoice, or replace them with the Default
+        Notes?
+      copy_clashing_note_confirmation_for_quote: Do you want to transfer the Notes
+        from this Quote to the Sales Invoice, or replace them with the Default Notes?
+      copy_note_confirmation_for_estimate: Do you want to transfer the Notes from
+        this Estimate to the Sales Invoice?
+      copy_note_confirmation_for_quote: Do you want to transfer the Notes from this
+        Quote to the Sales Invoice?
+      default_prices: The default product price for %{customer} is <strong>%{price_name}</strong>.
+        Do you want to update this invoice to use %{customer}'s default product prices,
+        or keep the prices currently listed?
+      fuji_banking/bank_activity:
+        bulk_destroy:
+          one: Are you sure you wish to delete this Bank Activity?
+          other: Are you sure you wish to delete these Bank Activities?
+      fuji_contacts/contact:
+        bulk_destroy:
+          one: Are you sure you wish to delete this Contact?
+          other: Are you sure you wish to delete these Contacts?
+      fuji_contacts/customer:
+        bulk_destroy:
+          one: Are you sure you wish to delete this Customer?
+          other: Are you sure you wish to delete these Customers?
+      fuji_contacts/supplier:
+        bulk_destroy:
+          one: Are you sure you wish to delete this %{model}?
+          other: Are you sure you wish to delete these %{model}?
+      fuji_invoicing/sales_quote:
+        bulk_destroy:
+          one: Are you sure you wish to delete this Quote or Estimate?
+          other: Are you sure you wish to delete these Quotes or Estimates?
+      include_future_vat_return:
+        success: Transaction updated successfully
+      inventory/models/stock_movement:
+        bulk_destroy:
+          adj_in: Your quantity in stock and average cost price will be updated.
+          adj_out: Your quantity in stock will be updated.
+          error_lockdown_date:
+            one: You can't delete this Adjustment as the date must be later than the
+              year-end lock date of %{date}. <a href="%{help_url}/find_by_tag?language=%{help_language}&locale=%{help_locale}&service=accounts_extra&tag=extra_financial_year_end"
+              target="_">Change the year-end lock down date</a> and try again.
+            other: You can't delete one or more Adjustments as the date must be later
+              than the year-end lock date of %{date}. <a href="%{help_url}/find_by_tag?language=%{help_language}&locale=%{help_locale}&service=accounts_extra&tag=extra_financial_year_end"
+              target="_">Change the year-end lock down date</a> and try again.
+          error_negative_stock:
+            one: You can't delete this Adjustment as it would result in negative stock.
+            other: You can't delete one or more Adjustments as it would result in
+              negative stock.
+          error_non_adjustments:
+            one: You can't delete this item, only Adjustments can be deleted.
+            other: You can't delete one or more items, only Adjustments can be deleted.
+          error_stock_item_inactive:
+            one: You can't delete this item as your stock item is inactive.
+            other: You can't delete one or more items as your stock item is inactive.
+          one: Are you sure you wish to delete this Adjustment?
+          other: Are you sure you wish to delete these Adjustments?
+        delete:
+          error: We were unable to delete this Adjustment.
+          error_non_adjustments: The selected item could not be deleted, only Adjustments
+            can be deleted.
+          question:
+            adj_in: |-
+              Are you sure you want to delete this Adjustment?
+
+              Your quantity in stock and average cost price will be updated.
+            adj_out: |-
+              Are you sure you want to delete this Adjustment?
+
+              Your quantity in stock will be updated.
+          success: Adjustment has been deleted!
+      multi_currency:
+        convert: Convert
+        convert_values: Would you like us to convert all your entered values into
+          the currency for the contact or leave them as entered?
+        keep_current: Keep Current Rate
+        leave: Leave
+        use_latest: Use Latest Rate
+        use_new_rate: The latest exchange rate for this contacts currency does not
+          match your current entered rate, would you like to use the latest value
+          or keep the current one?
+    titles:
+      advanced_uk/catalog_item:
+        bulk_destroy:
+          one: Delete?
+          other: Delete?
+        convert: Change to %{item_type}
+        delete: Delete?
+      advanced_uk/category:
+        bulk_destroy:
+          one: Delete Category?
+          other: Delete Categories?
+      advanced_uk/transactions:
+        include_transaction_on:
+          future_vat_return: Include Transaction on Future VAT Return
+      copy_clashing_note_confirmation_for_estimate: Create Sales Invoice from Estimate
+      copy_clashing_note_confirmation_for_quote: Create Sales Invoice from Quote
+      copy_note_confirmation_for_estimate: Create Sales Invoice from Estimate
+      copy_note_confirmation_for_quote: Create Sales Invoice from Quote
+      default_prices: Update Invoice Prices?
+      fuji_banking/bank_activity:
+        bulk_destroy:
+          one: Delete Bank Activity?
+          other: Delete Bank Activities?
+      fuji_contacts/contact:
+        bulk_destroy:
+          one: Delete Contact?
+          other: Delete Contacts?
+      fuji_contacts/customer:
+        bulk_destroy:
+          one: Delete Customer?
+          other: Delete Customers?
+      fuji_contacts/supplier:
+        bulk_destroy:
+          one: Delete %{model}?
+          other: Delete %{model}?
+      fuji_invoicing/sales_quote:
+        bulk_destroy:
+          one: Delete Quote/Estimate?
+          other: Delete Quotes/Estimates?
+      inventory/models/stock_movement:
+        bulk_destroy:
+          one: Delete Adjustment?
+          other: Delete Adjustments?
+        delete:
+          adj_in: Delete Adjustment In?
+          adj_out: Delete Adjustment Out?
+      please_select: Please select
+  confirm_dialogs:
+    duplicate_artefacts:
+      cancel: Review
+      message_for_purchase: One or more of these entries have the same date, reference
+        and supplier as previously entered transactions. Click Save Anyway to continue,
+        or Review to check the entries.
+      message_for_sales: One or more of these entries have the same date, reference
+        and customer as previously entered transactions. Click Save Anyway to continue,
+        or Review to check the entries.
+      ok: Save Anyway
+      title: Warning
+  contact_activity:
+    contacts:
+      bank_details:
+        aba_routing: ABA/Routing Number
+        account_no: Account Number
+        account_no_validation: Account number must be between 5 and 12 digits
+        bic: BIC/SWIFT
+        institution_no: Institution Number
+        institution_no_validation: Institution number must be 3 digits
+        transit_no: Bank Transit Number
+        transit_no_validation: Transit number must be 5 digits
+        withholding_tax_rate: Default IRPF Rate
+      dialog:
+        account_default: Account Default
+        address_1: Delivery Address
+        address_2: Invoice Address
+        address_one: Address 1
+        aux_reference:
+          customer: Debtor Number
+          supplier: Creditor Number
+        auxiliary_account: Account code
+        bank_details: BANK DETAILS
+        business_name: Business Name
+        business_no: Business Number
+        city: City
+        contact_name: Contact Name
+        contact_type:
+          customer: customer
+          supplier: supplier
+        country_group:
+          display_name:
+            ALL: Other
+            CA: Canada
+            EU: Europe
+            GBIE: UK & Ireland
+            US: US
+        country_select: Select a country
+        county: County
+        day:
+          one: day
+          other: days
+        default_contact_name: Main Contact
+        default_price: Price Default
+        defaults: Defaults
+        delivery_address_same_as_main: Same as Invoice address
+        fixed_assets: |-
+          I buy fixed assets
+           from this supplier
+        fixed_assets_help: If you'll buy items for your business that you'll keep
+          for more than a financial year, check this option.
+        invoice_details_tab: Account Details
+        invoice_tab: Invoice Details
+        language: Language
+        ledger_accounts:
+          no_accounts_found: No ledger accounts found. Please check your Chart of
+            Accounts.
+        notes: Notes
+        payment_tab: Payment Details
+        payment_terms: PAYMENT TERMS
+        postal_code: Postal Code
+        postcode: Postcode
+        province: Province
+        province_select: Select a province
+        province_state: Province / State
+        recargo_checkbox_label: Invoice with Equivalence Surcharge
+        reference: Reference
+        set_credit_limit: Set Credit Limit (%{currency_symbol})
+        set_credit_terms: Set Credit Terms
+        state: State
+        state_select: Select a state
+        tax_calculation:
+          single_choice:
+            title: Invoice with Equivalence Surcharge
+        tax_rate_id: Tax Rate
+        taxable_help: Sole trader or small businesses are usually not taxable.
+        title: Create a new %{type}
+        town_city: Town / City
+        update_contact_record: Update Contact Record
+        vat_warning:
+          button:
+            cancel: Continue Editing Address
+            save: Save Changes
+          client_type:
+            customers: customer
+            suppliers: supplier
+          message: To make sure VAT is calculated correctly, after saving your changes,
+            enter a new VAT Number in the Options tab.
+          title: Enter a New VAT Number
+          warning: This %{client_type} currently has a VAT Number for %{old_country},
+            but you’re changing their main address to be in %{new_country}.
+        zipcode: ZIP Code
+      placeholders:
+        business_name: Company or Person
+        notes: Any additional information about this contact that you would like to
+          store.
+        reference: e.g. Account Number
+        registered_number: e.g. 12/345/67890
+        terms_and_conditions: Terms & Conditions
+    customer:
+      placeholders:
+        aux_reference: '10000'
+    grid_filter:
+      currency: Currency
+      outstanding: Show Outstanding Only
+      type:
+        show_all: All
+    supplier:
+      placeholders:
+        aux_reference: '70000'
+  contacts:
+    dialog:
+      address: Address
+      address_0: Main Address
+      address_1: Delivery Address
+      addresses: Addresses
+      contact_details: Contact Details
+      contacts: Contacts
+      defaults: Defaults
+      defaults_info: 'When I create a new invoice or credit note for this contact:'
+      notes: Notes
+      tax_calculation:
+        multiple_choice:
+          options:
+            cash: Payments
+            invoice: Invoice
+          title: VAT is calculated on
+    payment_terms:
+      days_credit: days credit
+    show:
+      add_client_notes: Add notes
+      address: Address
+      address_0: Main Address
+      address_1: Delivery Address
+      addresses: Addresses
+      contact_details: Contact Details
+      contacts: Contacts
+      defaults: Defaults
+      main_address_with_no_contacts: Add a new contact to make this your main address.
+      notes: Notes
+      set_main_address: Set main address
+      set_main_contact: Set main contact
+  core_accounting:
+    taxes:
+      decimal_places: '2'
+      default:
+        de_lower_name: Lower Rate
+        de_no_tax_name: No Tax
+        de_standard_name: Standard
+        de_zero_name: Zero Rated
+        es_exempt_name: Exempt
+        es_lower_1_name: Lower 1
+        es_lower_1_re_name: Lower 1 RE
+        es_lower_2_name: Lower 2
+        es_lower_2_re_name: Lower 2 RE
+        es_no_tax_name: No VAT
+        es_standard_name: Standard
+        es_standard_re_name: Standard RE
+        exempt_name: Exempt
+        fr_dom_exempt_name: DOM Exempt
+        fr_dom_lower_1_name: DOM
+        fr_dom_lower_2_name: DOM
+        fr_exempt_name: Exempt
+        fr_lower_1_name: Rate
+        fr_lower_2_name: Rate
+        fr_lower_3_name: Rate
+        fr_lower_4_name: Rate
+        fr_no_tax_name: No Tax
+        fr_standard_name: Rate
+        lower_name: Lower Rate
+        no_tax_name: No VAT
+        standard_name: Standard
+        zero_name: Zero Rated
+      short:
+        de_lower_name: Lower
+        de_no_tax_name: No Tax
+        de_standard_name: Standard
+        de_zero_name: Zero
+        es_exempt_name: Exempt
+        es_lower_1_name: Lower 1
+        es_lower_1_re_name: RE
+        es_lower_2_name: Lower 2
+        es_lower_2_re_name: RE
+        es_no_tax_name: No VAT
+        es_standard_name: Standard
+        es_standard_re_name: RE
+        exempt_name: Exempt
+        fr_dom_exempt_name: DOM Exempt
+        fr_dom_lower_1_name: DOM
+        fr_dom_lower_2_name: DOM
+        fr_exempt_name: Exempt
+        fr_lower_1_name: Rate
+        fr_lower_2_name: Rate
+        fr_lower_3_name: Rate
+        fr_lower_4_name: Rate
+        fr_no_tax_name: No Tax
+        fr_standard_name: Rate
+        lower_name: Lower
+        no_tax_name: No VAT
+        standard_name: Standard
+        zero_name: Zero
+      tax_rate_for: 'Tax rate for:'
+      tax_with_percentage: "%{tax_name} %{tax_percentage}%"
+  correction:
+    reference: Correction of %{reference}
+    void_reference: "%{reference}V"
+  corrective_invoices:
+    details: Details
+    help:
+      details: Explain the correction
+      reason: Select a reason
+    original_date: Original Date
+    reason: Reason for Correction
+  corrective_reason_codes:
+    administrative_judgement: Administrative judgement
+    discount_rebate: Discounts or rebates
+    fees_charged: Fees charged
+    fees_withheld: Fees withheld
+    invoice_date: Invoice date
+    invoice_number: Invoice number
+    invoice_prefix: Invoice prefix
+    invoice_type: Invoice type
+    issue_date: Issue date
+    issuer_address: Issuer address
+    issuer_name: Issuer name
+    issuer_tax_id: Issuer tax ID
+    legal_terms: Legal terms
+    packages_returned: Packages returned
+    receiver_address: Receiver address
+    receiver_name: Recipient name
+    receiver_tax_id: Recipient tax ID
+    statement_details: Statement details
+    tax_percentage: Tax percentage
+    tax_rate: Tax rate
+    taxable_amount: Taxable amount
+    unpaid_fees: Unpaid fees
+  counties_gb:
+    aberdeenshire: Aberdeenshire
+    angus: Angus
+    argyll: Argyll
+    avon: Avon
+    ayrshire: Ayrshire
+    banffshire: Banffshire
+    bedfordshire: Bedfordshire
+    berkshire: Berkshire
+    berwickshire: Berwickshire
+    buckinghamshire: Buckinghamshire
+    caithness: Caithness
+    cambridgeshire: Cambridgeshire
+    cheshire: Cheshire
+    clackmannanshire: Clackmannanshire
+    cleveland: Cleveland
+    clwyd: Clwyd
+    cornwall: Cornwall
+    county_antrim: County Antrim
+    county_armagh: County Armagh
+    county_down: County Down
+    county_durham: County Durham
+    county_fermanagh: County Fermanagh
+    county_londonderry: County Londonderry
+    county_tyrone: County Tyrone
+    cumbria: Cumbria
+    derbyshire: Derbyshire
+    devon: Devon
+    dorset: Dorset
+    dumfriesshire: Dumfriesshire
+    dunbartonshire: Dunbartonshire
+    dyfed: Dyfed
+    east_lothian: East Lothian
+    east_sussex: East Sussex
+    essex: Essex
+    fife: Fife
+    gloucestershire: Gloucestershire
+    gwent: Gwent
+    gwynedd: Gwynedd
+    hampshire: Hampshire
+    herefordshire: Herefordshire
+    hertfordshire: Hertfordshire
+    inverness-shire: Inverness-Shire
+    isle_of_lewis: Isle of Lewis
+    isle_of_skye: Isle of Skye
+    isle_of_wight: Isle of Wight
+    kent: Kent
+    kincardineshire: Kincardineshire
+    kirkcudbrightshire: Kirkcudbrightshire
+    lanarkshire: Lanarkshire
+    lancashire: Lancashire
+    leicestershire: Leicestershire
+    lincolnshire: Lincolnshire
+    london: London
+    merseyside: Merseyside
+    mid_glamorgan: Mid Glamorgan
+    middlesex: Middlesex
+    midlothian: Midlothian
+    morayshire: Morayshire
+    norfolk: Norfolk
+    north_humberside: North Humberside
+    north_yorkshire: North Yorkshire
+    northamptonshire: Northamptonshire
+    northumberland: Northumberland
+    nottinghamshire: Nottinghamshire
+    orkney: Orkney
+    oxfordshire: Oxfordshire
+    peeblesshire: Peeblesshire
+    perthshire: Perthshire
+    powys: Powys
+    renfrewshire: Renfrewshire
+    rosssShire: Ross-Shire
+    roxburghshire: Roxburghshire
+    rutland: Rutland
+    selkirkshire: Selkirkshire
+    shropshire: Shropshire
+    somerset: Somerset
+    south_glamorgan: South Glamorgan
+    south_humberside: South Humberside
+    south_yorkshire: South Yorkshire
+    staffordshire: Staffordshire
+    stirlingshire: Stirlingshire
+    suffolk: Suffolk
+    surrey: Surrey
+    sutherland: Sutherland
+    tyne_and_wear: Tyne and Wear
+    warwickshire: Warwickshire
+    west_glamorgan: West Glamorgan
+    west_lothian: West Lothian
+    west_midlands: West Midlands
+    west_sussex: West Sussex
+    west_yorkshire: West Yorkshire
+    wigtownshire: Wigtownshire
+    wiltshire: Wiltshire
+    worcestershire: Worcestershire
+  counties_ie:
+    carlow: Carlow
+    cavan: Cavan
+    clare: Clare
+    cork: Cork
+    donegal: Donegal
+    dublin: Dublin
+    galway: Galway
+    kerry: Kerry
+    kildare: Kildare
+    kilkenny: Kilkenny
+    laois: Laois
+    leitrim: Leitrim
+    limerick: Limerick
+    longford: Longford
+    louth: Louth
+    mayo: Mayo
+    meath: Meath
+    monaghan: Monaghan
+    offaly: Offaly
+    roscommon: Roscommon
+    sligo: Sligo
+    tipperary: Tipperary
+    waterford: Waterford
+    westmeath: Westmeath
+    wexford: Wexford
+    wicklow: Wicklow
+  credit_notes_general:
+    credit_note_already_issued:
+      message_text: If you make any changes, make sure you inform your customer and
+        provide an updated copy.
+      message_title: Credit note already issued
+    eu_no_vat:
+      supplier:
+        message_title: This supplier has an address in the EU, but their VAT number
+          hasn't been entered.
+        show_message_text: This supplier has an address in the EU, but their VAT number
+          hasn't been entered.
+    eu_tax_registration:
+      customer:
+        message_text: The credit note address has been fixed and the VAT Rate has
+          been set to zero (0). Please review the EU Goods/Services and EC Sales Descriptions.
+        message_title: This customer is registered for tax in the EU.
+        show_message_text: This customer is registered for tax in the EU.
+      supplier:
+        message_text: This credit note will be treated as an EC Purchase and VAT will
+          be charged under the Reverse Charge mechanism. Please review the EU Goods/Services
+          and EC Sales Descriptions.
+        message_title: This supplier is registered for VAT in the EU.
+        show_message_text: This supplier is registered for VAT in the EU.
+    row:
+      customer:
+        message_text: The credit note address has been fixed and the VAT Rate has
+          been set to zero (0).
+        message_title: This customer is outside the EU.
+        show_message_text: This customer is outside the EU.
+      supplier:
+        message_text: This credit note will be charged under the Reverse Charge mechanism.
+        message_title: This supplier is outside the EU.
+        show_message_text: This supplier is outside the EU.
+  currency_symbols:
+    cad: "$"
+    eur: "€"
+    gbp: "£"
+    usd: "$"
+  data_management:
+    description: Reset or restore your data.
+    reset_data:
+      action: Reset my Data
+      confirm_action: Reset Data
+      confirm_consequence: All your data will be reset and you'll need to start afresh.
+      confirm_email: 'Please enter your email address to confirm this:'
+      confirm_title: Reset Data
+      description: Reset all your __%{service}__ data for __%{business}__, and start
+        afresh.
+      success: Data Reset has completed.
+      title: Reset Data
+    restore_data:
+      action: Restore my Data
+      can_restore_message: |-
+        You can restore your data as it was on %{date}.
+        You'll lose any data since this time, and this can't be undone.
+      cant_restore_message: You have no previously deleted data to restore.
+      confirm_action: Restore Data
+      confirm_consequence: |-
+        You can restore your data as it was on %{date}.
+        You'll lose any data since this time, and this can't be undone.
+      confirm_email: 'Please enter your email address to confirm this:'
+      confirm_title: Restore Data
+      description: If you've previously deleted your data, you can restore it.
+      success: Data Restore has completed.
+      success_message: You have restored your data as it was on %{date}.
+      title: Restore Data
+    title: Data Management
+  date:
+    formats:
+      default_2_year: "%d/%m/%y"
+      journals_long: "%d %b %Y"
+      short_da_mo_long_yr: "%d %b %Y"
+      short_with_year: "%d %b %y"
+      tax_return: "%d/%m/%y"
+    time_ago: "%{time} ago"
+  datetime:
+    date_words:
+      x_years:
+        one: 1 year
+        other: "%{count} years"
+    distance_in_words:
+      about_x_hours:
+        one: 1 hour
+        other: "%{count} hours"
+      about_x_years:
+        one: 1 year
+        other: "%{count} years"
+  default:
+    advanced_uk/address_contact:
+      add_contact: Add Address Contact
+      default_contact_name: Contact
+      main_contact_name: Main Contact
+      new_contact_name: New Contact
+  default_accounts:
+    cash_in_hand:
+      account_name: Cash
+      ledger_name: Cash in Hand
+    current:
+      account_name: Bank Account
+      ledger_name: Cash at Bank
+  defaults:
+    advanced_uk/analysis_type:
+      group:
+        type_1:
+          name: Customer Group
+        type_2:
+          name: Supplier Group
+        type_3:
+          name: Product Group
+      transaction:
+        type_1:
+          name: Department
+        type_2:
+          name: Cost Centre
+        type_3:
+          name: Project
+    advanced_uk/ec_sales_description:
+      exempt: This supply is exempt from VAT
+      names:
+        exempt: Exempt
+        outside_scope_of_vat: Outside Scope of VAT
+        standard: Standard/Lower
+        zero: Zero
+      outside_scope_of_vat: This supply is outside the scope of VAT
+      standard: This supply is an intra-community supply
+      zero: This is a Zero rated EC Supply
+    advanced_uk/journal_opening_balance:
+      description: Opening Balance
+      details: "(Opening Balance)"
+    advanced_uk/sage_pay/request_form:
+      billing_address_1: "[Add Address Line 1]"
+      billing_city: "[Add City]"
+      billing_firstnames: "[Add Firstnames]"
+      billing_post_code: Add
+      billing_surname: "[Add Surname]"
+      delivery_address_1: "[Add Address Line 1]"
+      delivery_city: "[Add City]"
+      delivery_firstnames: "[Add Firstnames]"
+      delivery_post_code: Add
+      delivery_surname: "[Add Surname]"
+      description:
+        moto: MOTO payment for sales invoice %{artefact_number_formatted}
+        pay_now: Pay Invoice
+        payment_moto: MOTO payment for existing Payment
+    advanced_uk/transaction_types:
+      customer_opening_balance: Customer Opening Balance
+      supplier_opening_balance: Supplier Opening Balance
+    core_accounting/taxes:
+      exempt_tax_name: Non-taxable
+      no_tax_name: Without tax
+    fuji_core_accounting/financial_settings:
+      tax_contacts:
+        customer:
+          name: HMRC Reclaimed
+          reference: HMRC Rec
+        supplier:
+          name: HMRC Payments
+          reference: HMRC Pay
+  demo:
+    preparing_account: Preparing your new account...
+  deposits:
+    cheques:
+      select_dialog_title: Select Cheques
+      view_dialog_title: View Cheques
+  dialog:
+    account_start_date:
+      enter_balances: You'll only be able to enter opening balances before this date.
+      on_or_before: 'Since you''ve already entered some transactions, it should be
+        on or before '
+      record_start_date: Before you enter your opening balances, we need to know your
+        Accounts Start Date.
+      start_date_info: Accounts Start Date
+      transactions: Choose the earliest date you'll be entering transactions.
+      which_date: Which date should I choose?
+    advanced_uk/journal_code:
+      titles:
+        edit: Edit Journal Code
+        new: Create Journal Code
+    other_payments:
+      buttons:
+        continue_editing: Continue Editing
+        save: Save
+      message: HMRC provide **[guidance on when to use a Zero-rated or Exempt VAT
+        status](https://www.gov.uk/guidance/rates-of-vat-on-different-goods-and-services)**.
+      title: "'No VAT' status"
+      warning_message: You’ve selected ‘No VAT’ status on this payment. If you’re
+        unsure, you might want to consult your accountant for advice.
+    other_receipts:
+      buttons:
+        continue_editing: Continue Editing
+        save: Save
+      message: |
+        Do not use 'No VAT' status for **customers who are not VAT registered**. Although these customers can't reclaim VAT they should always be charged any applicable VAT.
+
+        HMRC provide **[guidance on when to use a Zero-rated or Exempt VAT status](https://www.gov.uk/guidance/rates-of-vat-on-different-goods-and-services)**.
+      title: "'No VAT' status"
+      warning_message: You've selected 'No VAT' status on this receipt. This applies
+        in special circumstances. You might want to consult your accountant for advice.
+    tax_number:
+      description: To do business in other EU countries, you must enter your USt-ID
+        number. We can then apply the right tax rates on your invoice, and prepare
+        your VAT return for you.
+      description_hint: If you've lost or need to apply for a USt-ID, contact the
+        Federal Central Tax Office.
+      note:
+        description: Please <a target='_blank' href='%{help_site_url}'>contact us</a>
+          so we can send you the right invoice each month, as a VAT registered business.
+        title: Your invoice
+      save: Save
+      title: Missing Vat-Number
+    titles:
+      import: Import %{plural_name}
+  direct_payment:
+    form_fields:
+      amount:
+        label: Amount
+      bank_account:
+        label: Bank Account
+        placeholder: Choose Your Bank Account
+      bic:
+        label: BIC
+      iban:
+        label: IBAN
+      pin:
+        label: PIN
+      receiver:
+        label: Receiver
+      receiver_bank:
+        label: Receiver Bank
+      tan_confirmation:
+        label: TAN
+      tan_medium:
+        label: TAN Medium
+        placeholder: Please choose a TAN medium
+      tan_system:
+        label: TAN System
+        placeholder: Please choose a TAN system
+      usage:
+        label: Usage
+    hints:
+      payment_data: Please fill in the complete payment data. If you want to pay the
+        invoice of a supplier, you can automatically import the invoice data into
+        this payment via the function Automatically Choose Invoice.
+      tan_confirmation: Please check the payment information below and enter the TAN
+        to authorize the payment. If all information are valid press "Submit Payment"
+        to perform the payment.
+      tan_medium: There are multiple TAN Media configured for this bank account. Please
+        choose your preferred TAN Medium for the chosen TAN System.
+      tan_system: Multiple TAN systems are available for this bank account. Please
+        choose the preferred TAN system.
+    messages:
+      created_payment_on_account: The invoice was marked as paid. An additional payment
+        on account was created because the payment amount was greater than the outstanding
+        amount of the invoice.
+      no_bank_accounts: Connect an HBCI supported bank account to use direct payment.
+      no_general_direct_payment: Direct payments are only possible from within outstanding
+        purchase invoices.
+      unsupported_bank_account: The selected bank account does not support direct
+        payment (missing HBCI support).
+    steps:
+      bank_login: Bank Login
+      payment_data: Payment Data
+      summary: Summary
+      tan_confirmation: TAN Confirmation
+      tan_medium: TAN Medium
+      tan_system: TAN System
+    submit: Submit Payment
+    summary:
+      back_to_invoice: Back to Invoice
+      overpaid_title: Invoice Overpaid
+      success_message: Payed at %{payment_time} with TAN %{tan}.
+      successful: The payment has been sent successfully.
+    tan_confirmation:
+      amount: Amount
+      from_bank_label: From
+      to_bank_label: To
+  dropdown:
+    advanced_uk/product_service:
+      prompt: Please Select
+    advanced_uk/state:
+      outside_country: Outside of %{country}
+  email:
+    fuji_invoicing/sales_corrective_invoice:
+      pdf_filename: Corrective invoice %{business_name} %{artefact_number}.pdf
+    fuji_invoicing/sales_credit_note:
+      pdf_filename: Credit note %{business_name} %{artefact_number}.pdf
+    fuji_invoicing/sales_estimate:
+      pdf_filename: Estimate %{business_name} %{artefact_number}.pdf
+    fuji_invoicing/sales_invoice:
+      pdf_filename: Invoice %{business_name} %{artefact_number}.pdf
+    fuji_invoicing/sales_quote:
+      pdf_filename: Quote %{business_name} %{artefact_number}.pdf
+  email_alert:
+    messages:
+      migrated_artefacts: You can't email one or more of the selected items because
+        it was migrated from your old accounting system.
+    titles:
+      migrated_artefacts:
+        credit_note: Email Sales Credit Note
+        invoice: Email Sales Invoice
+        sales_artefact: Email Sales Item
+  email_dialog:
+    also_print:
+      fuji_invoicing/sales_corrective_invoice: Also print a copy of this corrective
+        invoice
+      fuji_invoicing/sales_credit_note: Also print a copy of this credit note
+      fuji_invoicing/sales_estimate: Also print a copy of this estimate
+      fuji_invoicing/sales_invoice: Also print a copy of this invoice
+      fuji_invoicing/sales_quote: Also print a copy of this quote
+    attachment:
+      fuji_invoicing/sales_corrective_invoice: We'll attach a PDF of the corrective
+        invoice
+      fuji_invoicing/sales_credit_note: We'll attach a PDF of the credit note
+      fuji_invoicing/sales_estimate: We'll attach a PDF of the estimate
+      fuji_invoicing/sales_invoice: We'll attach a PDF of the invoice
+      fuji_invoicing/sales_quote: We'll attach a PDF of the quote
+      monthly_statement: We'll attach a PDF of the statement
+    attachment_label: Attach
+    change_later: Edit your email defaults in Settings
+    description:
+      advanced_uk/catalog_items: Email a list of products and services
+      advanced_uk/contact_activities: Email a list of contact activities
+      advanced_uk/customer_refund_payment: This is where you can send a Remittance
+        Advice to your customer as a PDF file attachment.
+      advanced_uk/purchase_artefacts: Email a purchase list
+      advanced_uk/purchase_batches: Email a purchase quick entry list
+      advanced_uk/sales_artefacts: Email sales documents
+      advanced_uk/sales_batches: Email a sales quick entry list
+      advanced_uk/stock_movements: Email a list of stock movements
+      advanced_uk/supplier_expense_payment: This is where you can send a Remittance
+        Advice to your supplier as a PDF file attachment.
+      fuji_banking/bank_accounts: Email a list of bank accounts
+      fuji_banking/bank_activities: Email a list of bank activities
+      fuji_contacts/contacts: Email a list of contacts
+      fuji_contacts/customers: Email a list of customers
+      fuji_contacts/suppliers: Email a list of suppliers
+      fuji_invoicing/purchase_corrective_invoices: Email a list of purchase corrective
+        invoices
+      fuji_invoicing/purchase_credit_notes: Email a list of purchase credit notes
+      fuji_invoicing/purchase_invoices: Email a list of purchase invoices
+      fuji_invoicing/sales_corrective_invoice: This is where you can send your corrective
+        invoice to your customer as a PDF file attachment.
+      fuji_invoicing/sales_corrective_invoices: Email multiple sales corrective invoices
+      fuji_invoicing/sales_credit_note: This is where you can send your credit note
+        to your customer as a PDF file attachment.
+      fuji_invoicing/sales_credit_notes: Email multiple sales credit notes
+      fuji_invoicing/sales_estimate: This is where you can send your estimate as a
+        PDF file attachment.
+      fuji_invoicing/sales_invoice: This is where you can send your invoice to your
+        customer as a PDF file attachment.
+      fuji_invoicing/sales_invoices: Email multiple sales invoices
+      fuji_invoicing/sales_quote: This is where you can send your quote as a PDF file
+        attachment.
+      fuji_invoicing/sales_quotes: Email multiple sales quotes and estimates
+    payment_label: Payment
+    pdf_attached: Include PDF Attachment
+    pdf_link:
+      credit_note: PDF_credit_note
+      invoice: PDF_invoice
+      quote: PDF_quote
+      remittance: PDF_remittance
+    send_bcc: Send me a copy
+    subject:
+      advanced_uk/catalog_items: Products and services list from %{business_name}
+      advanced_uk/contact_activities: Sales Documents from %{business_name}
+      advanced_uk/customer_refund_payment: "%{business_name} - Remittance for %{total}"
+      advanced_uk/purchase_artefacts: Purchase List from %{business_name}
+      advanced_uk/purchase_batches: Purchase Quick Entry List from %{business_name}
+      advanced_uk/sales_artefacts: Sales Documents from %{business_name}
+      advanced_uk/sales_batches: Sales Quick Entry List from %{business_name}
+      advanced_uk/stock_movements: Stock movement list from %{business_name}
+      advanced_uk/supplier_expense_payment: "%{business_name} - Remittance for %{total}"
+      extra:
+        fuji_invoicing/sales_corrective_invoice: "%{business_name} - Corrective Invoice
+          (%{artefact_number}) for %{total}, due on %{date}"
+        fuji_invoicing/sales_credit_note: "%{business_name} - Credit Note (%{artefact_number})
+          for %{total}, on %{date}"
+        fuji_invoicing/sales_estimate: "%{business_name} - Estimate (%{artefact_number})
+          for %{total}, on %{date}"
+        fuji_invoicing/sales_estimate_expires_on: "%{business_name} - Estimate (%{artefact_number})
+          for %{total}, on %{date} (Expires on %{expiry_date})"
+        fuji_invoicing/sales_invoice:
+          with_duedate: "%{business_name} - Invoice (%{artefact_number}) for %{total},
+            due on %{date}"
+          without_duedate: "%{business_name} - Invoice (%{artefact_number}) for %{total}"
+        fuji_invoicing/sales_quote: "%{business_name} - Quote (%{artefact_number})
+          for %{total}, on %{date}"
+        fuji_invoicing/sales_quote_expires_on: "%{business_name} - Quote (%{artefact_number})
+          for %{total}, on %{date} (Expires on %{expiry_date})"
+      fuji_banking/bank_accounts: Bank List from %{business_name}
+      fuji_banking/bank_activities: Bank Activity from %{business_name}
+      fuji_contacts/contacts: Contact List from %{business_name}
+      fuji_contacts/customers: Customer List from %{business_name}
+      fuji_contacts/suppliers: Supplier List from %{business_name}
+      fuji_invoicing/purchase_corrective_invoices: Purchase Corrective Invoice Documents
+        from %{business_name}
+      fuji_invoicing/purchase_credit_notes: Purchase Credit Note List from %{business_name}
+      fuji_invoicing/purchase_invoices: Purchase Invoice List from %{business_name}
+      fuji_invoicing/sales_corrective_invoices: Sales Corrective Invoice Documents
+        from %{business_name}
+      fuji_invoicing/sales_credit_notes: Sales Credit Note Documents from %{business_name}
+      fuji_invoicing/sales_invoices: Sales Invoice Documents from %{business_name}
+      fuji_invoicing/sales_quotes: Sales Quote and Estimate Documents from %{business_name}
+      statement: Statement from %{business}
+    subject_label: Subject
+    success_message: Email sent successfully
+    success_message_with_invalid_email_addresses: Email sent successfully, however
+      unable to send to %{email_addresses} because the email address is marked as
+      inactive
+    title:
+      advanced_uk/catalog_items: Email products and services
+      advanced_uk/contact_activities: Email Contact Activity
+      advanced_uk/customer_refund_payment: Email Remittance Advice
+      advanced_uk/purchase_artefacts: Email Purchase List
+      advanced_uk/purchase_batches: Email Purchase Quick Entries
+      advanced_uk/sales_artefacts: Email Sales Documents
+      advanced_uk/sales_batches: Email Sales Quick Entries
+      advanced_uk/stock_movements: Email Stock Movements
+      advanced_uk/supplier_expense_payment: Email Remittance Advice
+      fuji_banking/bank_accounts: Email Bank Accounts
+      fuji_banking/bank_activities: Email Bank Activity
+      fuji_contacts/contacts: Email Contacts
+      fuji_contacts/customers: Email Customers
+      fuji_contacts/suppliers: Email Suppliers
+      fuji_invoicing/purchase_corrective_invoice: Email Purchase Corrective Invoice
+      fuji_invoicing/purchase_corrective_invoices: Email Purchase Corrective Invoices
+      fuji_invoicing/purchase_credit_note: Email Purchase Credit Note
+      fuji_invoicing/purchase_credit_notes: Email Purchase Credit Notes
+      fuji_invoicing/purchase_invoice: Email Purchase Invoice
+      fuji_invoicing/purchase_invoices: Email Purchase Invoices
+      fuji_invoicing/sales_corrective_invoice: Email Sales Corrective Invoice
+      fuji_invoicing/sales_corrective_invoices: Email Sales Corrective Invoices
+      fuji_invoicing/sales_credit_note: Email Credit Note
+      fuji_invoicing/sales_credit_notes: Email Sales Credit Notes
+      fuji_invoicing/sales_estimate: Email Estimate
+      fuji_invoicing/sales_invoice: Email Invoice
+      fuji_invoicing/sales_invoices: Email Sales Invoices
+      fuji_invoicing/sales_quote: Email Quote
+      fuji_invoicing/sales_quotes: Email Sales Quotes and Estimates
+    unable_to_send_email: 'Unable to send email. Please try again and contact support
+      if problems still persist. Error code: %{error_code}'
+    unable_to_send_email_to_inactive_recipients: 'The following email addresses: %{email_addresses},
+      have been marked as inactive after generating a hard bounce or spam complaint.
+      Please update the recipients and try again.'
+    view_file: view file
+  email_template:
+    footer:
+      legal_notes_html: Sage, SAS. <br /> %{address} <br /> ©2017 The Sage Group Ltd
+        or its partners. All rights reserved
+      links_html: "<a href='%{privacy_url}' style='color: #547dbb; text-decoration:
+        none;'>Privacy policy</a>"
+    view_invoice: View Invoice
+  email_verification:
+    error: Your email could not be verified.
+    success: Your email has been verified, thank you.
+    text: We have successfully verified your E-Mail address. Please access Sage Business
+      Cloud Accounting via your reseller.
+    text_failure: There has been a problem verifying your E-Mail address. Please contact
+      your reseller.
+  email_verification_pattern:
+    description:
+      complete_status: "%{email_address}"
+      in_progress_status: "<br><br> You're in the process of changing your reply address
+        to <b>%{new_email_address}</b>"
+      initial_status: Logged in user's email (%{email_address})
+    email:
+      message: |-
+        Hi,
+
+        %{user_name} (%{user_email}) has asked that when emails are sent directly through Sage Business Cloud Accounting for %{business_name}, and a recipient replies, the replies should go to your email address - %{new_reply_address}.
+
+        To allow %{business_name} to do this, just log in to Accounting, go to Settings, then Email Defaults, and enter this verification code. Alternatively, you can forward this email to %{user_name}.
+      message2: If you don't approve of this request, no further action is needed
+        and no change will be made.
+      subject: Sage Verification Code
+    email_reply_address: Email Reply Address
+    in_progress_email_verification_dialog:
+      description: Check your emails and enter the verification code we sent you.
+      hint:
+        description: 'Please check any junk mail boxes, or we can '
+        link_label: re-send the email
+        title: Can't find the email?
+      resend: Email resent to <b>%{new_email_address}</b> at %{time}.
+      send: We've sent an email to <b>%{new_email_address}</b>, on %{time}.
+      title: Verify Email Reply Address
+      verification_code: Verification code
+    initial_email_verification_dialog:
+      email_reply_address_description: Your current reply address, <b>%{email_address}</b>,
+        will be used until this one is verified.
+      hint:
+        description: We'll send an email to the new reply address with a verification
+          code, so you'll need access to this mailbox.
+        title: What happens next?
+      list:
+        bullet1: When we send emails on your behalf, and a recipient responds, this
+          is the email address their replies go to.
+        bullet2: This setting will apply to all emails we send on behalf of %{business_name}.
+      title: Change Email Reply Address
+    reset_dialog:
+      list:
+        bullet1: When emails are sent directly through Accounting, and a recipient
+          replies, their reply will go to the email address of the user who sent the
+          original email.
+        bullet2: This setting will apply to everyone who logs in to %{business_name}.
+        title: If you remove this email reply address...
+      question: Are you sure you want to remove the email reply address?
+      title: Remove Email Reply Address
+  error:
+    messages:
+      delete_user_messages_as_admin: You do not have permission to delete this message.
+      no_services: You are currently not subscribed to any services. Please subscribe
+        to at least one service.
+  errors:
+    concurrency:
+      message: Someone else may have updated/deleted this record. Please check the
+        details and try again.
+    messages:
+      bankdrive_pdf_form_unavailable: The bank account pdf form is not available
+      cannot_modify: You cannot modify the code or classification of a ledger account.
+      catalog_items_modal_data_error: Sorry, a technical error means you can't create
+        an item right now. Please try again.
+      duplicate_cheque_number: This number was used on a cheque printed or issued
+        %{printed_date}.  Please try another.
+      duplicate_contact_reference: This reference is already taken for %{company}.
+        Please try another.
+      ensure_vat_number: This is not a valid VAT number.
+      extension_white_list_error: 'You are not allowed to upload %{extension} files,
+        allowed types: %{allowed_types}'
+      invalid_email_addresses: You have entered an illegal character in the email
+        address. Special characters allowed are '+', '.', '-' and '_'
+      max_value_reached: You have reached the maximum limit for this field
+      min_value_not_reached: You have entered a value below the minimum limit for
+        this field
+      must_be_active: This product or service is inactive.
+      must_be_unique: must be unique.
+      name_and_company_blank: A Contact or Company Name is required.
+      reconciling_cash_account_prohibited: Reconciling cash account prohibited.
+      terminate_string_does_not_match: The confirmation string doesn't match
+      too_many_email_addresses: You can only enter up to %{count} email addresses
+      validate_postcode_uk: Invalid format for a Postal code
+      vendor_cheque: You must choose a vendor to pay by cheque.
+      wrong_format: Wrong format
+    sop_core_models/business:
+      membership_not_saved: User was not added to the business
+      owner_not_set: In order to set the business owner, the user needs to be part
+        of the business. The owner was not set.
+    sop_settings/area_code:
+      primary_only_full_access: A System Manager must have full access
+    sop_settings/business_memberships:
+      current_user_cannot_delete_owner: Cannot delete business owner
+      current_user_cannot_delete_self: Cannot delete yourself
+      current_user_cannot_unset_primary: Cannot allow your own user to remove System
+        Manager
+      owner_must_have_full_access: A business owner must have full access and needs
+        to be a system manager
+    sop_settings/manage_businesses:
+      switch:
+        invalid_business: Access Denied. You are now allowed to switch to the specified
+          business
+    sop_settings/new_business:
+      multi_business_service_required: Please select a valid multi-business service
+        for the business you are adding
+      service_required: Please select a valid service for the business you are adding
+  export:
+    advanced_uk/catalog_items:
+      csv:
+        filename: product_and_service_list.csv
+      pdf:
+        filename: product_and_service_list.pdf
+        page_title: Product and Service List
+    advanced_uk/contact_activities:
+      csv:
+        filename: contact_activity.csv
+      pdf:
+        filename: sales_documents.pdf
+    advanced_uk/customer_refund_payments:
+      pdf:
+        filename: remittance.pdf
+        page_title: Remittance
+    advanced_uk/purchase_artefacts:
+      csv:
+        filename: purchase_list.csv
+      pdf:
+        filename: purchase_list.pdf
+    advanced_uk/purchase_batches:
+      csv:
+        filename: purchase_quick_entries.csv
+      pdf:
+        filename: purchase_quick_entries.pdf
+    advanced_uk/sales_artefacts:
+      csv:
+        filename: sales_list.csv
+      pdf:
+        filename: sales_documents.pdf
+    advanced_uk/sales_batches:
+      csv:
+        filename: sales_quick_entries.csv
+      pdf:
+        filename: sales_quick_entries.pdf
+    advanced_uk/sales_revenue:
+      csv:
+        filename: sales_revenue.csv
+      pdf:
+        filename: sales_revenue.pdf
+    advanced_uk/stock_movements:
+      csv:
+        filename: stock_movements.csv
+      download:
+        title: Download PDF
+      pdf:
+        filename: stock_movements.pdf
+        page_title: Stock Movements
+      print:
+        title: Print Stock Movements
+    advanced_uk/supplier_expense_payments:
+      pdf:
+        filename: remittance.pdf
+        page_title: Remittance
+    detailed_reports:
+      label: Export Detailed Report
+    fuji_banking/bank_accounts:
+      csv:
+        filename: bank_list.csv
+      pdf:
+        filename: bank_list.pdf
+        page_title: Bank List
+    fuji_banking/bank_activities:
+      csv:
+        filename: bank_activity.csv
+      pdf:
+        filename: bank_activity.pdf
+        page_title: Bank Activity
+        recurrance:
+          is_not_recurring: 'No'
+          is_recurring: 'Yes'
+    fuji_banking/bank_reconciliations:
+      pdf:
+        page_title: Bank Reconciliation
+    fuji_contacts/contacts:
+      csv:
+        filename: contact_list.csv
+      pdf:
+        filename: contact_list.pdf
+        page_title: Contact List
+    fuji_contacts/customers:
+      csv:
+        filename: customer_list.csv
+      pdf:
+        filename: customer_list.pdf
+        page_title: Customer List
+    fuji_contacts/export_pending_contacts_gdpr_data:
+      csv:
+        filename: contacts_to_remove_list.csv
+      pdf:
+        filename: contacts_to_remove_list.pdf
+        page_title: List of contacts to be removed
+    fuji_contacts/suppliers:
+      csv:
+        filename: supplier_list.csv
+      pdf:
+        filename: supplier_list.pdf
+        page_title: Supplier List
+    fuji_invoicing/purchase_corrective_invoices:
+      csv:
+        filename: purchase_corrective_invoice_list.csv
+      pdf:
+        filename: purchase_corrective_invoices_list.pdf
+        page_title: Purchase Corrective Invoices List
+    fuji_invoicing/purchase_credit_notes:
+      csv:
+        filename: purchase_credit_notes_list.csv
+      pdf:
+        filename: purchase_credit_notes_list.pdf
+        page_title: Purchase Credit Notes List
+    fuji_invoicing/purchase_invoices:
+      csv:
+        filename: purchase_invoice_list.csv
+      pdf:
+        filename: purchase_invoices_list.pdf
+        page_title: Purchase Invoices List
+    fuji_invoicing/sales_corrective_invoices:
+      bulk:
+        issue:
+          title: Issue
+        list:
+          title: List
+      csv:
+        filename: sales_corrective_invoice_list.csv
+      download:
+        description: How would you like to generate the selected corrective invoices?
+        title: Download PDF
+      pdf:
+        filename: sales_corrective_invoice_list.pdf
+        page_title: Sales Invoices List
+      print:
+        description: How would you like to print the selected corrective invoices?
+        title: Print Corrective Invoices
+    fuji_invoicing/sales_credit_notes:
+      csv:
+        filename: sales_credit_notes_list.csv
+      pdf:
+        filename: sales_documents.pdf
+        page_title: Sales Credit Notes List
+    fuji_invoicing/sales_invoices:
+      bulk:
+        issue:
+          title: Issue
+        list:
+          title: List
+      csv:
+        filename: sales_invoice_list.csv
+      download:
+        description: How would you like to generate the selected invoices?
+        title: Download PDF
+      pdf:
+        filename: sales_documents.pdf
+        page_title: Sales Invoices List
+      print:
+        description: How would you like to print the selected invoices?
+        title: Print Invoices
+    fuji_invoicing/sales_quotes:
+      bulk:
+        issue:
+          title: Issue
+        list:
+          title: List
+      csv:
+        filename: sales_quote_estimate_list.csv
+      download:
+        description: How would you like to generate the selected quotes and estimates?
+        title: Download PDF
+      pdf:
+        filename: sales_documents.pdf
+        page_title: Sales Quotes and Estimates List
+      print:
+        description: How would you like to print the selected quotes and estimates?
+        title: Print Quotes and Estimates
+    multiple_artefacts_to_pdf:
+      contact_activities:
+        filename: contact_activities.pdf
+      errors:
+        max_number_of_pdfs: Please select less than %{number_of_pdfs} documents.
+      filename: sales_documents.pdf
+      sales_corrective_invoices:
+        filename: sales_corrective_invoices.pdf
+    nominal_activity:
+      detailed: Export Detailed
+      detailed_tooltip: "<span class='beta_version'>BETA</span> Export transactions
+        for many Nominal Accounts in one go."
+      summary: Export Summary
+    reports:
+      csv: CSV
+      invalid_form: Please correct the highlighted errors and try again
+      label: Export
+      pdf: PDF
+      sap: SAP/SAPA
+    unreconciled_bank_transactions:
+      csv: CSV
+      label: Export
+      pdf: PDF
+  feedback:
+    cancel: Cancel
+    comment: Please provide a brief summary of your experience
+    email:
+      bdp: "(Business migrated via BDP on %{date}, from %{product} %{product_version},
+        source tool %{tool} %{tool_version} and schema id %{schema_id})"
+      contact_message: "Rating: %{rating} \n\nComment: %{comments} \n\nPage: %{page}
+        \n\nBusiness: %{business_guid} \nUser: %{user_guid} \n\nContact details: %{user},
+        %{email} \n\nBrowser: %{browser_name} (%{browser_ver}) \nOS: %{os_name} (%{os_ver}
+        - %{device_type}) \n\n %{migration_text}"
+      legacy: "(Business upgraded from legacy product on %{date})"
+      message: "Rating: %{rating} \n\nComment: %{comments} \n\nPage: %{page} \n\nBusiness:
+        %{business_guid} \nUser: %{user_guid} \n\nBrowser: %{browser_name} (%{browser_ver})
+        \nOS: %{os_name} (%{os_ver} - %{device_type}) \n\n %{migration_text}"
+      reply_to: "%{user} < %{email} >"
+      slack_message: "%{comments} \n\n%{page} \n\n %{migration_text}"
+      slack_subject: "%{type}: %{service} (%{country}) - %{rating}"
+      subject: "%{type}: %{service} (%{country}) - %{user}, %{business}, %{email}"
+    email_address: Email
+    feedback_checkbox: I am happy to be contacted to discuss this feedback
+    feedback_info: Your feedback will be shared with our product delivery teams, and
+      taken into consideration for future product development.
+    feedback_label: What would you like to tell us?
+    feedback_prompt:
+      link: "**We'd love your feedback** on this feature."
+    feedback_success:
+      check_help: Have your say about Accounting, test out improvements, and be the
+        first to see new features, by joining **[the Sage Experience Panel](%{panel_url})**.
+      close: Close
+      thanks_label: Your feedback helps us continually improve our software.
+      title: Thanks for your feedback!
+    feedback_title: Give Feedback
+    info: We'd really like to hear what you think about Accounting. If there's anything
+      you would like us to improve please tell us below, or if you need some help
+      using the service, please email us at sagebusinesscloudsupport@sage.com.
+    info_note: 'Note: Any response will be sent to your registered email address.'
+    link: Give Feedback
+    name: Name
+    rating: How does Accounting make you feel?
+    ratings:
+      level_1: Happy
+      level_2: Indifferent
+      level_3: Sad
+    response:
+      success:
+        message: We've received your feedback - many thanks!
+        title: Thank you for your feedback
+    send: Send
+    submit: Submit
+    support_checkbox: I am happy to be contacted regarding my help request
+    support_info: Your help request will be submitted to our customer service team,
+      who will be in touch shortly.
+    support_label: What can we help you with?
+    support_success:
+      check_help: You may find the answer to your question, along with other useful
+        information, including support articles and tutorials on our Help Site.
+      help: Get help now
+      thanks_label: Thank you, your request has been emailed to our customer services
+        team.  We aim to respond within 24 hours.
+      title: Help request sent
+    support_title: Ask for help
+    title: What would you like to do?
+    validation_errors:
+      comment_length_validation: Please enter less than %{count} characters.
+      rating_required: Please click one of the face icons.
+  filters:
+    scope:
+      label: Type
+    status:
+      active: Active
+      inactive: Inactive
+      label: Status
+    stock_level:
+      below_reorder_level: Below reorder level
+      label: Stock level
+      out_of_stock: Out of stock
+  financial_year_notification:
+    dismissed:
+      link_text: "%{day} %{month}"
+      text: 'Financial Year end: '
+    no_year_end_set: 'No financial year set. '
+    no_year_end_set_link: Set it
+    not_dismissed:
+      link_text: Change this
+      text: 'Your Financial Year is set to %{day} of %{month}. '
+  gdpr:
+    contacts:
+      confirmation_dialog:
+        save_button:
+          text: Remove Data
+        text_1: All personal data will be removed from this contact’s record and related
+          transactions by completing this process.
+        text_2_1: 'Please enter '
+        text_2_2: " below to confirm you wish to remove this contact’s personal data."
+        textbox:
+          label: Enter Confirmation Word*
+        title: Remove Personal Data
+        word: REMOVE
+      extension_date: Extended Removal Date
+      extension_reason:
+        help: You have to provide a reason if you're extending the period you hold
+          this contact's data.
+        label: Reason for Extension
+      last_transaction: Last Transaction Date
+      no_transaction: No transaction
+      obfuscated_at:
+        pending: Pending
+        title: Personal Data Removed
+      obfuscation:
+        bulk:
+          errors:
+            contact_already_obfuscated: The selected contacts could not have their
+              personal data removed.
+            in_extended_retention_period: The selected contacts could not have their
+              personal data removed.
+            in_retention_period: The selected contacts could not have their personal
+              data removed.
+            outstanding_balance: The selected contacts could not have their personal
+              data removed as one or more of them have an outstanding balance.
+            permanent_contact: The selected contacts could not have their personal
+              data removed.
+            suggested_removal_date_unset: The selected contacts could not have their
+              personal data removed.
+        errors:
+          contact_already_obfuscated: This contact has already been obfuscated.
+          in_extended_retention_period: The retention period has been extended and
+            this contact is still in it.
+          in_retention_period: This contact is still in the retention period.
+          outstanding_balance: This contact has an outstanding balance and can't be
+            obfuscated.
+          permanent_contact: This is a permanent contact and can't be obfuscated.
+          suggested_removal_date_unset: Suggested Removal Date can't be calculated
+            because you didn't set the gdpr configuration.
+        success: Personal data has been successfully removed for this contact.
+      outstanding_balance_dialog:
+        button:
+          text: Okay
+        message:
+          link:
+            text: Help on outstanding balances
+            url: https://help.sageone.com/en_uk/accounting/delete_contact_check_for_outstanding_balance
+          text: You can’t remove personal data for a contact with an outstanding balance.
+          title: This contact has an outstanding balance of %{amount} on their account.
+        title: Remove Personal Data
+      permanent_reason:
+        help: You have to provide a reason why the contact requires a permanent record.
+        label: Reason for Permanent Record
+      permanent_record:
+        label: This contact has consented to be a permanent record
+        title: Permanent Record
+      remove_data_button:
+        text: Remove Personal Data
+      retention_settings:
+        success:
+          message: Successfully updated GDPR Personal Data
+      set_retention_period_link: Set your retention period
+      suggested_removal_date:
+        not_applicable: Not applicable
+        not_set: Not set
+        title: Suggested Removal Date
+      title:
+        help: Under GDPR there are strict rules around how long you can keep personal
+          details. We'll help you by suggesting when a contact's personal data should
+          be removed, based on their last transaction with you and the retention period
+          you set up.
+        text: GDPR Personal Data
+    history:
+      by: by
+      item:
+        date_format: "%e %b %Y - %l:%M %p"
+        from: from
+        permanent_record_no: Remove Permanent Record
+        permanent_record_yes: Set to Permanent Record
+        removal_data: Removal Date changed to %{date}
+        retention_period_set: Retention Period Set to
+      title: Show history
+    info_dialog:
+      button_text: Set Up Now
+      checkbox:
+        label: Don’t show me this again
+      content_line_1: Accounting will help you get ready for this change by allowing
+        you to set a Retention Period for your business.  Setting this means we will
+        be able to prompt you at the end of this period so that you can decide if
+        you want to erase the personal data.
+      content_line_2: We recommend setting your Retention Period straight away.
+      error_setting_hide_dialog: Wrong parameters supplied to hide/unhide dialog
+      info_text: General Data Protection Regulation (GDPR) comes into effect on 25th
+        May 2018. It introduces new rules for how you manage your contact’s personal
+        data.
+      title: Get Ready for GDPR
+  grid:
+    cells:
+      masks:
+        category:
+          bank_transfer: 'Transfer: %{account_name}'
+          deposit: 'Deposit: %{account_name}'
+    titles:
+      advanced_uk/contact_activity:
+        currency_discount: Discount <span data-currency="%{currency_symbol}">&nbsp;</span>
+        currency_outstanding: Outstanding <span data-currency="%{currency_symbol}">&nbsp;</span>
+        currency_total: Total <span data-currency="%{currency_symbol}">&nbsp;</span>
+        currency_total_net_amount: Net <span data-currency="%{currency_symbol}">&nbsp;</span>
+        currency_total_tax_amount: VAT <span data-currency="%{currency_symbol}">&nbsp;</span>
+        discount: Discount <span data-currency="%{base_currency_symbol}">&nbsp;</span>
+        exchange_rate_gain: Exch. Variance <span data-currency="%{base_currency_symbol}">&nbsp;</span>
+        outstanding: Outstanding <span data-currency="%{base_currency_symbol}">&nbsp;</span>
+        total: Total <span data-currency="%{base_currency_symbol}">&nbsp;</span>
+        total_net_amount: Net <span data-currency="%{base_currency_symbol}">&nbsp;</span>
+        total_tax_amount: VAT <span data-currency="%{base_currency_symbol}">&nbsp;</span>
+      advanced_uk/journal_code:
+        code: Code
+        country_journal_type_id: Journal Type
+        name: Name
+      advanced_uk/tax_return:
+        total_amount: Value
+      auxiliary_account_formatted: Account Code
+      currency: Currency
+      from_date: Date From
+      fuji_contacts/contact:
+        formatted: Name
+      fuji_contacts/customer:
+        formatted: Name
+      fuji_contacts/supplier:
+        formatted: Name
+      homepage_url: Homepage
+      inventory/models/stock_movement:
+        cost_price: Cost Price
+        date: Date
+        details: Details
+        quantity: Quantity
+        quantity_in: In
+        quantity_out: Out
+        readable_type: Type
+        reference: Reference
+        sales_price: Sales Price
+      journal_code_code: Journal code
+      mysageone_core/user_activity:
+        authenticated_user_guid: User
+        created_at: Date/Time
+        description: Action
+      name: Name
+      paid_formatted: Paid
+      retailer_amount: RE
+      submitted_date: Submitted Date
+      tax_number: VAT Registration No
+      tax_rate: Tax Rate
+      tax_return_number: Return Number
+      tax_return_status_id: Status
+      to_date: Date To
+      total_amount: Total
+      transaction_number: Trx No
+  headings:
+    advanced_uk/customer_income_payment:
+      bank: Receipt Details
+      contact: Customer Details
+    advanced_uk/customer_refund_payment:
+      bank: Refund Details
+      contact: Customer Details
+    advanced_uk/other_expense_payment:
+      bank: Payment Details
+      contact: Supplier Details
+    advanced_uk/other_income_payment:
+      bank: Receipt Details
+      contact: Customer Details
+    advanced_uk/supplier_expense_payment:
+      bank: Payment Details
+      contact: Supplier Details
+    advanced_uk/supplier_refund_payment:
+      bank: Refund Details
+      contact: Supplier Details
+  heartbeat:
+    cancel: Log out
+    confirm: Stay logged in
+    message: We'll log you out in <span class='heartbeat-logout-timer'>%{time}</span>
+      seconds
+    retained_session:
+      message: We have noticed you are busy and have not automatically logged you
+        out.
+      title: You are still logged in
+    title: All done?
+  helpers:
+    label:
+      all: All
+      filter:
+        artefact_status_id: Status
+        category: Category
+        close: Close
+        coa_group_type_id: Group
+        end_date: To
+        exclude_disputed: Exclude Disputed
+        filter: Filter
+        filter_type: Show
+        ledger_account_classification_id: Class
+        ledger_account_type_id: Category
+        reset_filters: Reset Filters
+        search_text: Type to search
+        show_type: Included in Chart
+        start_date: From
+        type: Type
+      grid_filter_bank_accounts:
+        selection_text: Bank Accounts
+      grid_filter_sales_quotes:
+        end_date: To
+        quote_status: Status
+        quote_type: Type
+        start_date: From
+      report:
+        address_type_values:
+          main: Main
+        address_types: Address Types
+        analysis_category: Analysis Category
+        analysis_type: Analysis Type
+        cash_flow_forecast_detail_report: Cash Flow Forecast - Detailed Breakdown
+        cash_flow_forecast_prior_transactions: Cash Flow Forecast - Expected Prior
+          Cash Flow Detailed Breakdown
+        cash_flow_forecast_report: Cash Flow Forecast Report
+        cash_flow_statement_detail_report: Cash Flow Statement - Detailed Breakdown
+        cash_flow_summary_report: Cash Flow Statement Report
+        category: Category
+        classification: Class
+        cr: Cr
+        date: Date
+        dr: Dr
+        ec_sales_report: EC Sales List
+        end_date: To
+        ledger_account_id: Display Name
+        nominal_activity_report: Nominal Activity Report
+        nominal_activity_report_detail: Detailed Nominal Activity
+        sage_pay_ecommerce_payments: Ecommerce Payments
+        sage_pay_payments: Payments Received
+        search: Search
+        start_date: From
+        statement_period: Statement period %{start_date} to %{end_date}
+        total: Total
+        transaction_type: Transaction Type
+        transaction_type_group: Receipts/Payments
+        type: Show type
+        unreconciled_bank_transactions_report: Unreconciled Bank Transactions Report
+      signup:
+        business_coa_template_id: COA template
+        financial_settings_tax_number: VAT Number
+        financial_settings_tax_scheme_id: VAT Scheme
+        financial_settings_tax_submission_frequency_type_id: Submission Frequency
+    link:
+      fuji_invoicing/purchase_credit_note:
+        invoice: 'Invoice Number: %{invoice_number}'
+      fuji_invoicing/sales_credit_note:
+        invoice: 'Invoice Number: %{invoice_number}'
+    no_activity_for_date_range: No activity for the selected date range
+    select:
+      all: All
+      prompt_for_ledger_account: Select ledger account
+      sales_tax_prompt: Default from customer
+      tax_period_rate: Tax Rate
+  invoice:
+    credit_note_voided: Credit Note Voided
+    email_date_title:
+      credit_date: Credit Date
+      due_date: Due Date
+      expiry_date: Expiry Date
+    email_failure:
+      fuji_invoicing/sales_corrective_invoice: The Sales Corrective Invoice cannot
+        be emailed as it has been voided.
+      fuji_invoicing/sales_credit_note: The Sales Credit Note cannot be emailed as
+        it has been voided.
+      fuji_invoicing/sales_estimate: The Sales Invoice cannot be emailed as it has
+        been voided.
+      fuji_invoicing/sales_invoice: The Sales Invoice cannot be emailed as it has
+        been voided.
+      fuji_invoicing/sales_quote: The Sales Invoice cannot be emailed as it has been
+        voided.
+    email_powered_by_title: Powered By
+    email_subject:
+      fuji_invoicing/sales_corrective_invoice: Corrective invoice %{number} from %{business_name}
+      fuji_invoicing/sales_credit_note: Credit note %{number} from %{business_name}
+      fuji_invoicing/sales_estimate: Estimate %{number} from %{business_name}
+      fuji_invoicing/sales_invoice: Invoice %{number} from %{business_name}
+      fuji_invoicing/sales_quote: Quote %{number} from %{business_name}
+    email_success:
+      fuji_invoicing/sales_corrective_invoice: Sales Corrective Invoice has been sent.
+      fuji_invoicing/sales_credit_note: Sales Credit Note has been sent.
+      fuji_invoicing/sales_estimate: Sales Estimate has been sent.
+      fuji_invoicing/sales_invoice: Sales Invoice has been sent.
+      fuji_invoicing/sales_quote: Sales Quote has been sent.
+    email_total_title: Total
+    email_type:
+      sales_corrective_invoice: Invoice
+      sales_credit_note: Credit Note
+      sales_estimate: Estimate
+      sales_invoice: Invoice
+      sales_quote: Quote
+    print_failure:
+      fuji_invoicing/sales_corrective_invoice: The Sales Corrective Invoice cannot
+        be printed as it has been voided.
+      fuji_invoicing/sales_credit_note: The Sales Credit Note cannot be printed as
+        it has been voided.
+      fuji_invoicing/sales_invoice: The Sales Invoice cannot be printed as it has
+        been voided.
+    save_button: Save
+    void: The %{invoice} has been voided successfully.
+    voided: Invoice Voided
+  invoice_settings:
+    default:
+      sales_corrective_invoice_prefix: CI-
+      sales_credit_note_prefix: SCN-
+      sales_estimate_prefix: SE-
+      sales_invoice_prefix: SI-
+      sales_quote_prefix: SQ-
+  invoices_general:
+    corrections_applied:
+      show:
+        message_title: A correction has been applied to this invoice
+    eu_no_vat:
+      customer:
+        message_text: If they’re VAT registered, enter a VAT number on the customer’s
+          record to apply a zero rate and keep your returns and reports correct.
+        message_title: This customer has an address in the EU, but no VAT number.
+        show_message_text: This customer has an address in the EU, but no VAT number.
+      supplier:
+        message_title: This supplier has an address in the EU, but their VAT number
+          hasn't been entered.
+        show_message_text: This supplier has an address in the EU, but their VAT number
+          hasn't been entered.
+    eu_tax_registration:
+      customer:
+        message_text: VAT rates are therefore set to zero below. You’ll need to submit
+          an EC Sales List to HMRC.
+        message_title: This customer is registered for VAT in the EU.
+        show_message_text: This customer is registered for VAT in the EU.
+      show:
+      supplier:
+        message_text: This invoice will be treated as an EC Purchase and VAT will
+          be charged under the Reverse Charge mechanism. Please review the EU Goods/Services
+          and EC Sales Descriptions.
+        message_title: This supplier is registered for VAT in the EU.
+        show_message_text: This supplier is registered for VAT in the EU.
+    help:
+      original_number: Invoice Number (e.g. SI-1234)
+    invoice_already_issued:
+      message_text: If you make any changes, make sure you inform your customer and
+        provide an updated copy.
+      message_title: Invoice already issued
+    missing_business_address:
+      message: Before you can create a %{model}, you must supply your Business Address.  Click
+        'Ok' to enter this now, or 'Cancel' to return to the List.
+      title: Business Address Required
+    missing_financial_settings:
+      message: 'You have specified that this business is registered for VAT but have
+        not specified the following: '
+      submission_frequency: VAT Submission Frequency
+      tax_number: VAT Number
+      tax_rate: Flat Rate Percentage
+      tax_scheme: You must specify whether this business is registered for VAT.
+    original_number: Original Invoice Number
+    pdf:
+      company_registration: Registered in %{country} Number %{number}
+      company_registration_office: 'Registered Office: %{address}'
+      line_items:
+        tax_amount: VAT
+        tax_percentage: "% VAT"
+      mobile: 'Mobile: %{value}'
+      reference: Reference
+      telephone: 'Telephone: %{value}'
+      vat_number: VAT Number
+      website: 'Website: %{value}'
+    row:
+      customer:
+        message_text: VAT rates are therefore set to zero below.
+        message_title: This customer is outside the EU.
+        show_message_text: This customer is outside the EU.
+      supplier:
+        message_text: This invoice will be charged under the Reverse Charge mechanism.
+        message_title: This supplier is outside of the EU.
+        show_message_text: This supplier is outside of the EU.
+    tax_calculation:
+      cash: VAT on these entries will be collected on date of payment.
+      invoice: VAT on these entries will be collected on the date of invoice.
+      purchase_quick_entries: VAT on these entries may be collected on the date of
+        the invoice, or on payment, depending on your individual Supplier settings.
+        Please ensure you have the right method selected for your suppliers.
+      title: VAT Calculation Method
+    tax_on_non_taxable_business: You cannot add tax, your business is not registered
+      for tax
+  jwt_email_verification:
+    subject: Jwt Email Verification Subject
+  jwt_reseller_mailer:
+    subject: Reseller email subject
+  loading_animation:
+    text_end1: All done.
+    text_end2: Your accounting adventure begins here
+    text_start1: Just a moment…
+    text_start2: Customising your experience
+  locale_options:
+    de: German
+    en: English
+    en-CA: English (Canadian)
+    en-GB: English
+    en-US: English
+    en_IE: English
+    es: Spanish
+    es-US: Spanish (US)
+    fr: French
+    fr-CA: French (Canadian)
+  localised_suffix:
+    en: uk
+    en_IE: ireland
+  lockdown:
+    message: The transaction date must be later than the year-end lock down date of
+      %{date}.<a href="%{help_url}/find_by_tag?language=%{help_language}&locale=%{help_locale}&service=%{help_service}&tag=extra_financial_year_end"
+      target="_"> Change the year-end lock down date and try again.</a>
+  mailers:
+    footer:
+      col1: 'For further information about our terms and conditions please view our '
+      col2: 'If you have further queries, please visit the '
+      col3: To ensure that our emails get to your inbox, please add us to your email
+        Address Book or Safe List.
+    labels:
+      contact: Contact Us
+      help: Help
+      safe_list: Add us to your Safe List
+      terms: Terms &amp; Conditions
+    links:
+      contact: http://www.sageone.com/help/contact-us
+      help: http://www.sageone.com/help
+      terms: http://www.sageone.com/terms-conditions
+    page: " page"
+    plain_text:
+      footer:
+        col1: |-
+          For further information about our terms and conditions
+           please view our terms and conditions
+        col2: If you have further queries, please visit the contact us page
+        col3: To ensure that our emails get to your inbox, please\n add us to your
+          email Address Book or Safe List.
+      sage_info: |-
+        Sage (UK) Limited.
+         Registered in England at North Park,
+         Newcastle upon Tyne,
+         NE13 9AA.
+         Registration Number 1045967.
+      terms: Terms and Conditions
+    sage_info: Sage (UK) Limited. Registered in England at North Park, Newcastle upon
+      Tyne, NE13 9AA.<br />Registration Number 1045967.
+    tooltips:
+      contact_link: Contact Sage
+      finance_email: Sage Finance Email Address
+      help_link: Help
+      support_email: Sage Support Email Address
+      terms_link: Terms &amp; Conditions
+  making_tax_digital:
+    authentication:
+      error: Unable to authenticate with HMRC please try again.
+      failure: You must grant authority to interact with HMRC please try again.
+      not_authenticated: You are not authenticated with HMRC please reconnect.
+      success: Successfully authenticated with HMRC.
+    date_format: "%-d %b %Y"
+    due_date_message: HMRC requires this VAT return to be submitted by %{date}.
+    error_codes:
+      client_or_agent_not_authorised: Unable to connect to HMRC. Please verify your
+        VAT settings and try again.
+      duplicate_submission: You have already submitted a VAT return for this period.
+      invalid_numeric_value: Please check the information entered and try again.
+      invalid_request: Please check the information entered and try again.
+      not_finalised: Please check the information entered and try again.
+      period_key_invalid: Please select a valid VAT return period.
+      tax_period_not_ended: HMRC have rejected this return as the period has not ended.
+      unknown: Please check the information entered and try again.
+      vat_net_value: Please check the information entered and try again.
+      vat_total_value: Please check the information entered and try again.
+      vrn_invalid: Please enter a valid VAT registration number.
+    overdue_message: HMRC required this VAT return to be submitted by %{date}.
+  menu:
+    accountant:
+      text: Accountant
+    adjustments:
+      text: Adjustments
+    aged_creditors:
+      text: Aged Creditors
+    aged_debtors:
+      text: Aged Debtors
+    audit_trail_selector:
+      text: Audit Trail
+    balance_sheet:
+      text: Balance Sheet Report
+    balance_statement:
+      text: Balance Sheet
+    bank_accounts:
+      text: Banking
+    business_settings:
+      text: Business Settings
+    buy_and_sell:
+      text: Buy & Sell
+    cash_flow_forecast:
+      text: Cash Flow Forecast
+    cash_flow_summary:
+      text: Cash Flow Statement
+    chart_of_accounts:
+      text: Chart of Accounts List
+    contacts:
+      text: Contacts
+    corrections:
+      text: Correct Transactions
+    create:
+      text: Create...
+    customers:
+      text: Customers
+    ec_sales:
+      text: EC Sales Analysis Report
+    income_statement:
+      text: Income Statement
+    invoice_profit_analysis:
+      text: Profit Analysis
+    journals:
+      text: Journals
+    ledger_accounts:
+      text: Chart of Accounts
+    more_options:
+      text: More...
+    nominal_activity:
+      text: Nominal Activity
+    payments:
+      text: Payments
+    payments_and_receipts:
+      text: Payments & Receipts
+    products_services:
+      text: Products & Services
+    profit_and_loss:
+      text: Profit & Loss
+    purchase_batches:
+      text: Quick Entries
+    purchase_corrective_invoices:
+      text: Purchase Corrective Invoices
+    purchase_credit_notes:
+      text: Purchase Credit Notes
+    purchase_day_book:
+      text: Purchase Day Book
+    purchase_invoices:
+      text: Purchase Invoices
+    purchase_ledger:
+      text: Purchase Ledger
+    purchases:
+      text: Purchases
+    quotes:
+      text: Quotes
+    receipts:
+      text: Receipts
+    receipts_and_payments_day_book:
+      text: Receipts & Payments Day Book
+    reporting:
+      text: Reporting
+    reports:
+      text: Reports
+    return_of_trading_details:
+      text: Return of Trading Details
+    sage_pay_ecommerce_payments:
+      text: Ecommerce Payments
+    sage_pay_payments:
+      text: Payments Received
+    sales:
+      text: Sales
+    sales_batches:
+      text: Quick Entries
+    sales_corrective_invoices:
+      text: Sales Corrective Invoices
+    sales_credit_notes:
+      text: Sales Credit Notes
+    sales_day_book:
+      text: Sales Day Book
+    sales_invoices:
+      text: Sales Invoices
+    sales_ledger:
+      text: Sales Ledger
+    sales_quotes:
+      text: Quotes & Estimates
+    sales_tax:
+      text: Sales Tax Report
+    settings:
+      text: Settings
+    summary:
+      text: Summary
+    suppliers:
+      text: Suppliers
+    tax:
+      text: VAT
+    tax_returns:
+      text: VAT Returns
+    trial_balance:
+      text: Trial Balance
+    unallocated_payments:
+      text: Unallocated Receipts or Payments
+    unreconciled_bank_transactions:
+      text: Unreconciled Bank Transactions
+  micro:
+    actions:
+      advanced:
+        payment:
+          new: Money Out
+        receipt:
+          new: Money In
+      fuji_core_accounting:
+        ledger_account:
+          new: New Category
+    activerecord:
+      attributes:
+        advanced_uk/audit_trail_summary:
+          date: Date
+        advanced_uk/journal_opening_balance_line:
+          ledger_account_id: Category
+        advanced_uk/other_expense_payment:
+          name: Contact (optional)
+        advanced_uk/other_income_payment:
+          name: Contact (optional)
+        advanced_uk/payment:
+          bank_account: Bank Account
+          bank_account_id: Paid from Bank Account
+          contact_id: Name
+          formatted_type: Type
+          id: Number
+          money_in: Money in
+          money_out: Money out
+          payment_type: Method
+          recurrence: Repeat
+          reference: Reference
+          total_amount: Total
+          total_net_amount: Net
+          total_tax_amount: VAT
+        advanced_uk/payment_line_item:
+          ledger_account_id: Category
+        fuji_contacts/contact:
+          purchase_ledger_account_id: Purchase Category
+          purchases_to_date: Money out - to Date
+          sales_ledger_account_id: Sales Category
+          sales_to_date: Money in - to Date
+        fuji_core_accounting/business_retention_settings:
+          gdpr:
+            help_link: https://help.sageone.com/find_by_tag?language=en&locale=uk&service=start&tag=setup_gdpr_retention_period
+        fuji_core_accounting/ledger_account:
+          coa_group_type: Group
+          coa_group_type_id: Group
+          has_other_payment_scope: Money Out
+          has_other_receipt_scope: Money In
+          has_purchasing_scope: Supplier defaults
+          has_sales_scope: Sales - Invoice / Credit, Customer defaults
+          ledger_account_type_id: Type
+          name: Category Name
+          name_for_grid: Category Name
+          nominal_code: Category Code
+          nominal_code_formatted: Category Code
+        fuji_core_accounting/ledger_entry:
+          category: Type
+          recurrence: Repeat
+        fuji_support/recurrence:
+          expiry_date: Repeat Until
+        journal_line:
+          ledger_account_id: Category
+      models:
+        advanced_uk/other_expense_payment: Money out
+        advanced_uk/other_income_payment: Money in
+        fuji_core_accounting/ledger_account: Category
+    advanced_uk/summary:
+      balance: Balance
+      expense: Money out
+      income: Money in
+      new_expense: Add
+      new_income: Add
+    cashbook:
+      buttons:
+        new_expense: Money Out
+        new_income: Money In
+    contact_activity:
+      contacts:
+        dialog:
+          account_default: Default Category
+          invoice_details_tab: Contact Details
+    export:
+      nominal_activity:
+        detailed_tooltip: "<span class='beta_version'>BETA</span> Export transactions
+          for many categories in one go."
+    filters:
+      all_accounts: All Accounts
+      all_types: All Types
+      ledger_account_type_id: Type
+      show_type: Included in Chart
+    grid:
+      titles:
+        advanced_uk/audit_trail:
+          ledger_account_name: Category
+    headings:
+      advanced_uk/other_expense_payment:
+        contact: Contact Details
+      advanced_uk/other_income_payment:
+        contact: Contact Details
+    helpers:
+      label:
+        filter:
+          ledger_account_type_id: Type
+        report:
+          nominal_activity_report: Category Activity
+          nominal_activity_report_detail: Category Activity - Detailed
+    localised_lookup:
+      fuji_core_accounting:
+        transaction_type:
+          other_expense_payment: Money out
+          other_expense_payment_refund: Money in
+          other_income_payment: Money in
+          other_income_payment_refund: Money out
+    menu:
+      bank_accounts:
+        text: Banking
+      cashbook:
+        text: Cashbook
+      customer_receipt:
+        text: Customer receipt
+      deposit_cash:
+        text: Deposit cash
+      money_in:
+        text: Money in
+      money_out:
+        text: Money out
+      more:
+        text: More
+      new_bank_account:
+        text: Bank Account
+      new_journal:
+        text: Journal
+      withdraw_or_transfer:
+        text: Transfer
+    micro_invoicing:
+      actions:
+        fuji_invoicing/sales_corrective_invoice:
+          refund_dialog:
+            title: 'Refund Money In: %{paid_amount}'
+        fuji_invoicing/sales_invoice:
+          refund_dialog:
+            title: 'Refund Money In: %{paid_amount}'
+      activerecord:
+        attributes:
+          fuji_invoicing/sales_corrective_invoice:
+            currency_total_net_amount: Subtotal
+          fuji_invoicing/sales_invoice:
+            currency_total_net_amount: Subtotal
+      bulk_destroy:
+        messages:
+          warning_draft:
+            sales_artefact: One or more of the selected items has a Draft status.
+              Draft invoices or credit notes will be fully deleted and won't be retained
+              after deletion.
+            sales_invoice: One or more of the selected items has a Draft status. Draft
+              invoices will be fully deleted and won't be retained after deletion.
+      bulk_pay_or_allocate:
+        messages:
+          payments_allocated_or_voided:
+            sales_artefact: One or more of the selected items are already voided,
+              fully allocated or draft.
+            sales_invoice: One or more of the selected items are already voided, fully
+              allocated or draft.
+      invoices_general:
+        missing_business_address:
+          currency_total_tax_amount: VAT
+          message: Before you can create a %{model}, you must supply your Business
+            Address.
+      page_info:
+        advanced_uk/customer_income_payments:
+          info:
+            show: ''
+        advanced_uk/other_expense_payment_refunds:
+          info:
+            show: Record receipts, such as refunds for over the counter purchases,
+              that you've received during the course of running your business.
+          title:
+            default: Money In
+            show: Money In
+        advanced_uk/other_income_payment_refunds:
+          info:
+            show: Record payments, such as refunds for over the counter sales, that
+              you've paid out in the course of running your business.
+          title:
+            default: Money Out
+            show: Money Out
+        advanced_uk/reports:
+          help:
+            aged_debtors: start_aged_debtors_report
+            sales_day_book: start_sales_day_book
+          info:
+            aged_debtors: This report shows all outstanding or unallocated customer
+              transactions, broken down by ageing periods.
+        advanced_uk/sales_artefacts:
+          help:
+            index: start_sales_invoices_list
+        fuji_invoicing/sales_corrective_invoices:
+          help:
+            copy: start_create_sales_corrective_invoices
+            create: start_create_sales_corrective_invoices
+            edit: start_manage_sales_corrective_invoices
+            index: extra_sales_corrective_list
+            new: start_create_sales_corrective_invoice
+            show: start_manage_sales_corrective_invoices
+        fuji_invoicing/sales_credit_notes:
+          help:
+            copy: start_create_sales_credit_notes
+            create: start_create_sales_credit_notes
+            edit: start_manage_sales_credit_notes
+            index: extra_sales_list
+            new: start_create_sales_credit_note
+            show: start_manage_sales_credit_notes
+        fuji_invoicing/sales_invoices:
+          help:
+            copy: start_create_sales_invoices
+            create: start_create_sales_invoices
+            edit: start_manage_sales_invoices
+            index: extra_sales_list
+            new: start_create_sales_invoice
+            show: start_manage_sales_invoices
+        sop_settings/email_defaults:
+          info:
+            show: Set a default message which you can customise when you email an
+              invoice or credit note.
+        sop_settings/invoice_settings:
+          help:
+            show: start_invoice_settings
+          info:
+            show: Select the invoice template to use for your business, your numbering
+              defaults and enter the text to appear on your documents.
+          title:
+            default: Invoice Form Settings
+            show: Invoice Form Settings
+      sop_settings:
+        invoices_and_quotes:
+          link_text: Invoice Form Settings
+      table:
+        titles:
+          fuji_invoicing/sales_invoice_line_item:
+            currency_unit_price: Amount excl VAT
+            ledger_account_id: Category
+    page_info:
+      advanced_uk/cashbook:
+        help:
+          index: cashbook_option
+        info:
+          index: This is where you record the flow of money in and out of your business
+        title:
+          index: Cashbook
+      advanced_uk/other_expense_payments:
+        alert_not_home:
+          message: EC and Rest of World payments are not supported by Accounting.
+            Click <a href=%{help} target='new'>here</a> to find out more.
+          title: Overseas Supplier
+        help:
+          overseas_supplier: start_overseas_supplier
+          show: money_out
+        info:
+          show: Record one-off payments, over the counter purchases, and other money
+            that you’ve paid out in the course of running your business.
+        title:
+          show: Money Out
+      advanced_uk/other_income_payments:
+        help:
+          show: money_in
+        info:
+          show: Record receipts, such as for over the counter sales and other money
+            that you’ve received during the course of running your business.
+        title:
+          show: Money In
+      advanced_uk/payments:
+        help:
+          recurrence: extra_bank_recurring_entries
+        info:
+          recurrence: If you make payments and receipts on a regular basis you can
+            set them up as recurring entries.
+        title:
+          expense: Money Out
+          income: Money In
+      advanced_uk/reports:
+        help:
+          chart_of_accounts: chart_accounts_list
+          nominal_activity: category_report
+          profit_and_loss: extra_management_reports
+          receipts_and_payments_day_book: start_reports_incomeexpense_daybook
+        info:
+          chart_of_accounts: Use this report to view and export a list of your categories.
+          nominal_activity: This report shows the categories with activity for analysis
+            codes in a given date range.
+          nominal_activity_detail: This report shows the transaction activity for
+            specified category, analysis codes in a given date range.
+          trial_balance: This report shows the balance on your categories for a specified
+            date range. You can include brought forward values and include current
+            year’s profit and loss values only
+        title:
+          nominal_activity: Category Activity - Summary
+          nominal_activity_detail: 'Category Activity - Detailed: %{context_string}'
+          receipts_and_payments_day_book: Income and Expense Day Book
+      advanced_uk/reports/financial_statements/report:
+        message:
+          link: " Category Activity report "
+      advanced_uk/summary:
+        help:
+          index: start_summary
+        info:
+          index: ''
+        link:
+          help:
+            text: sageone.com/support
+      fuji_banking/bank_accounts:
+        title:
+          index: Banking
+      fuji_core_accounting/ledger_accounts:
+        info:
+          index: Create, view and manage your categories. Select existing categories
+            to view or change the areas they are visible in, or create new categories
+            for improved analysis.
+      journals:
+        info:
+          index: Create, view and manage your journals to directly update or move
+            values between categories.
+      outstanding_invoices:
+        one: "%{number_of_oustanding_invoices} invoice to be paid"
+        other: "%{number_of_oustanding_invoices} invoices to be paid"
+      sop_settings/default_settings:
+        chart_of_accounts:
+          list_order:
+            choice_code: Number
+            choice_name: Description
+            label: Sort order for lists
+        expenses_other_payment_ledger_account: Default for expenses
+        help: When you create new income or expenses, these categories are already
+          selected for you to make entry faster. You can still change them each time.
+        incomes_other_receipt_ledger_account: Default for income
+        invoice_sales_discount_ledger_account: Default for sales discounts
+        invoice_sales_ledger_account: Default for sales
+        title:
+          default: Default Categories
+      sop_settings/financial_settings:
+        info:
+          show: Record your financial details including VAT scheme information, financial
+            year end and the start date for transactions.
+      sop_settings/nominal_opening_balances:
+        info:
+          show: Record the balances of your categories from your previous accounting
+            system. Opening balances already entered through the customer, supplier
+            or bank opening balance options appear automatically. You can enter or
+            amend these by clicking each line. Each debit or credit balance is offset
+            against the opening balance control account, and when the full trial balance
+            is entered, this account should be zero.
+        title:
+          show: Category Opening Balances
+      sop_settings/settings:
+        help:
+          index: start_settings
+    quick_start:
+      description: Let's get set up in less than a minute
+      fields:
+        business_name:
+          hint: We'll put this on your reports automatically
+        business_type:
+          hint: Accounting Start is great for essential accounting - if your company
+            has lots of activity, find out if <u>Accounting</u> might be right for
+            you.
+      tax_scheme:
+        cash_accounting:
+          description: VAT is applied on money in or money out
+        flat_cash:
+          description: A flat VAT rate is applied on money in or money out
+    recurrence:
+      dialog:
+        fields:
+          label: Repeats every...
+      link:
+        edit: Edit Repeat
+        stop: Stop Repeat
+      notifications:
+        delete: Repeat deleted
+        set: Repeat set
+      payment: Money Out
+      receipt: Money In
+      title: "%{prefix} Recurring"
+    reporting:
+      cash_flow_statement_detail:
+        customer: Name
+        other_payments: Money Out
+        other_receipts: Money In
+        supplier: Name
+      cash_flow_summary:
+        liability_title: Owed to others
+      cash_reports:
+        description: Make your cash flow work for you!
+        receipts_and_payments_day_book_title: Income and Expense Day Book
+      detail_reports:
+        description: Clever stuff for your accountant or bookkeeper.
+        nominal_activity_title: Category Activity
+        title: ADVANCED REPORTS
+      export_dialog:
+        nominal_activity:
+          download: Category Activity (%{file_type})
+        nominal_activity_detail:
+          download: Category Activity Detail (%{file_type})
+        nominal_activity_transaction:
+          download: Category Activity Detailed (%{file_type})
+        receipts_and_payments_day_book:
+          download: Income and Expense Day Book (%{file_type})
+        title:
+          nominal_activity: Category Activity
+          nominal_activity_detail: Generate Category Activity - Detailed Report
+          nominal_activity_transaction: Generate Detailed Category Activity Report
+          receipts_and_payments_day_book: Generate Income and Expense Day Book
+      index_descriptions:
+        chart_of_accounts: What categories are set up?
+        nominal_activity: What transactions took place for each category?
+        trial_balance: What is the balance for each category?
+      index_sub_descriptions:
+        chart_of_accounts: 'Shows: A list of your categories, their type and tax rate.'
+        nominal_activity: 'Shows: Balances for each category for a given date range.'
+        trial_balance: 'Shows: Balance for each of your categories, for a given date
+          range.'
+      management:
+        description: How good is business? We’ll crunch the numbers for you.
+      nominal_activity:
+        category: Type
+        filename: category_activity
+        ledger_account: Category
+      nominal_activity_detail:
+        filename: category_activity_detailed
+      nominal_activity_transaction:
+        filename: category_activity_detail
+      receipts_and_payments_day_book:
+        filename: income_and_expense_day_book
+        title: Income and Expense Day Book
+        transaction_type_group: Income/Expense
+        transaction_type_group_values:
+          expense: Expense
+          income: Income
+          payments: Expense
+          receipts: Income
+      remote_reports:
+        category_activity: Category Activity
+        category_activity_detail: Category Activity - Detailed
+        category_activity_detailed: Category Activity - Detailed
+        income_and_expense_day_book: Income and Expense Day Book
+      sales_invoicing:
+        title: Invoices
+      tax_reports:
+        description: Keeping HMRC happy.
+      trial_balance:
+        ledger_account: Category Name
+        name: Category Name
+        nominal_code: Category Code
+      unreconciled_bank_transactions:
+        payment: Paid
+        receipt: Received
+    settings:
+      email_defaults:
+        email_defaults:
+          desc: Save time by setting up default email messages to use when sending
+            documents. You can easily customise these messages whenever you email
+            an invoice
+        pdf_attached:
+          desc: When sending an email we can automatically include a pdf version of
+            your invoice. Do you want us to do this?
+    sop_settings:
+      nominal_opening_balances:
+        link_text: Category Opening Balances
+    tabs:
+      titles:
+        fuji_contacts/contacts:
+          addresses: Address
+  migration:
+    mailer:
+      completed:
+        actions:
+          login_to_new:
+            html: Log in to New Account
+            text: 'Log in to New Account:'
+          login_to_old:
+            html: Back to Old Account
+            text: 'Back to Old Account:'
+        closing:
+          html: Thanks,<br>Sage Business Cloud Team
+          text: |-
+            Thanks,
+            Sage Business Cloud Team
+        footer:
+          html: The Sage Group plc
+          text: The Sage Group plc
+        greeting:
+          html: Hi %{name},
+          text: Hi %{name},
+        main_message:
+          part_1:
+            html: Thanks for waiting - your upgrade is now complete, and you're ready
+              to log in<br>to the latest version of Compta & Facturation!
+            text: |-
+              Thanks for waiting - your upgrade is now complete, and you're ready to log in
+              to the latest version of Compta & Facturation!
+          part_2:
+            html: You can still view your old data, but you can't make changes.<br>Deactivate
+              your old account when you're ready, so you'll no longer pay its<br>monthly
+              subscription.
+            text: |-
+              You can still view your old data, but you can't make changes.
+              Deactivate your old account when you're ready, so you'll no longer pay its
+              monthly subscription.
+        subject: Your upgrade is complete
+        title:
+          html: Your upgrade is complete!
+          text: Your upgrade is complete!
+      contact_link:
+        html: For any question, contact customer support by email at <a href='mailto:serviceclientsageone@sage.com'>serviceclientsageone@sage.com</a>
+          or by phone at 0 825 95 00 70.
+        text: |-
+          For any question, contact customer support by email at serviceclientsageone@sage.com
+          or by phone at 0 825 95 00 70.
+      failed:
+        closing:
+          html: Thanks,<br>Sage Business Cloud Team
+          text: |-
+            Thanks,
+            Sage Business Cloud Team
+        footer:
+          html: The Sage Group plc
+          text: The Sage Group plc
+        greeting:
+          html: Hi %{name},
+          text: Hi %{name},
+        main_message:
+          part_1:
+            html: It looks like your data is a little more complex than usual, so
+              it can’t be<br> upgraded automatically.
+            text: It looks like your data is a little more complex than usual, so
+              it can’t be upgraded automatically.
+          part_2:
+            html: So you can continue working, we’ve left your data in your existing
+              account.
+            text: So you can continue working, we’ve left your data in your existing
+              account.
+          part_3:
+            html: We will contact you when we have more information.
+            text: We will contact you when we have more information.
+        subject: We’ve had to stop your upgrade.
+        title:
+          html: Sorry about this, we've had to cancel your<br> upgrade.
+          text: Sorry about this, we've had to cancel your upgrade.
+      help_link:
+        html: For help and information, <a href="https://www.sageone.fr/nouvelle-version/">view
+          our guide</a>.
+        text: 'For help and information, view our guide: https://www.sageone.fr/nouvelle-version/'
+    user_admin:
+      bdp: Business migrated via BDP on %{date}, from %{product} %{product_version},
+        source tool %{tool} %{tool_version}.
+  mobile:
+    complete_setup:
+      ready: We now have enough information for you to start using Accounting
+    fieldsets:
+      business_name: 'My Business Name:'
+      your_details: 'My Details:'
+      your_email: 'My Email Address:'
+    get_started:
+      launch_demo: Have a go with the demo
+      login: Log In
+      login_help: Already have an account?
+      or: or
+      register: Sign Up
+      register_help: New to Accounting?
+    login:
+      errors:
+        auth_error:
+          access_denied: Please log in and accept the required permissions.
+          default: Please log in or sign up to Sage Business Cloud Accounting.
+          title: Authentication failed
+          user_denied: Please log in and accept the required permissions.
+        unlinked_account:
+          description: Please log in with a different account or sign up to Sage Business
+            Cloud Accounting.
+          title: Unable to authenticate account
+    placeholders:
+      business_name: Business Name
+      email: Email Address
+      user_first_name: First Name
+      user_last_name: Last Name
+    providers:
+      facebook: Facebook
+      google: Google
+    signup:
+      create_account: Create an Account
+      create_account_dev: Create an Account (Developer)
+      errors:
+        auth_already_exists: A user already exists with this authentication.
+      or_use_auth_provider: 'Or sign up with one of the following:'
+      terms_and_conditions:
+        acceptance: 'I agree to the %{link}:'
+        link: terms of use
+  multi_currency:
+    allocations:
+      error: You cannot allocate invoices and credit notes with different exchange
+        rates. You should edit the documents you want to allocate, and update the
+        exchange rates to ensure both use the same exchange rate.
+      title: Exchange Rate Difference
+      warning: The invoices and credit notes you are allocating have different exchange
+        rates. This may result in an imbalance between the currency value and base
+        value of your contact's account. Do you wish to proceed?
+    currency: Currency
+    exchange_rate: Exchange Rate
+  multi_tabs:
+    notes_title: Notes
+    terms_and_conditions_title: Terms and Conditions
+    voided_title: Void Reason
+  n_a: N/A
+  new_account_dialog:
+    account_name_prompt: e.g. Lloyds Current Account
+    address: Address
+    contact_details: Contact Details
+    starting_balance_source_placeholder: This transaction will be posted to Opening
+      Balances Control Account (9998)
+  notifications:
+    advanced_uk/category:
+      failure:
+        create: 'There was a problem creating the category: %{category_errors}'
+        delete: There was a problem deleting the selected categories.
+        update: 'There was a problem updating the category: %{category_errors}'
+      success:
+        delete: The selected categories have been deleted successfully
+    advanced_uk/sage_pay_notification:
+      messages:
+        multiple_transactions: There are %{transaction_count} transactions ready to
+          import from Sage Pay
+        single_transaction: There is %{transaction_count} transaction ready to import
+          from Sage Pay
+    advanced_uk/sage_pay_payment:
+      failure:
+        invoice: 'There was a problem with the Sage Pay MOTO payment: %{sage_pay_error}'
+        invoice_allocation: Sage Pay MOTO payment cannot be allocated to this invoice
+        payment: 'There was a problem with the Sage Pay MOTO payment: %{sage_pay_error}'
+        payment_allocation: Sage Pay MOTO payment cannot be allocated to this payment
+      problem:
+        transaction: Your payment has been processed successfully, but there has been
+          an issue displaying the confirmation page. If you require any further information,
+          please contact the vendor.
+        transaction_title: Sage Pay Payment Problem
+      success:
+        invoice: Sage Pay MOTO payment was successfully created for this Invoice
+        payment: Sage Pay MOTO payment was successfully created for this Payment
+      warning:
+        modifications:
+          payment: Received via Sage Pay - Any changes made to this payment will not
+            be reflected in your Sage Pay account. Some changes may result in the
+            entry no longer being flagged as received via Sage Pay.
+          receipt: Received via Sage Pay - Any changes made to this receipt will not
+            be reflected in your Sage Pay account. Some changes may result in the
+            entry no longer being flagged as received via Sage Pay.
+    advanced_uk/sage_pay_vendor:
+      success:
+        ecommerce_enabled: Edited Sage Pay Settings Successfully.  Your Sage Pay transactions
+          will be imported daily.  It may take up to 24 hours for your first transactions
+          to be ready to import.
+    core_accounting/tax_profiles:
+      success:
+        update: Tax settings saved successfully
+    core_accounting/tax_rate:
+      success:
+        create: Tax Rate saved successfully
+        update: Tax Rate updated successfully
+    email_defaults:
+      reset_email: Email reply address set back to use logged in user's email address.
+    failure:
+      payment_not_found: Payment not found.
+      user_already_activated: User already activated.
+      user_not_in_sageid: User's auth provider is not SageID. No E-Mail has been sent.
+    fuji_contacts/contacts:
+      changes_saved: Changes Saved
+      created_address: Successfully Created New Address
+      created_individual: Successfully Created New Individual
+      deleted_address: Successfully Deleted Address
+      deleted_individual: Successfully Deleted Individual
+      updated_account_details: Successfully Updated Account Details
+      updated_address: Successfully Updated Address
+      updated_analysis_types: Successfully Updated Analysis Types
+      updated_contact: Successfully Updated Contact
+      updated_individual: Successfully Updated Individual
+      updated_notes: Successfully Updated Notes
+      updated_payment_details: Successfully Updated Payment Details
+      updated_statement_settings: Successfully Updated Statement Settings
+    fuji_invoicing/purchase_corrective_invoice:
+      failure:
+        disputed: Paid Purchase Corrective Invoices cannot be disputed.
+      success:
+        cleared_disputed: Purchase Corrective Invoice Dispute Cleared Successfully.
+        disputed: Purchase Corrective Invoice Disputed Successfully.
+    fuji_invoicing/purchase_credit_note:
+      failure:
+        disputed: Paid Purchase Credit Notes cannot be disputed.
+      success:
+        cleared_disputed: Purchase Credit Note Dispute Cleared Successfully.
+        disputed: Purchase Credit Note Disputed Successfully.
+    fuji_invoicing/purchase_invoice:
+      failure:
+        disputed: Paid Purchase Invoices cannot be disputed.
+      success:
+        cleared_disputed: Purchase Invoice Dispute Cleared Successfully.
+        disputed: Purchase Invoice Disputed Successfully.
+    fuji_invoicing/sales_estimate:
+      failure:
+        declined: Draft and invoiced sales estimates cannot be declined.
+      success:
+        declined: Sales Estimate Declined Successfully.
+        undeclined: Sales Estimate Cleared Declined Successfully.
+    fuji_invoicing/sales_quote:
+      failure:
+        declined: Draft and invoiced sales quotes cannot be declined.
+      success:
+        declined: Sales Quote Declined Successfully.
+        undeclined: Sales Quote Cleared Declined Successfully.
+    notice:
+      title: 'Information: '
+    success:
+      delete_activity: Payment deleted successfully
+      email: "%{model} emailed successfully."
+      email_monthly_statement: Monthly Statement option has been saved
+      finish: This Bank Reconciliation has been successfully finished
+      interest_and_charges: Interest and Charges created
+      pay: VAT payment has been successfully created
+      payment_refunded: Payment successfully refunded.
+      payment_unallocated: Payment successfully unallocated.
+      reclaim: VAT reclaim has been successfully created
+      reconcile_all: All entries have been reconciled
+      reconcile_entry: The entry has been reconciled
+      reorder: Accounts reordered successfully.
+      resend_activation: An activation email has been sent to this user.
+      save: Saved %{model} Successfully
+      show: Edited %{model} Successfully
+      unreconcile_all: All entries have been unreconciled
+      unreconcile_entry: The entry has been unreconciled
+      verify: Email reply address changed successfully.
+  number:
+    currency:
+      format:
+        currency_code:
+          AUD: "$"
+          BGN: лв
+          BRL: R$
+          CAD: "$"
+          CHF: CHF
+          CNY: "¥"
+          CZK: Kč
+          DKK: kr
+          EUR: "€"
+          GBP: "£"
+          HKD: "$"
+          HRK: kn
+          HUF: Ft
+          IDR: Rp
+          ILS: "₪"
+          INR: "₹"
+          JPY: "¥"
+          KRW: "₩"
+          MXN: "$"
+          MYR: RM
+          NOK: kr
+          NZD: "$"
+          PHP: "₱"
+          PLN: zł
+          RON: lei
+          RUB: руб
+          SEK: kr
+          SGD: "$"
+          THB: "฿"
+          TRY: "₺"
+          USD: "$"
+          ZAR: R
+        unit_html: "&pound"
+  online_payment:
+    allow_online_payment: Allow customer to pay this invoice online
+    auto_refund_warning: Payments processed with %{providers} are automatically refunded.  Are
+      you sure you wish to delete this bank activity?
+    buttons:
+      alert:
+        timeout: You’ve already attempted to make a payment. To avoid duplicate payments
+          you must wait %{timeout} before trying again.
+        title: 'Alert:'
+      prompt:
+        default: 'Payment options:'
+        owner: Process Payment
+    disable: Disable
+    edit_delete_payment_warning:
+      one: It is strongly recommended that you do not modify this payment transaction.
+        It was created from a transaction processed outside of Accounting and may
+        not match the original value if modified.  Before editing this transaction,
+        review the details from your payment processor. Failure to do so may result
+        in inconsistent transaction details.
+      other: It is strongly recommended that you do not modify these payment transactions.
+        They were created from transactions processed outside of Accounting and may
+        not match the original value if modified.  Before editing these transaction,
+        review the details from your payment processor. Failure to do so may result
+        in inconsistent transaction details.
+    email:
+      message:
+        invoice:
+          greeting: Hello %{recipient},
+          parting: Thanks!
+        payment:
+          full: You have paid Invoice# %{invoice} in full. The amount paid was $%{amount}.
+          greeting:
+            default: Hello %{recipient},
+            owner: Dear %{recipient},
+          log_in: log into Sage Business Cloud Accounting
+          owner: We thought you would like to know that your customer, %{cus_bus_name}
+            made an online payment of $%{amount} for invoice %{invoice}. You can
+          owner_end: to view invoice and payment details.
+          partial: You have paid $%{amount} towards Invoice# %{invoice}. The remaining
+            balance is $%{balance}.
+          parting:
+            default: Thank you for your payment!
+            owner: The Sage Business Cloud Accounting Team
+      subject:
+        invoice: Invoice# %{invoice} from %{business}
+        payment: Payment confirmation for Invoice# %{invoice} from %{business}
+      view:
+        html: View this invoice.
+        text: To view this invoice, copy the link and paste it into your browser address
+          bar.
+      view_and_pay:
+        html: View and pay this invoice.
+        text: To view and pay this invoice, copy the link and paste it into your browser
+          address bar.
+    errors:
+      expired:
+        message: Access to your invoice has expired. In order to regain access you
+          will need to have the invoice resent to you.
+        title: Access Unavailable
+      non_refundable: Paid through a non-refundable provider
+      not_setup: Payment provider is not set up for use
+      voided:
+        message: This invoice has been deleted and is no longer available.
+        title: Access Unavailable
+    in_progress: Your payment can not be processed. Payment of this invoice has been
+      recently attempted. For security reasons there is a 20 minute waiting period
+      between attempts.
+    invoice_number: Invoice#
+    minute: minute
+    minutes: minutes
+    no_foreign_currency: Online payments are not available for invoices in foreign
+      currency. You may accept payment externally, then manually record the payment
+      in Accounting.
+    notification:
+      error:
+        ajax: Your invoice could not be processed. Please reload the page and try
+          again.
+    paid: This invoice is paid in full.
+    paypal:
+      bank_account_id: Default Bank Account
+      button:
+        default: PayPal
+      disable_confirm: Do you want to stop accepting payments through PayPal?
+      disable_success: You will now stop accepting payments through PayPal.
+      disable_title: Disable PayPal
+      email: PayPal Email
+      reference_prefix: 'PayPal: '
+      settings_logo: paypal_logo.png
+      settings_title: PayPal Account
+      title: PayPal
+    processing: Processing...
+    required_field: "* Required field"
+    save: Save PDF
+    select_or_type: Select or type to search
+    settings_subtitle: 'Account Settings:'
+    settings_success: Your changes have been saved.
+    sps:
+      aux_promo: Get immediate payment and reduce your collections by accepting electronic
+        payments from your customers!
+      bank_account_id: Default Bank Account
+      button:
+        default: Credit Card
+        single_owner: Process Credit Card
+      cannot_delete: We were unable to delete this transaction. Please try again later.
+      delete_payment:
+        error: Error deleting %{txn_id}. %{response}.
+      disable_confirm: Do you want to stop accepting payments through Paya?
+      disable_success: You will now stop accepting payments through Paya.
+      disable_title: Disable Paya
+      invalid_merchant: The account information entered for your Paya account is invalid.
+        Please re-enter this information in the Settings panel.
+      merchant_id: Merchant ID
+      merchant_key: Merchant Key
+      reference_prefix: 'Authorization #: '
+      report:
+        aux_title: Credit card transaction reports
+        description: View credit card reports in the Paya Virtual Terminal.
+        link_title: credit card transaction reports
+        title: Paya Reports
+      settings_logo: paya_logo.png
+      settings_title: Paya Account
+      signup:
+        get_started: Get Started Now
+        promo: Get paid faster by accepting credit card payments online.
+        sub_title: Existing Paya customer? Enter Merchant ID and Key.
+      title: Paya
+      view_report: View your %{link} in the Paya Virtual Terminal.
+    status:
+      approved: Congratulations! Your credit card payment for %{amount} has been approved.
+      button: Continue
+      continue: Don't worry - you can continue working and we'll automatically update
+        your invoice as soon as your payment is finished processing.
+      declined: We're sorry, but your payment has been declined.
+      description: We'll update your invoice automatically.
+      error: We're sorry, there was an error processing your payment.
+      please_wait: Please wait
+      taking_longer: We're sorry, it's taking longer than expected to process your
+        payment.
+      timeout: Your payment transaction has timed out. Please try again.
+      title: Processing your payment
+    title:
+      invoice: View Invoice
+      link_desc: Manage your Paypal and Paya settings.
+      sales_corrective_invoice: View Invoice
+      sales_credit_note: View Credit Note
+      sales_estimate: View Estimate
+      sales_invoice: View Invoice
+      sales_quote: View Quote
+      settings: Paypal and Paya
+    unknown: An unexpected error has occurred. Please contact customer support at
+      %{support}.
+  opening_balance:
+    add_itemised_opening_balances: Add itemised opening balances
+    title: Opening Balance
+  page_info:
+    advanced_uk/batches:
+      alert:
+        cross_border_contact:
+          message: You cannot record Quick Entries for Cross Border contacts. To correctly
+            deal with VAT when recording cross border transactions, you must use the
+            Invoice or Credit Note Option. Delete these lines and resave.
+        foreign_currency_contact:
+          message: You cannot record Quick Entries for this contact. To correctly
+            deal with foreign currency transactions, you must use the Invoice or Credit
+            Note option.
+        retailer_contact:
+          message: |
+            You can't create quick entries for this customer, because you need to charge equivalence surcharge.
+
+            To calculate the right VAT, create an Invoice or Corrective Invoice instead.
+          title: Customer with recargo
+    advanced_uk/catalog_items:
+      help:
+        data_import: extra_products_and_services_import
+        default: Products & Service
+        index: extra_products_and_services_list
+      info:
+        default: If you have Products or Services that you sell frequently, to save
+          you typing the details into an invoice repeatedly, record them here.
+        index: Create, view and manage records of the products or services that you
+          sell.
+      title:
+        default: Products & Services
+        index: Products & Services
+    advanced_uk/categories:
+      title:
+        default: Categories
+        edit: Edit Category
+        index: Manage Categories
+        new: Create New Category
+    advanced_uk/customer_allocations:
+      help:
+        new: extra_account_allocations
+      info:
+        new: Allocate outstanding invoices, credit notes and payments on account together
+          without recording a receipt. The date of the most recent transaction being
+          allocated will be used as your allocation date.
+      title:
+        new: 'Account Allocation: %{context_string}'
+        show: 'Account Allocation: %{context_string}'
+    advanced_uk/customer_income_payments:
+      help:
+        show: extra_customer_receipts
+      info:
+        show: Record money received from your customers and allocate it to one or
+          more outstanding invoices, or save it as a payment on account to allocate
+          later.
+      negative_payment_message:
+        allocated:
+          text: This is a negative payment that has been allocated to an invoice.
+            This negative payment was created in a previous system as you cannot create
+            or change negative payments in Accounting.
+          title: Allocated Negative Payment
+        identified:
+          text: Negative payments allocated to invoices are included here. These negative
+            payments were created in a previous system. You cannot create or change
+            negative payments in Accounting.
+          title: Negative Payments Identified
+        link: Read more about this.
+      title:
+        create: Receipt
+        default: Customer Receipt
+    advanced_uk/customer_refund_payments:
+      help:
+        show: extra_customer_refunds
+      info:
+        show: Record money paid to your customers to refund outstanding credit notes,
+          or return a payment on account.
+      title:
+        create: Payment
+        default: Customer Refund
+    advanced_uk/direct_payment:
+      title:
+        default: Direct Payment
+    advanced_uk/global_tax_returns:
+      title:
+        default: VAT Returns
+    advanced_uk/income_tax_es:
+      help:
+        index: modelo_130_return
+        new: modelo_130_return
+        show: modelo_130_return
+    advanced_uk/journal_codes:
+      help:
+        index: extra_journal_codes
+      info:
+        index: Create, show and manage journal codes.
+      title:
+        index: Journal Codes
+    advanced_uk/migration:
+      title:
+        default: Upgrade
+    advanced_uk/online_payment:
+      title:
+        show: ''
+    advanced_uk/opening_balances:
+      accounts_start_date: 'Accounts Start Date: '
+    advanced_uk/other_expense_payment_refunds:
+      alert:
+        message: You cannot record Other Payment Refunds for this contact. To correctly
+          deal with foreign currency transactions you must use the Invoice option.
+        title: Overseas Customer
+      alert_not_home:
+        message: You cannot record Other Payment Refunds for this contact. To correctly
+          deal with VAT for overseas contacts, you must use the Invoice option.
+        title: Overseas Customer
+      help:
+        show: banking_other_receipt_refund
+      info:
+        show: Record one-off purchase payments, such as a refund and other money you've
+          paid linked to a purchase where you haven't been issued a credit note.
+      link:
+        text: Enter a refund for a purchase
+      title:
+        create: Refund
+        default: Purchase Other Receipt (Incoming money)
+        show: Purchase Other Receipt (Incoming money)
+    advanced_uk/other_expense_payments:
+      alert:
+        message: You cannot record Other Payments for this contact. To correctly deal
+          with foreign currency transactions you must use the Invoice option.
+        title: Overseas Supplier
+      alert_not_home:
+        message: You cannot record Other Payments for this contact. To correctly deal
+          with VAT for overseas contacts, you must use the Invoice option.
+        title: Overseas Supplier
+      help:
+        show: extra_bank_payments_other_payments
+      info:
+        show: Record one-off payments, such as over the counter purchases, and other
+          money you've paid where you haven't received an invoice.
+      title:
+        create: Payment
+        default: Other Payment
+        show: Other Payment
+    advanced_uk/other_income_payment_refunds:
+      alert:
+        message: You cannot record Other Receipt Refunds for this contact. To correctly
+          deal with foreign currency transactions you must use the Invoice option.
+        title: Overseas Customer
+      alert_not_home:
+        message: You cannot record Other Receipt Refunds for this contact. To correctly
+          deal with VAT for overseas contacts, you must use the Invoice option.
+        title: Overseas Customer
+      help:
+        show: banking_other_payment_refund
+      info:
+        show: Record one-off sales payments, such as a refund and other money you've
+          paid linked to a sale where you haven't issued a credit note.
+      link:
+        text: Enter a refund for a sale
+      title:
+        create: Refund
+        default: Sales Other Payment (Outgoing money)
+        show: Sales Other Payment (Outgoing money)
+    advanced_uk/other_income_payments:
+      alert:
+        message: You cannot record Other Receipts for this contact. To correctly deal
+          with foreign currency transactions you must use the Invoice option.
+        title: Overseas Customer
+      alert_not_home:
+        message: You cannot record Other Receipts for this contact. To correctly deal
+          with VAT for overseas contacts, you must use the Invoice option.
+        title: Overseas Customer
+      help:
+        show: extra_bank_receipts_other_receipts
+      info:
+        show: Record one-off receipts, such as for over the counter sales, and other
+          money you've received without issuing an invoice.
+      title:
+        create: Receipt
+        default: Other Receipt
+        show: Other Receipt
+    advanced_uk/part_payments:
+      allocation_warning:
+        payment:
+          message: The value of selected items exceeds the total payment value. Reduce
+            the allocated amount by deselecting or part paying selected items.
+        receipt:
+          message: The value of selected items exceeds the total receipt value. Reduce
+            the allocated amount by deselecting or part paying selected items.
+        refund:
+          message: The value of selected items exceeds the total refund value. Reduce
+            the allocated amount by deselecting items or increase the total refund
+            amount.
+        title: 'Warning: '
+      credits_warning:
+        message: Allocation of credits should be entered as a negative value.
+        title: 'Note: '
+      saved_allocation_warning: You are editing a saved allocation
+    advanced_uk/payments:
+      add_another: Add Another
+      help:
+        extra_error_corrections: extra_error_corrections
+        recurrence: extra_bank_recurring_entries
+        remove_cleared_status: remove_cleared_status
+      info:
+        modifications:
+          headers:
+            multi:
+              bank_and_cleared:
+                editable: 'You can only make limited changes because this transaction
+                  is:'
+              bank_and_excluded:
+                editable: 'You can only make limited changes because this transaction
+                  is:'
+              bank_and_tax:
+                editable: 'You can only make limited changes because this transaction
+                  is:'
+              cleared_and_excluded:
+                editable: 'You can only make limited changes because this transaction
+                  is:'
+              cleared_and_tax:
+                editable: 'You can only make limited changes because this transaction
+                  is:'
+              default:
+                editable: 'You can only make limited changes because this transaction
+                  is:'
+            single:
+              bank_reconciled:
+                editable: You can only make limited changes because this transaction
+                  was bank reconciled on the statement dated %{bank_reconciliation_date}.
+              cleared:
+                editable: You can only make limited changes because this transaction
+                  is marked as cleared in your bank account.
+              locked:
+                uneditable: Transactions created by third-party integrations cannot
+                  be changed.
+              tax_excluded:
+                editable: You can only make limited changes because this transaction
+                  was manually excluded when VAT Return %{return_no} was calculated
+                  (covering %{date_from} to %{date_to}).
+              tax_included:
+                editable: You can only make limited changes because this transaction
+                  is included on VAT Return %{return_no} (covering %{date_from} to
+                  %{date_to}).
+              uneditable:
+                uneditable: You can’t edit this transaction as it has an associated
+                  payment or refund.
+          help_link:
+            bank_reconciled:
+              text: Get help with corrections.
+              url: extra_error_corrections
+            cleared:
+              text: Get help on removing cleared status.
+              url: remove_cleared_status
+            corrections:
+              text: Get help with corrections.
+              url: extra_error_corrections
+            tax_excluded:
+              text: Get help on correcting VAT reconciled transactions.
+              url: extra_error_corrections
+            tax_included:
+              text: Get help on correcting VAT reconciled transactions.
+              url: extra_error_corrections
+            uneditable:
+              text: ''
+              url: ''
+          messages:
+            editable:
+              bank_reconciled: Bank reconciled on the statement dated %{bank_reconciliation_date}.
+              cleared: Marked as cleared in your bank account.
+              tax_excluded: Manually excluded from VAT Return %{return_no} (covering
+                %{date_from} to %{date_to}).
+              tax_included: On VAT Return %{return_no} (covering %{date_from} to %{date_to}).
+          titles:
+            multi:
+              bank_and_excluded: Transaction Excluded from VAT Return and Bank Reconciled
+              bank_and_tax: VAT and Bank Reconciled Transaction
+              cleared_and_excluded: Transaction Excluded from VAT Return and Cleared
+              cleared_and_tax: VAT Reconciled and Cleared Transaction
+              default: Only limited changes allowed
+            single:
+              bank_reconciled: Bank Reconciled
+              cleared: Cleared Transaction
+              locked: This transaction was created through an integration with another
+                service.
+              tax_excluded: Excluded from VAT Returns
+              tax_included: VAT Reconciled
+              uneditable: ''
+        recurrence: If you make payments and receipts on a regular basis you can set
+          them up as recurring entries.
+      pay_existing_invoice: "<a class='UILink' href='%{href}' data-tag='%{data_tag}'
+        data-role='%{data_tag}'>Pay an existing invoice</a> instead?"
+      print_remittance: Print Remittance
+      save: Save
+      title:
+        expense: Payment (Outgoing money)
+        income: Receipt (Incoming money)
+    advanced_uk/purchase_artefacts:
+      help:
+        index: extra_the_purchases_list
+      info:
+        index: Create, view and manage your purchase invoices and credit notes.
+      title:
+        default: Purchases
+    advanced_uk/purchase_batches:
+      alert:
+        message: You cannot record Quick Entries for this contact. To correctly deal
+          with foreign currency transactions, you must use the Invoice or Credit Note
+          option.
+        title: Overseas Supplier
+      help:
+        entries: extra_purchase_quick_entries_list
+        new: extra_purchase_quick_entries
+      import:
+        help:
+          data_import: extra_quick_entry_import
+      info:
+        entries: Create batch purchase transactions to quickly enter invoices and
+          credit notes from each supplier against a single ledger account, without
+          specifying a product.
+        new: Quickly record purchase invoices and credit notes as single lines on
+          the batch, choosing the appropriate details for each entry.
+        show: Quickly record purchase invoices and credit notes as single lines on
+          the batch, choosing the appropriate details for each entry.
+      title:
+        default: Quick Entries
+    advanced_uk/reports:
+      alert:
+        audit_trail:
+          drilldown_alert:
+            message: The selected entry has been deleted, and there are no subsequent
+              versions which can be viewed.
+            title: Deleted Entry
+        export:
+          error:
+            message: An error occurred generating the report.
+          failure:
+            message: You already have a report being generated
+          success:
+            message: Your report is being generated and a notification will appear
+              in the top bar when it is available
+          title: Report Generation
+      cash_flow_forecast:
+        text:
+          inbound_adjustments_dialog: 'Enter manual adjustments to include in forecast.  NB:
+            Entries dated prior to your forecast period will be included in the opening
+            balance figure.'
+          outbound_adjustments_dialog: 'Enter manual adjustments to include in forecast.  NB:
+            Entries dated prior to your forecast period will be included in the opening
+            balance figure.'
+          payroll_adjustments_dialog: 'Enter your estimated payroll costs. NB: Entries
+            dated prior to your forecast period will be included in the opening balance
+            figure.'
+        title:
+          inbound_adjustments_dialog: Adjustments In
+          outbound_adjustments_dialog: Adjustments Out
+          payroll_adjustments_dialog: Payroll costs
+      drilldown:
+        headers:
+          category: Category
+          closing_balance: Closing Balance
+          contact_name: Name
+          cr: Credit
+          credits: Total Credits
+          date: Date
+          debits: Total Debits
+          description: Description
+          display_name: Ledger Name
+          dr: Debit
+          invoice_number: Inv No
+          nominal_code: Nominal Code
+          opening_balance: Opening Balance
+          reference: Reference
+          running_total: Running Total
+          transaction_number: Trans Number
+          transaction_type: Type
+          variance: Variance
+        ledger_account: Account
+        rows:
+          closing_balance: 'Closing balance: %{end_date}'
+          opening_balance: 'Opening balance: %{start_date}'
+          variance: 'Variance:'
+        subheader: Up until %{end_date}
+        subheader_period: From %{start_date} to %{end_date}
+      help:
+        aged_creditors: extra_aged_creditors_report
+        aged_creditors_breakdown: extra_aged_creditors_report
+        aged_debtors: extra_aged_debtors_report
+        aged_debtors_breakdown: extra_aged_debtors_report
+        audit_trail: extra_audit_trail
+        audit_trail_summary: extra_audit_trail
+        balance_sheet: extra_management_reports
+        cash_flow_forecast: extra_cash_flow
+        cash_flow_forecast_detail: extra_cash_flow
+        cash_flow_forecast_prior_transactions: extra_cash_flow
+        cash_flow_statement_detail: extra_cash_flow
+        cash_flow_summary: extra_cash_flow
+        chart_of_accounts: chart_accounts_list
+        ec_sales: extra_ec_sales_analysis_report
+        index: extra_reports_index
+        invoice_profit_analysis: extra_profit_analysis_report
+        nominal_opening_balance: extra_opening_balances
+        profit_and_loss: extra_management_reports
+        purchase_day_book: extra_reports_purchase_daybook
+        purchase_day_book_detailed: extra_reports_purchase_daybook
+        receipts_and_payments_day_book: extra_reports_receipts_and_payments_daybook
+        return_of_trading_details: return_of_trading_details
+        sage_pay_ecommerce_payments: extra_sage_pay_ecommerce
+        sage_pay_payments: extra_sage_pay
+        sales_day_book: extra_reports_sales_daybook
+        sales_day_book_detailed: extra_reports_sales_daybook
+        trial_balance: extra_management_reports
+        unallocated_payments: extra_reports_unallocated_receipts_and_payments
+        unreconciled_bank_transactions: extra_unreconciled_bank_transactions_report
+      info:
+        aged_creditors: This report shows all outstanding or unallocated supplier
+          transactions, broken down by the ageing periods specified in Record and
+          Transactions Settings.
+        aged_creditors_breakdown: This report shows all outstanding or unallocated
+          supplier transactions, broken down by the ageing periods specified in Record
+          and Transactions Settings.
+        aged_debtors: This report shows all outstanding or unallocated customer transactions,
+          broken down by the ageing periods specified in Record and Transactions Settings.
+        aged_debtors_breakdown: This report shows all outstanding or unallocated customer
+          transactions, broken down by the ageing periods specified in Record and
+          Transactions Settings.
+        audit_trail: The audit trail breakdown is a detailed record of all transactions
+          posted. You can view this by transaction type for a specified date range.
+        audit_trail_selector: The audit trail report shows a summary or breakdown
+          of all transactions posted. You can view this by transaction type for a
+          specified date range.
+        audit_trail_summary: The audit trail summary is a record of all transactions
+          posted. You can view this by transaction type for a specified date range.
+        balance_sheet: The balance sheet shows what you own, your assets, and what
+          you owe, your liabilities.
+        cash_flow_forecast: View expected cash flow in and cash flow out for a future
+          date range, using recurrence date, or expected payment dates. Use this to
+          estimate when funds will come into or out of the business.
+        cash_flow_summary: Analyse your current financial position by viewing cash
+          flow into and out of selected bank accounts for a specified date range.  View
+          the detailed breakdown to see all entries affecting the selected banks in
+          that period.
+        chart_of_accounts: Use this report to view and export a list of your ledger
+          accounts.
+        contact_personal_data: This report provides you with a list of contacts whose
+          personal data is now outside of the retention period for accounting records.
+          You can remove contacts' data from this list.
+        ec_sales: This report shows all EC Sales transactions within a specified period.  Use
+          this report to help you complete your EC Sales List on HMRC's website.
+        index: Use reports to view your company and financial information at a glance.
+        invoice_profit_analysis: This report analyses the profit on your sales invoices
+          and quotations using the cost price and sales price of your products.
+        nominal_opening_balance: Record the balances of your ledger accounts from
+          your previous accounting system. Opening balances already entered through
+          the customer, supplier or bank opening balance options appear automatically.
+          You can enter or amend these by clicking each line. Each debit or credit
+          balance is offset against the opening balance control account, and when
+          the full trial balance is entered, this account should be zero.
+        profit_and_loss: This report shows your business income and expense, giving
+          the profit for your chosen date range.
+        purchase_day_book: This report shows purchase transactions for a specified
+          date range. You can view a certain transaction type, or all of your purchase
+          transactions, listed in date order.
+        purchase_day_book_detailed: This report shows detailed purchase transactions
+          for a specified date range. You can view a certain transaction type, or
+          all of your purchase transactions, listed in date order.
+        receipts_and_payments_day_book: This report shows receipt or payment transactions
+          for a selected bank account, for a specified date range.
+        sage_pay_ecommerce_payments: This is where you can view imported Sage Pay
+          ecommerce payments.
+        sage_pay_payments: This is where you can view invoice payments received via
+          Sage Pay.
+        sales_day_book: This report shows sales transactions for a specified date
+          range. You can view a certain transaction type, or all of your sales transactions,
+          listed in date order.
+        sales_day_book_detailed: This report shows detailed sales transactions for
+          a specified date range. You can view a certain transaction type, or all
+          of your sales transactions, listed in date order.
+        sales_revenue_detailed: This report shows the sales revenue for products and
+          services.
+        sales_revenue_summary: This report shows the sales revenue for products and
+          services.
+        sales_tax: This report shows a summary of the total sales tax due for each
+          tax rate.
+        sales_tax_breakdown: This report shows a breakdown of sales tax per rate per
+          artefact.
+        stock_movement_detailed: This report shows the stock movements for a specified
+          stock item for a given date range.
+        stock_movement_summary: This report shows the quantities received and dispatched
+          for each stock item.
+        summary: Welcome to Sage One Accounts. This summary screen allows you to keep
+          an eye on your financial status and your bank history.
+        tax_return: This report will submit VAT Returns to the HMRC.
+        trial_balance: This report displays the balance on your nominal accounts for
+          a specified date range. You can include brought forward values and include
+          current year’s profit and loss values only.
+        trial_balance_with_year_end_enabled: View the balance on your ledger accounts
+          for a specific date range - if viewing prior year values, your financial
+          year end journals will be excluded from the figures displayed.
+        unallocated_payments: This report shows receipts or payment transactions from
+          contacts that are not fully allocated.
+        unreconciled_bank_transactions: This report shows all unreconciled bank transactions.  You
+          can view these transactions by bank account up to a specified date.
+      notes:
+        accounting_type_indicator: 'Your current accounting type is: '
+      pod:
+        cash_flow:
+          description: Use these reports to analyse your cash flow in and cash flow
+            out for current and future periods.
+          title: Cash Flow
+      title:
+        aged_creditors: Aged Creditors Report
+        aged_creditors_breakdown: Aged Creditors Breakdown
+        aged_debtors: Aged Debtors Report
+        aged_debtors_breakdown: Aged Debtors Breakdown
+        audit_trail: Audit Trail Breakdown
+        audit_trail_summary: Audit Trail
+        balance_sheet: Balance Sheet Report
+        cash_flow_forecast: Cash Flow Forecast Report
+        cash_flow_forecast_detail: Cash Flow Forecast - Detailed Breakdown
+        cash_flow_forecast_prior_transactions: Cash Flow Forecast - Expected Prior
+          Cash Flow Detailed Breakdown
+        cash_flow_statement_detail: Cash Flow Statement - Detailed Breakdown
+        cash_flow_summary: Cash Flow Statement Report
+        chart_of_accounts: Chart of Accounts List
+        contact_personal_data: Contacts Personal Data
+        ec_sales: EC Sales List
+        index: Reports
+        invoice_profit_analysis: Profit Analysis
+        ledger_entries: Ledger Entries
+        profit_and_loss: Profit and Loss Report
+        purchase_day_book: Purchase Day Book Report
+        purchase_day_book_detailed: Purchase Day Book - Detailed
+        receipts_and_payments_day_book: Receipts and Payments Day Book Report
+        sage_pay_ecommerce_payments: Ecommerce Payments
+        sage_pay_payments: Payments Received
+        sales_day_book: Sales Day Book Report
+        sales_day_book_detailed: Sales Day Book - Detailed
+        sales_revenue_detailed: Sales Revenue Detailed - Products & Services
+        sales_revenue_summary: Sales Revenue - Products & Services
+        sales_tax: Sales Tax Report
+        sales_tax_breakdown: Sales Tax Breakdown
+        stock_movement_detailed: 'Stock Movement Detailed: %{context_string}'
+        stock_movement_detailed_export: Stock Movement Detailed
+        stock_movement_summary: Stock Movement Summary Report
+        summary: Summary
+        trial_balance: Trial Balance Report
+        unallocated_payments: Unallocated Receipts or Payments
+        unreconciled_bank_transactions: Unreconciled Bank Transactions
+    advanced_uk/reports/auxiliary_balance:
+      help:
+        auxiliary_balance: extra_management_reports
+      info:
+        auxiliary_balance: Allows you to see the results of your business and the
+          balance of each subaccounts at a given time.
+      title:
+        auxiliary_balance: Auxiliary Balance
+    advanced_uk/reports/cashbook_reports:
+      help:
+        cashbook: cashbook_report
+      info:
+        cashbook: This report shows receipts, payments and balances for the selected
+          bank account.
+      title:
+        cashbook: Cashbook Report
+      tooltip:
+        cashbook: 'Shows: Receipts, payments and balances for a selected bank account.'
+    advanced_uk/reports/financial_statements/report:
+      help:
+        balance_statement: extra_management_reports
+        income_statement: extra_management_reports
+      info:
+        balance_statement: How much is my business worth?
+        balance_statement_with_year_end_enabled: View the value of your business at
+          a specific date – if viewing prior year values, your financial year end
+          journals will be excluded from the figures displayed.
+        income_statement: How profitable was my business this period?
+        income_statement_with_year_end_enabled: View the profitability of your business
+          during a specific period - if viewing prior year values, your financial
+          year end journals will be excluded from the figures displayed.
+      message:
+        content_1: A technical problem means we can’t show you the figures that make
+          up the item you’ve selected right now - please try again later.
+        content_2: In the meantime, the
+        content_3: might be useful.
+        link: " Nominal Activity report "
+        title: Sorry about this...
+      title:
+        balance_statement: Balance Sheet
+        income_statement: Income Statement
+    advanced_uk/reports/income_tax:
+      help:
+        income_tax_expense: income_tax_statement
+        income_tax_revenue: irpf_income_statement
+      info:
+        income_tax_expense: How much IRPF was withheld from my purchase invoices
+        income_tax_revenue: How much IRPF was withheld from my sales invoices
+      title:
+        income_tax_expense: IRPF withheld from my suppliers
+        income_tax_revenue: IRPF withheld from my customers
+    advanced_uk/reports/nominal_activity:
+      help:
+        nominal_activity: extra_nominal_activity_report
+        nominal_activity_detail: extra_nominal_activity_report
+      info:
+        nominal_activity: This report shows the nominal accounts with activity for
+          analysis codes in a given date range.
+        nominal_activity_detail: This report shows the transaction activity for specified
+          nominal account, analysis codes in a given date range.
+      title:
+        nominal_activity: Nominal Activity Report
+        nominal_activity_detail: 'Detailed Nominal Activity: %{context_string}'
+    advanced_uk/reports/sales_revenue/detailed:
+      help:
+        sales_revenue_detailed: extra_sales_revenue_report
+      title:
+        sales_revenue_detailed: Sales Revenue Detailed - Products & Services
+    advanced_uk/reports/sales_revenue/report:
+      help:
+        sales_revenue: extra_sales_revenue_report
+      title:
+        sales_revenue: Sales Revenue
+    advanced_uk/reports/stock_movements/detailed:
+      help:
+        stock_movements_detailed: extra_stock_movements
+      title:
+        stock_movements_detailed: Stock Movements Detailed
+    advanced_uk/reports/stock_movements/report:
+      help:
+        stock_movements: extra_stock_movements
+      title:
+        stock_movements: Stock Movements
+    advanced_uk/reports/vendors:
+      help:
+        vendors: 1099_vendor_report
+      info:
+        vendors: This report gives you your total payments for each of your 1099 Vendors
+          for the year, to help you fill out a 1099 Misc Form when this is required.
+      title:
+        vendors: 1099 Vendor Report
+      tooltip:
+        vendors: How much have I paid my 1099 Vendors?
+    advanced_uk/sales_artefacts:
+      help:
+        index: extra_sales_list
+      info:
+        index: Create, view and manage your sales invoices and credit notes.
+      title:
+        default: Sales
+        index: Sales
+    advanced_uk/sales_batches:
+      alert:
+        message: You cannot record Quick Entries for this contact. To correctly deal
+          with foreign currency transactions, you must use the Invoice or Credit Note
+          option.
+        title: Overseas Customer
+      help:
+        entries: extra_sales_quick_entries_list
+        new: extra_sales_quick_entries
+      import:
+        contact_overseas_error: You cannot record Quick Entries for Cross Border contacts.
+        help:
+          data_import: extra_quick_entry_import
+      info:
+        entries: Create batch sales transactions, without producing a physical invoice
+          or credit note.  For example, where you have a separate invoicing system
+          and just want to record the value of existing invoices.
+        new: Quickly record sales invoices and credit notes as single lines on a batch,
+          choosing the appropriate details for each entry.
+        show: Quickly record sales invoices and credit notes as single lines on a
+          batch, choosing the appropriate details for each entry.
+      title:
+        default: Quick Entries
+    advanced_uk/stripe_transactions:
+      help:
+        status: view_stripe_activity
+    advanced_uk/summary:
+      header:
+        index: Hi, <strong>%{name}</strong>
+      help:
+        index: extra_summary
+      info:
+        index: The Summary tab gathers key information about your business.
+      title:
+        index: Summary
+    advanced_uk/supplier_allocations:
+      help:
+        new: extra_account_allocations
+      info:
+        new: Allocate outstanding invoices, credit notes and payments on account together,
+          without recording a payment. The date of the most recent transaction being
+          allocated will be used as your allocation date.
+      title:
+        new: 'Account Allocation: %{context_string}'
+        show: 'Account Allocation: %{context_string}'
+    advanced_uk/supplier_expense_payments:
+      help:
+        show: extra_supplier_payments
+      info:
+        show: Record money paid to suppliers and allocate it to one or more outstanding
+          invoices, or save it as a payment on account to allocate later.
+      negative_payment_message:
+        allocated:
+          text: This is a negative payment that has been allocated to an invoice.
+            This negative payment was created in a previous system as you cannot create
+            or change negative payments in Accounting.
+          title: Allocated Negative Payment
+        link: Read more about this.
+      title:
+        create: Payment
+        default: Supplier Payment
+        show: Supplier Payment
+    advanced_uk/supplier_refund_payments:
+      help:
+        show: extra_supplier_refunds
+      info:
+        show: Record money received from suppliers to refund outstanding credit notes,
+          or return a payment on account.
+      title:
+        create: Receipt
+        default: Supplier Refund
+        show: Supplier Refund
+    advanced_uk/tax_returns:
+      action:
+        save_draft: Save this return and submit it later
+        save_online: Submit to HMRC by other means
+        submit_mtd: Submit online to HMRC
+        submit_online: Submit online to the Government Gateway
+      button_submit_later: Submit later
+      button_submit_online: Submit Online
+      confirm_dialog_message:
+        info: " before this date not yet included on any VAT return."
+        title: This tax return is from %{date}
+        transactions:
+          one: There is %{number} transaction
+          other: There are %{number} transactions
+      detailed_report: Detailed Report
+      draft_failed_tax_return_does_not_exist: Your changes cannot be saved because
+        another user has already submitted the return
+      draft_tax_return_for_tax_type_exists: Please complete or remove your current
+        draft tax return before creating a new one
+      draft_waiting_failed_tax_return_exists: You already have a draft, waiting or
+        failed tax return
+      excluded_transactions_message:
+        info: You chose to exclude %{tax_return_excluded_entries} %{transaction_text}
+          dated before %{tax_return_from_date} from this return.
+        transactions:
+          one: transaction
+          other: transactions
+      excluded_transactions_view_pdf: Excluded Prior Transactions
+      feedback_status_correlation: 'Correlation ID: %{correlation_id}'
+      feedback_status_format_date: Submitted %-d %b %Y at %-l:%M%P
+      feedback_status_format_user: " by %{username}"
+      feedback_status_migrated: This VAT return is based on data migrated from your
+        old accounting system, so you can't adjust, delete, or submit it to HMRC.
+      fix_help_link:
+        text: How do I fix this?
+        url: http://help.sageone.com/en_uk/accounting/vat-submission-errors.html
+      help:
+        index: extra_vat_return_uk
+        new: extra_vat_return_uk
+        show: extra_vat_return_uk
+      info:
+        index: 'Create, view and manage your VAT Returns. '
+        new: Select the date range for your VAT Return and click Calculate.  To view
+          transactions included on your return, click detailed report.
+        show: You're viewing an existing VAT Return.  To see how the VAT Return was
+          calculated, click detailed report.
+      must_be_taxable: You must be VAT Registered to do a VAT Return
+      prior_transactions_message:
+        exclude: "<strong>Never</strong> - Exclude them from all future returns."
+        include: "<strong>Now</strong> - Include them on this return."
+        info: "<strong>Would you like to include these transactions on your VAT return…</strong>"
+        note: 'NOTE: If you choose No, these transactions will be permanently excluded
+          from all VAT Returns. You should print and save the available report before
+          continuing.'
+        skip: "<strong>Later</strong> - Ask me again when I run my next return."
+      prior_transactions_pdf_contact_name: Contact Name
+      prior_transactions_pdf_date: Date
+      prior_transactions_pdf_net_amount: Net
+      prior_transactions_pdf_reference: Reference
+      prior_transactions_pdf_title: Previous Unreconciled Transactions
+      prior_transactions_pdf_title_excluded: Excluded Transactions
+      prior_transactions_pdf_total_amount: Total
+      prior_transactions_pdf_type: Type
+      prior_transactions_pdf_vat_amount: VAT
+      prior_transactions_title: Including Previous Transactions
+      prior_transactions_view_pdf: View Previous Transactions
+      settings_dialog:
+        tax_rate_label: What Flat Rate VAT Percentage applies to your business?
+        tax_submission_frequency_type_label: How often do you submit VAT Returns?
+        text: 'In order to calculate your VAT Return correctly, you need to provide
+          the following information:'
+        title: VAT Return Settings
+      summary_report_view_pdf: Print
+      tax_return_for_range_already_exists: "#TR There already exists a tax return
+        for the selected date range. Please use the correction button on the index
+        page to create a correction for a existing tax return."
+      title:
+        default: VAT Returns
+        hmrc_response: HMRC Response
+        index: VAT Return List
+        new: VAT Return
+        show: View VAT Report
+        status: 'Status: '
+    core_accounting/taxes:
+      tax_rates_manager:
+        title: Manage Tax Rates
+    email_dialog:
+      button: Send
+    fuji_banking/bank_accounts:
+      alert_dialogs:
+        messages:
+          default_account: One or more of the selected bank accounts is a default
+            bank account and cannot be deleted.
+        title:
+          default_account: Default Bank Accounts
+      assets:
+        all_accounts_icon: bank_accounts/all-accounts-icon.svg
+        bank_hour_glass_icon_color: bank_accounts/bank-hour-glass-icon-color.svg
+        bank_icon: bank_accounts/bank-icon.svg
+        bank_icon_color: bank_accounts/bank-icon-color.svg
+        cash_icon: bank_accounts/bank-cash-icon.svg
+        credit_card_icon: bank_accounts/bank-credit-card-icon.svg
+        credit_card_icon_color: bank_accounts/credit-card-icon-color.svg
+        safe_icon_color: bank_accounts/safe-icon-color.svg
+        stripe_icon_color: bank_accounts/stripe-icon-color.png
+        wallet_icon_color: bank_accounts/wallet-icon-color.svg
+      confirm_dialogs:
+        messages:
+          bank_transfer: Please note that both sides of a transfer will be removed.
+      help:
+        cheque_register: extra_pay_into_bank
+        deposit: extra_pay_into_bank
+        index: extra_bank_account_list
+        new: extra_bank_accounts_create
+        show: extra_bank_record
+        transfer: extra_transfer_funds_between_bank_accounts
+      info:
+        deposit: Record cash and cheques deposited into your current account, from
+          your cash in hand account.
+        index: Create, view and manage your bank accounts and banking transactions
+          such as payments, receipts and transfers.
+        landing_page: Add your bank accounts, credit cards and loans. Connect to your
+          online bank account to automatically import your transactions.
+        new: Record details of your new bank account.  You should only record an opening
+          balance here, if you're transferring from a different accounting system.
+        show: View your bank account details and account activity.  Use New Entry
+          to record new transactions for this bank account, or use the Reconcile option
+          to check entries on this account against your bank statement.
+        transfer: Record the transfer of money between your bank accounts.  This includes
+          payments from your bank account to a credit card or loan account.
+      opening_balances:
+        add: Add an opening balance
+        after_start:
+          a: To enter a balance on this account after your Start Date, create an Other
+            Payment transaction for the amount owed, or a Transfer to move a balance
+            from another card.
+          b: If there was an opening balance on this account prior to you starting
+            to use Accounting, select a date prior to %{start_date} and record an
+            opening balance.
+        balance: Balance (%{currency_symbol})
+        balance_today: Today's Balance (%{currency_symbol})
+        credit:
+          cash_in_hand: Overdrawn Balance
+          credit_card: Card Balance
+          current: Overdrawn Balance
+          loan: Loan Balance
+          other: Overdrawn Balance
+          savings: Overdrawn Balance
+        debit:
+          cash_in_hand: Balance
+          credit_card: Overpayment
+          current: Balance
+          loan: Overpayment
+          other: Balance
+          savings: Balance
+        no_start: In order to enter an opening balance for this account, please first
+          go to the %{financial_link} Settings page and set your Accounts Start Date.
+        remove: Remove opening balance
+      title:
+        default: Bank Accounts
+        index: Banking
+    fuji_banking/bank_reconciliations:
+      calculation_running: A Bank Reconciliation is already running and should be
+        complete shortly. Please try again in a few minutes.
+      confirm_dialogs:
+        reconcile_all_prompt: This will reconcile all entries up to the statement
+          end date. Are you sure?
+        total_mismatch:
+          message: Your target balance and reconciled balance don't match. Are you
+            sure you want to finish?
+          title: Target Balance Mismatch
+        unreconcile_all_prompt: This will unreconcile all entries currently flagged
+          for reconciliation. Are you sure?
+      help:
+        reconcile: extra_bank_reconciliation
+      info:
+        reconcile: Check and match entries against your bank statement.  You can fully
+          save your reconciliation when done, or save it for later and complete it
+          another time.
+      links:
+        finish: Finish
+        interest_and_charges: Interest and Charges
+        print: Print
+        reconcile_all: Reconcile All Entries
+        save_for_later: Save for later
+        unreconcile_all: Unreconcile All Entries
+      title:
+        default: Bank Reconciliation
+        interest_and_charges: Interest and Charges
+    fuji_banking/bank_transfers:
+      title:
+        default: Bank Transfers
+    fuji_banking/cheque_register:
+      help:
+        index: check_register
+      info:
+        index: View all the cheque payments you've recorded and select cheques to
+          print.
+      title:
+        index: Cheque Register
+    fuji_banking/deposits:
+      help:
+        index: extra_pay_into_bank
+      info:
+        index: Record cash and cheques deposited into your current account, from your
+          cash in hand account.
+    fuji_contacts/contacts:
+      help:
+        data_import: extra_contacts_import
+        index: extra_contacts_list
+        new: extra_create_contacts
+        show: extra_contact_records
+      info:
+        index: Create and manage your customer and supplier records.
+        new: Record details of your customers or suppliers, including their name and
+          the reference you want to use for them. If this contact is VAT registered,
+          enter their VAT number and, so that this is validated correctly, ensure
+          you choose their country.
+      title:
+        default: Contacts
+        index: Contacts
+        new: New Contact
+        show: 'Contact: %{responding_with}'
+    fuji_contacts/customers:
+      help:
+        data_import: extra_contacts_import
+        index: extra_contacts_list
+        new: extra_create_contacts
+        show: extra_contact_records
+        statement: extra_customer_statements
+      info:
+        index: Create, view and manage your customer records.
+        new: Record your customer's details, including their name and the reference
+          you want to use for them. If this customer is VAT registered, enter their
+          VAT number and, so that this is validated correctly, ensure you choose their
+          country.
+        statement: View transactions within the specified date range and use Manage
+          Statements to print or email your customer's statement.
+      title:
+        default: Customers
+        index: Customers
+        new: New Customer
+        show: 'Customer: %{responding_with}'
+        statement: 'Statement: %{contact_name}'
+    fuji_contacts/suppliers:
+      help:
+        data_import: extra_contacts_import
+        index: extra_contacts_list
+        new: extra_create_contacts
+        show: extra_contact_records
+        statement: extra_supplier_statements
+      info:
+        index: Create, view and manage your supplier records.
+        new: Record your supplier's details, including their name and the reference
+          you want to use for them. If this supplier is VAT registered enter their
+          VAT number and, so that this is validated correctly, ensure you choose their
+          country.
+        statement: View transactions within the specified date range, and use Manage
+          Statements to print a statement of items on the account.
+      title:
+        default: Suppliers
+        field: Supplier
+        index: Suppliers
+        new: New Supplier
+        show: 'Supplier: %{responding_with}'
+        statement: 'Statement: %{contact_name}'
+    fuji_core_accounting/coa_accounts:
+      title:
+        default: COA Accounts
+    fuji_core_accounting/coa_templates:
+      title:
+        default: COA Templates
+    fuji_core_accounting/ledger_accounts:
+      edit_dialog:
+        account_name_label: Account Name
+        category_label: Category
+        class_label: Class
+        control_account: This account must be included because it's essential to your
+          accounting system.
+        deleted_bank_notification: You cannot make any changes to this ledger because
+          it belongs to a deleted bank account.
+        deleted_bank_notification_title: Deleted Bank Account Ledger
+        display_name_label: Display Name
+        duplicate_account: Duplicate Account
+        duplicate_notification: This is a new ledger account - the original account
+          hasn’t been changed.
+        duplicate_notification_title: Details Duplicated to New Ledger Account
+        excluded: Excluded
+        excluded_copy: hidden from view across Accounting.
+        included: Included
+        included_copy: available to use across Accounting.
+        included_hint: Where would you like to use this account?
+        number_label: Number
+        title:
+          duplicate: Duplicate Ledger Account
+          edit: Edit Ledger Account
+          new: New Ledger Account
+        tva_label: TVA
+        update_successful: Ledger account updated successfully
+        update_unsuccessful: The ledger account failed to update
+      filters:
+        all: All
+        all_categories: All Categories
+        all_codes: All Codes
+        categories: Category
+        category_groups: Category Groups
+        control_account: Control Account
+        control_account_tip: These accounts must be included for use, because they’re
+          essential to your accounting system.
+        display_name: Display Name
+        excluded: Excluded
+        included: Included
+        included_excluded: Included and Excluded
+        included_tip: Included accounts are available to use in Accounting. Select
+          a row to include or exclude an account.
+        mark_as_excluded: Exclude
+        mark_as_excluded_tip: Makes accounts hidden in Accounting
+        mark_as_included: Include
+        mark_as_included_tip: Makes accounts available to use in Accounting
+        new_account: New Account
+        number: Number
+        searchbox: Search for a code or name
+        type_to_search: Type to Search
+      help:
+        index: extra_chart_of_accounts
+      info:
+        deleted: Deleted Ledger Account
+        index: Create, view and manage your ledger accounts.  Select existing accounts
+          to view or change the areas they are visible in, or create new accounts
+          for improved analysis.
+      message:
+        excluded_success: Successfully Excluded
+        included_success: Successfully Included
+      title:
+        index: Chart of Accounts
+        new_ledger_account: New Ledger Account
+    fuji_invoicing/purchase_corrective_invoices:
+      help:
+        copy: extra_create_purchase_corrective_invoices
+        create: extra_create_purchase_corrective_invoices
+        index: extra_the_purchases_corrective_list
+        new: extra_create_purchase_corrective_invoices
+        show: extra_create_purchase_corrective_invoices
+      info:
+        copy: Record a new corrective invoice you've received. To search for or to
+          create a new supplier, start typing in the Name box.
+        create: Record a new corrective invoice you've received. To search for or
+          to create a new supplier, start typing in the Name box.
+        draft: When you’re ready to fully save your corrective invoice, remove the
+          Save as draft tick.
+        edit: Make changes to invoice details or values. %{additional_text}
+        index: Create, view and manage the corrective invoices your suppliers send
+          to you, particularly those you want to split by multiple ledger accounts
+          or products.
+        new: Record a new corrective invoice you've received. To search for or to
+          create a new supplier, start typing in the Name box.
+        show: View or edit the corrective invoice, or use the options available to
+          create a credit note, or set the status of the invoice to disputed.
+      title:
+        copy: New Purchase Corrective Invoice
+        create: New Purchase Corrective Invoice
+        default: Purchase Corrective Invoices
+        edit: 'Purchase Corrective Invoice: %{context_string}'
+        new: New Purchase Corrective Invoice
+        show: 'Purchase Corrective Invoice: %{context_string}'
+    fuji_invoicing/purchase_credit_notes:
+      help:
+        copy: extra_create_purchase_credit_notes
+        create: extra_create_purchase_credit_notes
+        index: extra_the_purchases_list
+        new: extra_create_purchase_credit_notes
+        show: extra_create_purchase_credit_notes
+      info:
+        copy: Record a new credit note issued by your supplier. To search for or to
+          create a new supplier, start typing in the Name box.
+        create: Record a new credit note issued by your supplier. To search for or
+          to create a new supplier, start typing in the Name box.
+        draft: When you’re ready to fully save your credit note, remove the Save as
+          draft tick.
+        edit: Make changes to credit note details or values. %{additional_text}
+        index: Create, view and manage the credit notes your suppliers send to you,
+          particularly those you want to split by multiple ledger accounts or products.
+        new: Record a new credit note issued by your supplier. To search for or to
+          create a new supplier, start typing in the Name box.
+        show: View or edit the credit note, or use the option available to set the
+          status of the credit note to disputed.
+      title:
+        copy: New Purchase Credit Note
+        create: New Purchase Credit Note
+        default: Purchase Credit Notes
+        edit: 'Purchase Credit Note: %{context_string}'
+        new: New Purchase Credit Note
+        show: 'Purchase Credit Note: %{context_string}'
+    fuji_invoicing/purchase_invoices:
+      help:
+        copy: extra_create_purchase_invoices
+        create: extra_create_purchase_invoices
+        index: extra_the_purchases_list
+        new: extra_create_purchase_invoices
+        show: extra_create_purchase_invoices
+      info:
+        copy: Record a new invoice you've received. To search for or to create a new
+          supplier, start typing in the Name box.
+        create: Record a new invoice you've received. To search for or to create a
+          new supplier, start typing in the Name box.
+        draft: When you’re ready to fully save your invoice, remove the Save as draft
+          tick.
+        edit: Make changes to invoice details or values. %{additional_text}
+        index: Create, view and manage the invoices your suppliers send to you, particularly
+          those you want to split by multiple ledger accounts or products.
+        new: Record a new invoice you've received. To search for or to create a new
+          supplier, start typing in the Name box.
+        show: View or edit the invoice, or use the options available to create a credit
+          note, or set the status of the invoice to disputed.
+      title:
+        copy: New Purchase Invoice
+        create: New Purchase Invoice
+        default: Purchase Invoices
+        edit: 'Purchase Invoice: %{context_string}'
+        new: New Purchase Invoice
+        show: 'Purchase Invoice: %{context_string}'
+    fuji_invoicing/sales_corrective_invoices:
+      help:
+        copy: extra_create_sales_corrective_invoices
+        create: extra_create_sales_corrective_invoices
+        index: extra_sales_corrective_list
+        new: extra_create_sales_corrective_invoices
+        show: extra_create_sales_corrective_invoices
+      info:
+        copy: Create a new corrective invoice to send to your customer. To search
+          for or to create a new customer, start typing in the Name box.
+        create: Create a new corrective invoice to send to your customer. To search
+          for or to create a new customer, start typing in the Name box.
+        draft: When you’re ready to fully save your corrective invoice, remove the
+          Save as draft tick.
+        edit: Make changes to invoice details or values. %{additional_text}
+        index: Create, view and manage the corrective invoices you send to your customers.
+        new: Create a new corrective invoice to send to your customer. To search for
+          or to create a new customer, start typing in the Name box.
+        show: View or edit the corrective invoice, or use the options available to
+          create a credit note, email it to your customer, or produce a PDF.
+      title:
+        copy: New Sales Corrective Invoice
+        create: New Sales Corrective Invoice
+        default: Sales Corrective Invoices
+        edit: 'Sales Corrective Invoice: %{context_string}'
+        new: New Sales Corrective Invoice
+        show: 'Sales Corrective Invoice: %{context_string} <span class=''invoice-status
+          %{status_css_class}''>%{status_string}</span>'
+    fuji_invoicing/sales_credit_notes:
+      help:
+        copy: extra_create_sales_credit_notes
+        create: extra_create_sales_credit_notes
+        index: extra_sales_list
+        new: extra_create_sales_credit_notes
+        show: extra_create_sales_credit_notes
+      info:
+        copy: Create a new credit note to send to your customer. To search for or
+          to create a new customer, start typing in the Name box.
+        create: Create a new credit note to send to your customer. To search for or
+          to create a new customer, start typing in the Name box.
+        draft: When you’re ready to fully save your credit note, remove the Save as
+          draft tick.
+        edit: Make changes to credit note details or values. %{additional_text}
+        index: Create, view and manage the credit notes you send to your customers.
+        new: Create a new credit note to send to your customer. To search for or to
+          create a new customer, start typing in the Name box.
+        show: View or edit the credit note, or use the options available to email
+          it to your customer, or produce a PDF.
+      title:
+        copy: New Sales Credit Note
+        create: New Sales Credit Note
+        default: Sales Credit Notes
+        edit: 'Sales Credit Note: %{context_string}'
+        new: New Sales Credit Note
+        show: 'Sales Credit Note: %{context_string}'
+    fuji_invoicing/sales_estimates:
+      help:
+        copy: accounting_sales_estimate
+        create: accounting_sales_estimate
+        new: accounting_sales_estimate
+        show: accounting_sales_estimate
+      info:
+        copy: Create a new estimate to send to a prospective customer. To search for
+          or create a new customer, start typing in the Name box.
+        create: Create a new estimate to send to a prospective customer. To search
+          for or create a new customer, start typing in the Name box.
+        draft: When you're ready to fully save your estimate, remove the Save as draft
+          tick.
+        edit: Make changes to estimate details or values. %{additional_text}
+        new: Create a new estimate to send to a prospective customer. To search for
+          or create a new customer, start typing in the Name box.
+        show: View or edit the estimate, or use the options available to set the status
+          of the estimate, email it to your customer or produce a PDF.
+      title:
+        copy: New Sales Estimate
+        create: New Sales Estimate
+        default: Sales Estimates
+        edit: 'Sales Estimate: %{context_string}'
+        new: New Sales Estimate
+        show: 'Sales Estimate: %{context_string}'
+    fuji_invoicing/sales_invoices:
+      help:
+        copy: extra_create_sales_invoices
+        create: extra_create_sales_invoices
+        index: extra_sales_list
+        new: extra_create_sales_invoices
+        show: extra_create_sales_invoices
+      info:
+        copy: Create a new invoice to send to your customer. To search for or to create
+          a new customer, start typing in the Name box.
+        create: Create a new invoice to send to your customer. To search for or to
+          create a new customer, start typing in the Name box.
+        draft: When you’re ready to fully save your invoice, remove the Save as draft
+          tick.
+        edit: Make changes to invoice details or values. %{additional_text}
+        index: Create, view and manage the invoices you send to your customers.
+        new: Create a new invoice to send to your customer. To search for or to create
+          a new customer, start typing in the Name box.
+        show: View or edit the invoice, or use the options available to create a credit
+          note, email it to your customer, or produce a PDF.
+      sage_pay:
+        pay_now_button: Pay Now
+        pay_now_multi_currency_text: Pay Now option will take payment of outstanding
+          value in %{base_currency}. Total outstanding for this invoice %{base_outstanding}
+        pay_now_text: <p>We accept online payments. It's a fast, secure and very easy
+          way to pay.<br />Simply click the "Pay Now" button to pay this invoice using
+          your credit or debit card.</p>
+      title:
+        copy: New Sales Invoice
+        create: New Sales Invoice
+        default: Sales Invoices
+        edit: 'Sales Invoice: %{context_string}'
+        new: New Sales Invoice
+        show: 'Sales Invoice: %{context_string} <span class=''invoice-status %{status_css_class}''>%{status_string}</span>'
+    fuji_invoicing/sales_quotes:
+      help:
+        copy: extra_sales_quotes
+        create: extra_sales_quotes
+        index: extra_sales_quotes_list
+        new: extra_sales_quotes
+        show: extra_sales_quotes
+      info:
+        copy: Create a new quote to send to a prospective customer. To search for
+          or create a new customer, start typing in the Name box.
+        create: Create a new quote to send to a prospective customer. To search for
+          or create a new customer, start typing in the Name box.
+        draft: When you’re ready to fully save your quote, remove the Save as draft
+          tick.
+        edit: Make changes to quote details or values. %{additional_text}
+        index: Create quotes (for a firm price) and estimates (if the price may change)
+          for your customers to accept or decline.
+        new: Create a new quote to send to a prospective customer. To search for or
+          create a new customer, start typing in the Name box.
+        show: View or edit the quote, or use the options available to set the status
+          of the quote, email it to your customer or produce a PDF.
+      title:
+        copy: New Sales Quote
+        create: New Sales Quote
+        default: Sales Quotes
+        edit: 'Sales Quote: %{context_string}'
+        index: Quotes and Estimates
+        new: New Sales Quote
+        show: 'Sales Quote: %{context_string}'
+    link_texts:
+      add_address: Add Address
+      add_address_contact: Add Contact
+      view_contact_statement: View Statement
+    mysageone_core/jwt_resellers:
+      title:
+        show: Reseller integration details
+    mysageone_core/oauth:
+      title:
+        authorize: Authorise application
+    sop_admin/business_memberships:
+      info:
+        default: Customer list including activation status.
+        show: Manage and view user details.
+      title:
+        default: Administrator View
+        show: 'Viewing User: %{responding_with}'
+    sop_admin/super/jwt_resellers:
+      title:
+        index: Resellers
+        show: Resellers
+    sop_admin/users:
+      info:
+        default: Customer list including activation status.
+        show: Manage and view user details.
+      title:
+        default: Administrator View
+        show: 'Viewing User: %{responding_with}'
+    sop_settings/accounts:
+      description: Use this area to manage and make changes to your personal settings.
+      title:
+        default: My Sage One
+    sop_settings/analysis_types:
+      help:
+        index: analysis_types
+      info:
+        index: Create analysis types and categories to suit your business and choose
+          the areas that you want each type to be available in.  Use Transactional
+          Analysis to break down your income and expenditure, and use Group Analysis
+          to segment your records, such as customers and suppliers.
+      title:
+        index: Analysis Types
+    sop_settings/bank_opening_balances:
+      help:
+        show: extra_opening_balances
+      info:
+        show: Enter bank account opening balances. If your account balance is made
+          up of a reconciled value and items that have not yet appeared on your bank
+          statement, enter these as separate items. You can then reconcile the entries
+          when they appear on your statement.
+      title:
+        show: Bank Account Opening Balances
+        update: Bank Account Opening Balances
+    sop_settings/business_settings:
+      antifraud:
+        button: Export certificate
+        desc: Export a copy of the anti-fraud compliance certificate for your business
+        title: Anti-fraud compliance
+      business:
+        changes: Changes will be reflected across all Sage applications.
+        desc: Where do you run your business from day-to-day?
+        title: Business Name & Trading Address
+      business_type:
+        desc: Where is your business registered for official purposes?
+        registered_address: Registered Address
+        title: Business Type
+      help:
+        show: extra_business_settings
+      info:
+        show: Edit your business name, address and company type.
+      registration_numbers:
+        desc: Registration numbers description
+        title: Registration numbers
+      title:
+        default: About your Business
+      update:
+        failure: Your business could not be updated.
+    sop_settings/businesses:
+      help_url:
+        default: http://www.sageone.com/help/accounts/settings/business-settings
+      info:
+        default: Use this area to manage your Business settings.
+      title:
+        default: Business Settings
+    sop_settings/check_settings:
+      help:
+        show: check_printing_settings
+      info:
+        show: Make payments by printing directly onto special check paper.
+      title:
+        show: Check Printing Settings
+    sop_settings/currency_settings:
+      accounting_settings:
+        desc: Set how you’d like to handle bank charges and exchange rate gains or
+          losses in your accounts.
+        title: ACCOUNTING SETTINGS
+      currency_transactions:
+        desc: Enable foreign currency transactions, and choose whether you’d like
+          to use our live exchange rates, or enter your own.
+        title: CURRENCY TRANSACTIONS
+      help:
+        show: extra_foreign_currency
+      info:
+        show: Get set up to handle foreign currency transactions and manage your exchange
+          rates.
+      title:
+        default: Currency Settings
+    sop_settings/customer_opening_balances:
+      help:
+        data_import: extra_import_opening_balances
+        index: extra_opening_balances
+      info:
+        index: 'Record outstanding customer transactions from your previous accounting
+          system. Opening balances must be dated prior to your start date. Note: Your
+          opening balance batch total automatically provides the balance for your
+          trade debtors account in the Nominal Opening Balances option.'
+      message:
+        no_customers: You need to create customers before you can set customer opening
+          balances
+      title:
+        index: Customer Opening Balances
+        update: Customer Opening Balances
+    sop_settings/data_managements:
+      title:
+        default: Data Management
+    sop_settings/datev_export_settings:
+      title:
+        default: DATEV Export Settings
+    sop_settings/default_settings:
+      ageing_periods:
+        ageing: Ageing
+        ageing_note: "(for reporting)"
+        from: From
+        older: Older
+        to: To
+      bank:
+        title: Bank Defaults
+      bank_charges_ledger_account: Bank Interest and Charges Paid Ledger Account
+      bank_gains_ledger_account: Bank Interest Received Ledger Account
+      bank_payment_type: Default Payment Type
+      bank_receipt_type: Default Receipt Type
+      carriage_ledger_account: Carriage Ledger Account
+      catalog_items_order:
+        choice_description: Item Description
+        choice_item_code: Item Code
+        label: Sort order for Product/Service Menus
+      chart_of_accounts:
+        desc: Set how you’d like ledger accounts to be sorted in menus and the Chart
+          of Accounts, and how you’d like to handle negative assets.
+        list_order:
+          choice_code: Nominal Code
+          choice_name: Ledger Name
+          label: Sort order for Ledger Accounts list
+        negative_assets:
+          choice_liabilities: As Liabilities
+          choice_negative_assets: As Negative Assets
+          label: Show Negative Assets on Balance Sheet
+        separate_profit_loss:
+          choice_include: Within calculated Profit/Loss
+          choice_separate: Separately on Balance Sheet
+          label: Show Profit and Loss Account value
+        title: Accounting Settings
+      customer:
+        changes: You can override these for individual sales later if you like.
+        desc: Set defaults for your sales to customers.
+        title: Customers
+      customer_receipt_discount_ledger_account: Customer Receipt - Discount Ledger
+        Account
+      customer_statement_type: Customer Statement Type
+      expenses_other_payment_ledger_account: Other Payment Ledger Account
+      help:
+        show: extra_default_settings
+      incomes_other_receipt_ledger_account: Other Receipt Ledger Account
+      info:
+        show: Choose the preferences and defaults to use when creating records and
+          transactions.
+      invoice_purchase_discount_ledger_account: Purchase Discount Ledger Account
+      invoice_purchase_ledger_account: Purchase Ledger Account
+      invoice_sales_discount_ledger_account: Sales Discount Ledger Account
+      invoice_sales_ledger_account: Sales Ledger Account
+      payments_receipts:
+        desc: Set how you’d like to handle payment transactions to suppliers, and
+          receipt transactions from customers.
+        title: Payments & Receipts
+      product:
+        title: Product Defaults
+      product_labels_enabled: Set global pricing labels
+      product_purchases_ledger_account: Purchase Account
+      product_sales_ledger_account: Sales Account
+      product_service:
+        desc: Set the prices or rates you’d like to use when you sell products or
+          services to customers.
+        product_ledgers: Default Non-stock Ledger Accounts
+        product_prices: Product Prices
+        service_ledgers: Default Service Ledger Accounts
+        service_rates: Service Rates
+        stock_ledgers: Default Stock Ledger Accounts
+        title: Products & Services
+        weight_settings:
+          measurement_unit:
+            g: Gram (g)
+            kg: Kilogram (kg)
+            label: Default Measurement
+            lb: Pound (lb)
+            oz: Ounce (oz)
+            ton: Ton (t)
+            tonne: Tonne (t)
+          title: Weight Settings
+          unit_of_measure:
+            imperial_uk: Imperial (UK)
+            imperial_us: Imperial (US)
+            label: Default Unit of Measure
+            metric: Metric
+      service:
+        title: Service Defaults
+      service_labels_enabled: Set global rate labels
+      service_purchases_ledger_account: Purchase Account
+      service_sales_ledger_account: Sales Account
+      stock_purchases_ledger_account: Purchase Account
+      supplier:
+        changes: You can override these for individual purchases later if you like.
+        desc: Set defaults for your purchases from suppliers.
+        title: Suppliers
+      supplier_payment_discount_ledger_account: Supplier Payment - Discount Ledger
+        Account
+      supplier_statement_type: Supplier Statement Type
+      title:
+        default: Record and Transactions Settings
+        show: Record and Transactions Settings
+    sop_settings/email_defaults:
+      help:
+        show: extra_email_defaults
+      info:
+        show: Set a default message which you can customise when you email an invoice,
+          statement or other document.
+      title:
+        default: Email Defaults
+    sop_settings/financial_settings:
+      accounting_dates:
+        desc: Choose when your financial year starts and ends. Choose a ‘Lockdown’
+          date to stop new transactions being saved before this.
+        title: Accounting Dates
+      help:
+        accounting_types: extra_accounting_types
+        show: extra_financial_settings
+      info:
+        accounting_types: Please ask your accountant which accounting method is best
+          for your business.
+        show: Record financial details including VAT scheme information, financial
+          year end and the start date for transactions.
+      tax_info:
+        desc: Enter details of your VAT registration, including how often you’ll submit
+          VAT returns to HMRC. Enter your HMRC User ID to submit VAT returns directly
+          from Accounting.
+        tax_calculation:
+          applicability: The VAT Calculation method will apply to future transactions
+            only.
+          cash:
+            label: On payment
+            text: The VAT collected is due when payment is collected.
+          invoice:
+            label: On invoice
+            text: The VAT collected is due from the date of issue of the invoice.
+          title: VAT Calculation
+        title: VAT Details
+      title:
+        default: Financial Settings
+    sop_settings/financial_years:
+      actions:
+        archive_download: Download
+        continue: Continue
+        run_year_end: Close
+        view: View
+      headers:
+        action: Action
+        archive: Archive
+        end_date: To
+        start_date: From
+        status: Status
+      help:
+        index: extra_financial_year_end_process
+        show: extra_financial_year_end_process
+      index:
+        message:
+          text: Your year-end journals have been applied, and your %{current_financial_year_formatted}
+            financial Year-End process is complete.
+          title: Happy New Year!
+      missing_lockdown_date: Choose a Lockdown Date
+      missing_year_end_date: Choose a Year End Date
+      show:
+        message:
+          text: Your year-end journals have been applied, and your %{current_financial_year_formatted}
+            financial Year-End process is complete.
+          title: 'Status:'
+        reason_cannot_undo: Because you’ve also completed the %{next_financial_year_formatted}
+          financial year, you can no longer undo this step.
+        step:
+          archiving:
+            done:
+              header: We're generating your archive. You can continue with your Year
+                End while it processes.
+              tasks:
+              - Your archive is being generated. We’ll email you when it’s available,
+                and it will be available from the top bar when complete.
+            title: Archive your financial reports
+            todo:
+              button_text: Request archive
+              header: 'We''ll generate an archive of your financial reports. You must
+                save this archive somewhere secure. '
+              tasks:
+              - 'The reports included in the archive are as follows: Nominal Activity,
+                Journal Export, Audit Trail, All Sales Invoices/Credit Notes, Balance
+                Sheet and Profit and Loss'
+              - " "
+              - The archive can take up to 48 hours to generate. We'’ll email you
+                when it''s ready, and it will be available from the top bar when complete.
+          close:
+            balance_journal_reference: Accounts Closing
+            creditor_journal_reference: Credit Accounts Closing
+            custom_message:
+              undo: To enter adjustments in your re-opened financial year, please
+                check your lockdown date
+            debtor_journal_reference: Debit Accounts Closing
+            dialogs:
+              do:
+                button_text: Close Financial Year
+                date_range: "%{current_financial_year_start_date} to %{current_financial_year_end_date}"
+                description: Are you sure you'd like to lock the %{current_financial_year_formatted}
+                  financial year?
+                footer:
+                - This step will number your transactions and create journals. You
+                  can un-do this change, but it's best to avoid this.
+                title: Close Financial Year
+              undo:
+                button_text: Undo Closing Financial Year
+                description: Are you sure you want to undo closing the %{current_financial_year_formatted}
+                  financial year?
+                footer:
+                - This will mean...
+                - "- You can move lockdown date before %{next_financial_year_start_date}."
+                - "- Year-end journals are reversed, but the originals and the reversals
+                  will still show up in your audit trial."
+                title: Undo Closing Financial Year
+            profit_loss_journal_reference: Retained Earnings
+            title: Close the %{current_financial_year_formatted} Financial Year
+            todo:
+              button_text: Close Financial Year
+              footer:
+              - You and your accountant should decide the best time to do this - ideally,
+                wait until all transactions are complete for the year.
+              - You can undo this step, but it’s best to avoid this.
+              header: 'We''ll get your accounts ready for the end of the year by:'
+          open:
+            balance_carried_forward_reference: Balance Carried Forward
+            creditor_balance_carried_forward_reference: Credit Balance Carried Forward
+            debtor_balance_carried_forward_reference: Debit Balance Carried Forward
+            dialogs:
+              do:
+                button_text: Open Financial Year
+                date_range: "%{next_financial_year_start_date} to %{next_financial_year_end_date}"
+                description: Are you sure you'd like to open the %{next_financial_year_formatted}
+                  financial year?
+                footer:
+                - You can un-do this change, but it's best to avoid this.
+                title: Open Financial Year
+              undo:
+                button_text: Undo Opening Financial Year
+                description: Are you sure you want to undo opening the %{next_financial_year_formatted}
+                  financial year?
+                footer:
+                - This will mean year-end journals are reversed, but the originals
+                  and the reversals will show up in your audit trial.
+                title: Undo Opening Financial Year
+            title: Open the %{next_financial_year_formatted} Financial Year
+            todo:
+              button_text: Open Financial Year
+              header: 'We''ll set you up for the new financial year by:'
+        title: "%{current_financial_year_formatted} Financial Year"
+        undo_button_text: Undo
+        undo_close:
+          text: Verify lockdown date to create new transactions
+          title: 'Status:'
+      status:
+        archiving: 'Step %{step_number}: Request archive'
+        close: 'Step %{step_number}: Financial Year to close'
+        complete: Year End Process Complete
+        current: Current Financial Year
+        generating: Generating...
+        next: Next Financial Year
+        open: 'Step %{step_number}: Open next Financial Year'
+      title: Manage Financial Years
+    sop_settings/google_drive_settings:
+      access_text: Sage will not be able to access any other data in your Google account.
+      disable_button: Disable
+      disable_text: Disable Sage access to your Google Drive?
+      enable_button: Enable
+      enable_failure: Google Drive cannot be enabled.
+      enable_success: Google Drive has been enabled.
+      enable_text: Enable Sage access to your Google Drive?
+      folder_name: Sage Invoices
+      help:
+        show: google_drive
+      info:
+        show: Use this area to manage your Google Drive Settings
+      initial_text: By enabling Google Drive, every time you create or update a sales
+        invoice, credit note, quote or estimate, a PDF copy is created in your Google
+        Drive.
+      revoke_success: Google Drive access has been removed successfully.
+      title:
+        default: Google Drive Settings
+    sop_settings/invoice_settings:
+      help:
+        show: extra_invoice_quote_settings
+      info:
+        show: Configure the defaults shown on invoices and other sales and purchases
+          forms
+      title:
+        default: Invoice Form Settings
+        show: Invoice Form Settings
+    sop_settings/logo_and_theme_settings:
+      help:
+        show: logo_and_document_templates
+      info:
+        show: Tailor the presentation of documents you print or send to suit your
+          business.
+      title:
+        default: Logo & Document Template
+        show: Logo & Document Template
+    sop_settings/nominal_opening_balances:
+      help:
+        show: extra_opening_balances
+      info:
+        show: Record the balances of your ledger accounts from your previous accounting
+          system.  Opening balances already entered through the customer, supplier
+          or bank opening  balance options appear automatically. You can enter or
+          amend these by clicking each line.  Each debit or credit balance is offset
+          against the opening balance control account, and when the full trial balance
+          is entered, this account should be zero.
+      title:
+        show: Nominal Opening Balances
+        update: Nominal Opening Balances
+    sop_settings/online_payment_settings:
+      help:
+        show: extra_sage_pay
+      info:
+        show: Manage your Paypal and Paya settings.
+        signup: Give your customers a convenient way to pay you. Accept online credit
+          card with Paya.
+      title:
+        show: Paypal and Paya
+        signup: Paya
+    sop_settings/opening_balances:
+      amount: Amount
+    sop_settings/payroll_settings:
+      help:
+        show: settings_payroll_integration
+        update: settings_payroll_integration
+      info:
+        show: Use this area to manage your Payroll integration settings
+        update: Use this area to manage your Payroll integration settings
+      note: 'Note: This account will be used for payments posted automatically from
+        payroll such HMRC and Pension payments.'
+      payroll_journals_enabled: Enable Journals from Payroll
+      post_net_wages_to_liability:
+        default_payroll_bank_account: Post employee net wages to the default bank
+          account above.
+        net_wages_liability_account: Post employee net wages to liability account.
+      title:
+        create_journals: Creates journals in the selected bank account when you complete
+          a pay run in Payroll.
+        header: Payroll journals
+        separate_journals: Separate journals are posted for payments to employees,
+          HMRC, and pensions payments.
+        show: Payroll Integration Settings
+        update: Payroll Integration Settings
+    sop_settings/sage_pay_settings:
+      account_details:
+        desc: Enter the details of your Sage Pay account.
+        title: ACCOUNT DETAILS
+      accounting_settings:
+        bank_account: Bank Account
+        desc: Set where you'd like your Sage Pay transactions to be recorded in Sage
+          Business Cloud Accounting <br/><br/>'Default Customer' records all your
+          transactions against one customer account.
+        surcharge: Separate Account for surcharges
+        title: ACCOUNTING SETTINGS
+      help:
+        show: extra_sage_pay
+        update: extra_sage_pay
+      info:
+        show: Manage your Sage Pay settings.
+        update: Manage your Sage Pay settings.
+      title:
+        show: Sage Pay
+        update: Sage Pay
+    sop_settings/services:
+      info:
+        default: Manage your settings.
+      title:
+        default: Service Settings
+    sop_settings/settings:
+      help:
+        index: accounting_settings
+      help_url:
+        index: http://www.sageone.com/help/accounts/settings
+      info:
+        default: Manage your settings.
+        index: Manage your settings.
+      title:
+        default: Settings
+        index: Settings
+    sop_settings/stripe_settings:
+      help:
+        show: connect_to_stripe
+      info:
+        show: Easy card payments straight from customer invoices. Sign up to Stripe
+          or manage your settings.
+      title:
+        show: Card Payments
+    sop_settings/supplier_opening_balances:
+      help:
+        data_import: extra_import_opening_balances
+        index: extra_opening_balances
+      info:
+        index: 'Record supplier transactions from your previous accounting system.
+          Opening balances must be dated prior to your start date. Note: Your opening
+          balance batch total automatically provides the balance for your trade creditors
+          account in the Nominal Opening Balances option.'
+      message:
+        no_suppliers: You need to create suppliers before you can set supplier opening
+          balances.
+      title:
+        index: Supplier Opening Balances
+        update: Supplier Opening Balances
+    sop_settings/tax_settings:
+      help:
+        index: extra_sales_tax_rates
+      info:
+        index: Create, view and manage the tax rates for products and services you
+          sell.
+      title:
+        default: Sales Tax Rates
+    sop_settings/user_managements:
+      alerts:
+        aged_creditor:
+          message: Purchases reports require access to purchases and contacts, and
+            won't be available to this user.
+        aged_debtor:
+          message: Sales reports require access to sales and contacts, and won't be
+            available to this user.
+        management_report:
+          message: Management reports require Full or Read Only access to all areas,
+            and won't be available to this user.
+        reports:
+          title: Access to Reports
+      info:
+        default: Use this area to manage your users.
+        new: Enter the user's email address, establish permissions, and invite them
+          to work with your data.
+      title:
+        default: User Management
+        new: Invite User
+    sop_settings/user_preferences:
+      info:
+        show: Make changes to suit your style of working.
+      title:
+        default: Navigation and Data Grids
+    sop_settings/users:
+      help_url:
+        default: http://www.sageone.com/help/manage-my-sage-one/sage-one-accounts/user-settings
+        index: http://www.sageone.com/help/manage-my-sage-one/sage-one-accounts/user-settings
+      info:
+        default: Manage your settings.
+        show: Manage your settings.
+      only_service_users_can_be_added: "%{email} is invalid"
+      title:
+        default: User Settings
+  payment_dialog:
+    discount: Discount Given%{currency_tag}
+    outstanding_balance: Outstanding Balance%{currency_tag}
+  payments:
+    dialog:
+      amount_to_pay: Amount to Pay
+      description: 'Enter the amount you want to pay:'
+      discount: Discount
+      new_outstanding_amount: New Outstanding Amount
+      outstanding: Outstanding
+      reference: Reference
+      title: Part Pay
+    grid_filter:
+      display:
+        due: Due
+        outstanding: Outstanding
+        paid_unpaid: All
+        this_allocation: This allocation
+    paid_on_invoice:
+      successful: Payment added successfully
+    ui:
+      payments_pod:
+        amount_paid: Amount Paid
+        invoice_receipt_details: Invoice Payment Details
+        outstanding: Amount Outstanding
+        pay: Record Payment
+        pay_receipt: Record Payment
+        payment_details: Invoice Payment Details
+        take_a_card_payment: Card Payment
+      refunds_pod:
+        amount_paid: Amount Paid
+        outstanding: Amount Outstanding
+        refund: Record Refund
+        refund_details: Refund Details
+  payments_pod:
+    amount_outstanding: Amount Outstanding
+    amount_paid: Amount Paid
+    amount_received: Amount Received%{currency_tag}
+    currency_charges: Currency Charges%{currency_tag}
+    last_paid: Last payment made
+    last_payment: Last payment received
+    last_refund: Last refunded
+    pay_now: Pay now
+    record_payment: Record Payment
+    record_refund: Record Refund
+    take_a_card_payment: Card Payment
+    voided_date: Voided Date
+  pdf:
+    of: of
+    page: Page
+  pdf_helpers:
+    address: Address
+    messages:
+      migrated_artefacts: You can't create a PDF for one or more of the selected items
+        because it was migrated from your old accounting system.
+    prefix:
+      advanced_uk/customer_income_payment: Remittance Advice
+      advanced_uk/customer_refund_payment: Customer Refund
+      advanced_uk/supplier_expense_payment: Remittance Advice
+      fuji_invoicing/sales_corrective_invoice: Sales_Corrective_Invoice_
+      fuji_invoicing/sales_credit_note: Credit_Note_
+      fuji_invoicing/sales_estimate: Sales_Estimate_
+      fuji_invoicing/sales_invoice: Sales_Invoice_
+      fuji_invoicing/sales_quote: Sales_Quote_
+    titles:
+      migrated_artefacts:
+        credit_note: Create Sales Credit Note PDF
+        invoice: Create Sales Invoice PDF
+        sales_artefact: Create Sales Item PDF
+  period_date_range:
+    list:
+      custom: Custom
+      last_month: Last month
+      last_year: Last year
+      this_month: This month
+      this_year: This year
+    title:
+      end: End
+      start: Start
+      type: Period
+  placeholder:
+    contacts:
+      reference: e.g. Account Number
+      search_text: Type the company / name to search
+    generic:
+      type_to_search: Type to search
+    payments:
+      advanced_uk/customer_income_payment:
+        reference: e.g. Cheque number
+      advanced_uk/customer_refund_payment:
+        reference: e.g. Cheque number or BACS Ref
+      advanced_uk/other_expense_payment:
+        reference: e.g. Cheque number or BACS Ref
+      advanced_uk/other_expense_payment_refund:
+        reference: e.g. Cheque number or BACS Ref
+      advanced_uk/other_income_payment:
+        reference: e.g. Cheque number
+      advanced_uk/other_income_payment_refund:
+        reference: e.g. Cheque number
+      advanced_uk/supplier_expense_payment:
+        reference: e.g. Cheque number or BACS Ref
+      advanced_uk/supplier_refund_payment:
+        reference: e.g. Cheque number
+    products_and_services:
+      category: Select a Category
+      code: e.g. Short name or code
+      no_categories: No categories found
+      no_suppliers: No suppliers found
+      purchase_description: Description on purchase forms
+      usual_supplier: Select a supplier
+    purchase_corrective_invoice:
+      reference: e.g. Purchase Order Number
+      supplier_reference: e.g. Supplier's Invoice Number
+    purchase_credit_note:
+      reference: e.g. Original Invoice Number
+      supplier_reference: e.g. Supplier's Credit Note number
+    purchase_invoice:
+      reference: e.g. Purchase Order Number
+      supplier_reference: e.g. Supplier's Invoice Number
+    sales_credit_note:
+      reference: e.g. Invoice Number
+    sales_estimate:
+      reference: e.g. Customer's Ref
+    sales_invoice:
+      reference: e.g. Order Number
+    sales_quote:
+      reference: e.g. Customer's Ref
+  purchase_corrective_invoice:
+    confirm:
+      helper_text:
+        confirm_no_vat: |
+          **You can use 'No VAT' if your supplier is not VAT registered,** as they can’t charge you VAT.
+
+          **Do not use 'No VAT' for overseas purchases -** instead, enter the supplier’s address and any VAT number on their record. Enter the VAT rate charged, and the Reverse Charge mechanism means the VAT value is cancelled out on your return.
+
+          **[Read guidance from HMRC](https://www.gov.uk/guidance/rates-of-vat-on-different-goods-and-services)** on when to use Zero rated or Exempt instead.
+        confirm_vat_only: "**For example, do not create VAT-only corrective invoices
+          for goods previously purchased** if you’ve just become VAT registered."
+      messages:
+        confirm_no_vat: |
+          **'No VAT' has been selected on this corrective invoice.**
+          If you’re unsure, check with an accountant.
+        confirm_vat_only: |
+          **This corrective invoice only has a VAT value.**
+          This is for special situations only - check with an accountant to be sure.
+        stock_cost_zero: |
+          One or more of your stock items has a price of %{currency_amount}. This will affect the average cost calculation for your stock.
+
+          Would you like to save it anyway, or continue editing?
+        total_zero: |
+          This Corrective Invoice has a value of %{currency_amount}.
+          Would you like to save it anyway, or continue editing?
+      title:
+        confirm_no_vat: Choosing 'No VAT'
+        confirm_vat_only: VAT-only Corrective Invoices
+        stock_cost_zero: Zero Value Stock Item
+        total_zero: Zero Value Corrective Invoice
+    eu_no_vat:
+      supplier:
+        message_text: If the supplier is registered for VAT in the EU, enter their
+          VAT number on the supplier record to apply the correct VAT treatment.
+    eu_tax_registration:
+      supplier:
+        message_text: VAT is set to zero and will be charged under the Reverse Charge
+          mechanism. Please review the EU Goods/Services selection on each invoice
+          line.
+    row:
+      supplier:
+        message_text: VAT is set to zero and will be charged under the Reverse Charge
+          mechanism. Please review the Goods/Services selection on each invoice line.
+  purchase_credit_note:
+    confirm:
+      helper_text:
+        confirm_no_vat: |
+          **You can use 'No VAT' if your supplier is not VAT registered,** as they can’t charge you VAT.
+
+          **Do not use 'No VAT' for overseas purchases -** instead, enter the supplier’s address and any VAT number on their record. Enter the VAT rate charged, and the Reverse Charge mechanism means the VAT value is cancelled out on your return.
+
+          **[Read guidance from HMRC](https://www.gov.uk/guidance/rates-of-vat-on-different-goods-and-services)** on when to use Zero rated or Exempt instead.
+        confirm_vat_only: "**For example, do not create VAT-only credit notes for
+          goods previously purchased** if you’ve just become VAT registered."
+      messages:
+        confirm_no_vat: |
+          **'No VAT' has been selected on this credit note.**
+          If you’re unsure, check with an accountant.
+        confirm_vat_only: |
+          **This credit note only has a VAT value.**
+          This is for special situations only - check with an accountant to be sure.
+        stock_cost_zero: |
+          One or more of your stock items has a price of %{currency_amount}. This will affect the average cost calculation for your stock.
+
+          Would you like to save it anyway, or continue editing?
+        total_zero: |
+          This Credit Note has a value of %{currency_amount}.
+          Would you like to save it anyway, or continue editing?
+      title:
+        confirm_no_vat: Choosing 'No VAT'
+        confirm_vat_only: VAT-only Credit Notes
+        stock_cost_zero: Zero Value Stock Item
+        total_zero: Zero Value Credit Note
+  purchase_credit_notes:
+    eu_no_vat:
+      supplier:
+        message_text: If the supplier is registered for VAT in the EU, enter their
+          VAT number on the supplier record to apply the correct VAT treatment.
+    eu_tax_registration:
+      customer:
+        message_text: The credit note address has been fixed and the VAT Rate has
+          been set to zero (0). Please review the EU Goods/Services.
+      supplier:
+        message_text: VAT is set to zero and will be charged under the Reverse Charge
+          mechanism. Please review the EU Goods/Services selection on each invoice
+          line.
+    row:
+      customer:
+        message_text: The credit note address has been fixed and the VAT Rate has
+          been set to zero (0). Please review the EU Goods/Services.
+      supplier:
+        message_text: VAT is set to zero and will be charged under the Reverse Charge
+          mechanism. Please review the Goods/Services selection on each invoice line.
+  purchase_invoice:
+    confirm:
+      helper_text:
+        confirm_no_vat: |
+          **You can use 'No VAT' if your supplier is not VAT registered,** as they can’t charge you VAT.
+
+          **Do not use 'No VAT' for overseas purchases -** instead, enter the supplier’s address and any VAT number on their record. Enter the VAT rate charged, and the Reverse Charge mechanism means the VAT value is cancelled out on your return.
+
+          **[Read guidance from HMRC](https://www.gov.uk/guidance/rates-of-vat-on-different-goods-and-services)** on when to use Zero rated or Exempt instead.
+        confirm_vat_only: "**For example, do not create VAT-only invoices for goods
+          previously purchased** if you’ve just become VAT registered."
+      messages:
+        confirm_no_vat: |
+          **'No VAT' has been selected on this invoice.**
+          If you’re unsure, check with an accountant.
+        confirm_vat_only: |
+          **This invoice only has a VAT value.**
+          This is for special situations only - check with an accountant to be sure.
+        stock_cost_zero: |
+          One or more of your stock items has a price of %{currency_amount}. This will affect the average cost calculation for your stock.
+
+          Would you like to save it anyway, or continue editing?
+        total_zero: |
+          This Invoice has a value of %{currency_amount}.
+          Would you like to save it anyway, or continue editing?
+      title:
+        confirm_no_vat: Choosing 'No VAT'
+        confirm_vat_only: VAT-only Invoices
+        stock_cost_zero: Zero Value Stock Item
+        total_zero: Zero Value Invoice
+  purchase_invoices:
+    eu_no_vat:
+      supplier:
+        message_text: If the supplier is registered for VAT in the EU, enter their
+          VAT number on the supplier record to apply the correct VAT treatment.
+    eu_tax_registration:
+      customer:
+        message_text: The invoice address has been fixed and the VAT Rate has been
+          set to zero (0). Please review the EU Goods/Services.
+      supplier:
+        message_text: VAT is set to zero and will be charged under the Reverse Charge
+          mechanism. Please review the EU Goods/Services selection on each invoice
+          line.
+    row:
+      customer:
+        message_text: The invoice address has been fixed and the VAT Rate has been
+          set to zero (0). Please review the EU Goods/Services.
+      supplier:
+        message_text: VAT is set to zero and will be charged under the Reverse Charge
+          mechanism. Please review the Goods/Services selection on each invoice line.
+  quick_entry:
+    total_items:
+      one: 1 item
+      other: "%{count} items"
+      zero: 0 items
+    totals_dialog:
+      title: Quick Entry Totals
+      total_amount: Total
+      total_batch_entry_type_1: Totals of %{count} Invoices
+      total_batch_entry_type_2: Totals of %{count} Credit Notes
+      total_description: ''
+      total_footer: Total
+      total_net_amount: Net
+      total_tax_amount: VAT
+  quick_start:
+    business_postcode:
+      placeholder: e.g. AB12 3CD
+    coa:
+      label: Chart of Accounts
+      skr03:
+        description: for small and medium companies
+        name: Standard (SKR03)
+      skr04:
+        description: for corporations
+        name: SKR04
+    fields:
+      accounts_start_date:
+        hint: This is the date that you’d like to start recording your transactions.
+          It’s best to choose a date that matches the start of your VAT period. Later,
+          you can enter opening balances before this date if you like.
+      business_classification:
+        hint: Type a word that describes what your business does, then choose one
+          of the suggestions.  This helps us provide the best experience for businesses
+          like yours.
+        placeholder: Type to search
+      business_name:
+        hint: This will appear on your customer invoices.
+      business_phone_number:
+        hint: We'll customise your customer invoices with this.
+      business_registered_street_1:
+        hint: This goes at the bottom of your customer invoices.
+      business_start_date:
+        hint: Tell us when your business officially started. This helps us to provide
+          the right products and services for you.
+      business_street_1:
+        hint: We'll put this address at the top of your customer invoices.
+      business_type:
+        hint: Choose your business type, and we’ll set up the right accounting structure
+          for you.
+      financial_year_end_date:
+        hint: We use this date to help produce your year-end accounts.
+      registered_country:
+        hint: We'll use this to customise your invoices and apply the right legislation,
+          keeping you compliant.
+        prompt: Select a Country
+      registered_number:
+        hint: Companies House give you this when you register with them. It could
+          be 2 letters and 6 numbers, or 8 numbers. You can look it up on the Companies
+          House website.
+        label: Registration Number
+      tax_number:
+        hint: you get from the tax office
+        label: tax identification number
+        placeholder: e.g. 123456789
+      tax_office:
+        hint: where your company is registered
+        label: tax office
+      vat_number:
+        hint: Issued by HM Revenue & Customs when you registered for VAT. It has 9
+          numbers, and can be found on your VAT registration certificate (sometimes
+          called a VAT 4 form). We'll put it on your customer invoices.
+      vat_rate:
+        hint: Your rate is set by HMRC, and depends on your type of business. For
+          more information, see the HMRC website.
+    finish: All Done!
+    help_text_link: Need some help?
+    mobile_view:
+      android_link: https://play.google.com/store/apps/details?id=com.sage.accounting
+      available_on: It's available for free for iOS and Android devices.
+      continue_desktop: Keep using the desktop version.
+      ios_link: https://itunes.apple.com/app/sage-accounting/id1341612411
+      pre_continue_desktop: Not quite ready?
+      screen_message: "(Designed for screens larger than 958px)"
+      summary_text: To get the very best experience on this device, download the Sage
+        Accounting app.
+      title: Get <span>the app!</span>
+    next: Save and Continue
+    prev: Back
+    required_note: "* Required"
+    step_header:
+      of: of
+      step: Step
+    steps:
+      business_address:
+        subtitle: Where do you run your business from day-to-day?
+        title: Business Trading Address
+      business_basics:
+        subtitle: Just a few quick questions, and you're ready to go!
+        title: ''
+      important_dates:
+        title: Important dates
+      registered_address:
+        subtitle: Where is your business registered for official purposes?
+        title: Registered Address
+      tax:
+        empty:
+        - We’re having issues verifying your zip code.
+        - Click Back to make sure you entered the correct zip code and try again.
+        - If you continue to have issues, you can manually create your tax rates in
+          Settings.
+        subtitle: And finally, do you charge VAT?
+        title: VAT
+    tax_calculation_method:
+      cash:
+        description: The VAT collected is due when payment is collected.
+        name: On payment
+      heading: VAT Calculation Method
+      invoice:
+        description: The VAT collected is due from the date of issue of the invoice.
+        name: On invoice
+      title: VAT Calculation Method
+    tax_scheme:
+      cash_accounting:
+        description: I pay VAT based on invoices as they are paid
+        name: Cash accounting
+      flat_cash:
+        description: I pay a flat rate on invoices as they are paid
+        name: Flat rate cash based
+      flat_invoice:
+        description: I pay a flat rate on invoices as they are raised
+        name: Flat rate invoice based
+      not_registered:
+        description: I don't have a VAT number
+        name: Not registered
+      simplified:
+        description: I deliver tax reports each month.
+        name: Simplified
+      standard:
+        description: I pay VAT based on invoices as they are raised
+        name: Standard
+    title: Let’s set up <span>your business</span>
+    vat_number:
+      placeholder: e.g. 123456789
+  quote_profit_breakdown:
+    dialog:
+      description: 'Note: Where an item does not have a cost price it is not included'
+      title: Profit Summary
+    report:
+      headers:
+        description: Description
+        profit: Profit
+        profit_percentage: Profit %
+        total_cost: Total Cost
+        total_sales: Total Sales
+  quotes:
+    estimate_already_invoiced: You cannot edit this estimate as it has been converted
+      to an invoice.
+    quote_already_invoiced: You cannot edit this quote as it has been converted to
+      an invoice.
+    quote_statuses:
+      converted: Converted
+      expired: Expired
+      pending: Pending
+  recurrence:
+    create: Create
+    dialog:
+      fields:
+        label: Recurs every...
+    edit: Edit
+    make: Make
+    notifications:
+      delete: Recurrence deleted
+      set: Recurrence set
+    payment: Payment
+    receipt: Receipt
+    title: "%{prefix} Recurring"
+  registered_country:
+  - England and Wales
+  - Wales
+  - Scotland
+  - Northern Ireland
+  - Republic of Ireland
+  reporting:
+    accounts_and_audit:
+      audit_trail_selector_title: Audit Trail
+      title: Accounting & Audit
+      trial_balance_title: Trial Balance
+    aged:
+      auxiliary_account: ", Auxiliary Account: %{auxiliary_account}"
+      contact_details: ", Tel: %{contact_number}"
+      contact_details_multiple: ", Tel: %{telephone_number} / %{mobile_number}"
+      contact_name: "%{contact_name}"
+      credit_limit: Credit limit
+      credit_limit_prefix: ", Credit limit: "
+      currency_prefix: ", Currency: "
+      customer: Customer
+      date: Date
+      due_date: Due Date
+      interval: "< %{end} days"
+      multi_currency_footer_message: All foreign values are calculated using the exchange
+        rate of the original transaction.
+      name: Name
+      older: Older
+      original_amount: Total
+      outstanding_amount: Outstanding Amount
+      overdue: " - OVERDUE"
+      payment_terms: ", Terms: %{payment_terms} days"
+      reference: Reference
+      sort_criteria: Sort by
+      sums_for_classes:
+        fuji_journals/journal: All Journals
+      supplier: Supplier
+      total: O/S Amt
+      total_uppercased: TOTAL
+      totals: Totals
+    aged_creditors:
+      csv_filename: aged_creditors_to_%{end_date}
+      description: This report shows all outstanding or unallocated supplier transactions,
+        broken down by the ageing periods specified in Record and Transactions Settings.
+      filename: aged_creditors
+      link_to_breakdown: Detailed
+      title: Aged Creditors Report
+    aged_creditors_breakdown:
+      filename: aged_creditors_breakdown
+      link_to_summary: Summary
+    aged_debtors:
+      csv_filename: aged_debtors_to_%{end_date}
+      description: This report shows all outstanding or unallocated customer transactions,
+        broken down by the ageing periods specified in Record and Transactions Settings.
+      filename: aged_debtors
+      link_to_breakdown: Detailed
+      title: Aged Debtors Report
+    aged_debtors_breakdown:
+      filename: aged_debtors_breakdown
+      link_to_summary: Summary
+    archive:
+      email:
+        body_html: 'Hello %{user}, <br><br><strong>Your archive of financial reports
+          is now available to download.</strong><br><br> It''ll be available when
+          you next sign in, or you can download it from the Financial Years page in
+          Settings.<br><br> <img src=''%{button_src}'' width=''400px'' style=''margin:0
+          auto; display:block;'' /><br><br> Make sure you remember to save the archive
+          to your computer.<br><br> <a href=''%{path}'' target=''_blank'' style=''width:
+          200px; display:block; margin: 0 auto; background-color:#ba296c; padding:
+          12px 0; color: #FFFFFF; font-family: Arial; font-size: 16px; font-weight:
+          bold; text-decoration:none; text-align: center;''>Sign in</a><br> Thank
+          you, <br> Sage'
+        subject: Email Confirmation Archive generated
+      filename: Archive_%{start_date}_%{end_date}
+    audit_trail:
+      description: The audit trail breakdown is a detailed record of all transactions
+        posted. You can view this by transaction type for a specified date range.
+      filename: audit_trail_breakdown
+      generic_description: The audit trail shows all transactions posted.
+      generic_title: Audit Trail
+      is_reconciled: 'Yes'
+      link_to_summary_report: Summary
+      not_reconciled: 'No'
+      short_title: Breakdown
+      status:
+        active: Exclude deleted
+        all: All
+        deleted: Deleted only
+        status: Status
+      title: Audit Trail Breakdown
+      transaction_type: Type
+    audit_trail_summary:
+      description: The audit trail summary is a record of all transactions posted.
+        You can view this by transaction type for a specified date range.
+      filename: audit_trail_summary
+      link_to_detailed_report: Detailed
+      short_title: Summary
+      title: Audit Trail
+    auxiliary_balance:
+      account: Account
+      account_name: Account Name
+      all_accounts: All Accounts
+      apply: Apply
+      auxiliary_account: Account Code
+      credit: Credit
+      credit_balance: Credit Balance
+      date: To
+      debit: Debit
+      debit_balance: Debit Balance
+      description: Allows you to see the results of your business and the balance
+        of each subaccounts at a given time.
+      filename: auxiliary_balance_%{collective_account_name}
+      grand_total: GRAND TOTAL
+      title: Auxiliary Balance
+      total: TOTAL
+    balance_sheet:
+      assets: Assets
+      current_assets: Current Assets
+      current_liabilities: Current Liabilities
+      description: The balance sheet shows what you own, your assets, and what you
+        owe, your liabilities.
+      equity: Equity
+      filename: balance_sheet
+      fixed_assets: Fixed Assets
+      liabilities: Liabilities
+      liabilities_equity: Liabilities & Equity
+      long_term_liabilities: Future Liabilities
+      net_assets: Net Assets
+      prior_years: "(prior year(s))"
+      title: Balance Sheet Report
+      total_tax_liabilities: VAT
+      trading_activity: Net Profit / Loss
+      trading_activity_current_year: Net Profit / Loss (current year)
+      trading_activity_prior_years: Net Profit / Loss (prior year(s))
+      vat: VAT
+    balance_statement:
+      filename: balance_statement
+    beta: BETA
+    cash_flow:
+      bank_accounts: Bank Account(s)
+      from_date: From
+      to_date: To
+      view_detailed_breakdown: Detailed
+    cash_flow_forecast:
+      bank_account_balances: Selected bank balance(s)
+      description: Use this report to analyse your projected cash flow in and cash
+        flow out for future periods.
+      detailed_reports: Detailed Breakdown
+      filename: cash_flow_forecast
+      forecast_transaction_prefix: Expected
+      forecast_transaction_title: Expected %{transaction_type}
+      inbound_adjustments: Manual Adjustments
+      outbound_adjustments: Manual Adjustments
+      payroll_adjustments: Payroll costs for forecast period
+      prior_expected_net_cashflow: Expected net cash flow prior to selected date range
+      title: Cash Flow Forecast Report
+      view_detailed_breakdown: Detailed
+      view_prior_transactions: View Prior Transactions
+    cash_flow_forecast_detail:
+      adjustment_details: Details
+      customer: Customer
+      expected_amount: Expected Amount
+      expected_customer_receipts: Expected Customer Receipts
+      expected_customer_refunds: Expected Customer Refunds
+      expected_date: Expected Date
+      expected_other_payments: Expected Other Payments
+      expected_other_receipts: Expected Other Receipts
+      expected_supplier_payments: Expected Supplier Payments
+      expected_supplier_refunds: Expected Supplier Refunds
+      filename: cash_flow_forecast_detail
+      inbound_manual_adjustments: Manual Adjustments
+      outbound_manual_adjustments: Manual Adjustments
+      payroll_manual_adjustments: Payroll Adjustments
+      reference: Reference
+      supplier: Supplier
+      total: Total
+    cash_flow_forecast_prior_transactions:
+      filename: cash_flow_forecast_prior_transactions
+    cash_flow_statement_detail:
+      amount: Amount
+      cashflow_in: Cash Flow In
+      cashflow_out: Cash Flow Out
+      contact: Contact
+      customer: Customer
+      customer_receipts: Customer Receipts
+      customer_refunds: Customer Refunds
+      filename: cash_flow_statement_detail
+      interest_charges_in: Interest/Charges In
+      interest_charges_out: Interest/Charges Out
+      journals_in: Journals In
+      journals_out: Journals Out
+      no_data: You do not have any %{type} transactions based on the current filter
+        selection.
+      no_data_title: There is nothing to show.
+      other_payment_refunds: Other Payment Refunds
+      other_payments: Other Payments
+      other_receipt_refunds: Other Receipt Refunds
+      other_receipts: Other Receipts
+      payment_date: Payment Date
+      receipt_date: Receipt Date
+      reference: Reference
+      revenue_payments: Revenue Payments
+      staff_payments: Staff Payments
+      supplier: Supplier
+      supplier_payments: Supplier Payments
+      supplier_refunds: Supplier Refunds
+      tax_payments: VAT Payments
+      tax_reclaims: VAT Reclaims
+      total: Total
+      transfers_in: Transfers/Deposits In
+      transfers_out: Transfers/Deposits Out
+    cash_flow_summary:
+      closing_balance: Closing Balance
+      current_vat_liability: VAT Liability for current period*
+      current_vat_liability_text: "* Current VAT Liability is estimate only, VAT period
+        not closed"
+      description: Use this report to analyse your cash flow in and cash flow out
+        for current periods.
+      filename: cash_flow_statement
+      flat_rate_current_vat_liability_text: "* Current VAT Liability is estimate only,
+        VAT period not closed. Based on Standard Scheme, Flat rate calculation will
+        differ."
+      graph:
+        balance: Balance
+        inbound_cashflow: Cash Flow In
+        outbound_cashflow: Cash Flow Out
+      inbound_cashflow: Cash Flow In
+      inbound_cashflow_balance: Total Cash Flow In
+      liability_title: Liability to offset
+      liability_total: Total Liability
+      net_balance: Net Balance
+      opening_balance: Opening Balance
+      outbound_cashflow: Cash Flow Out
+      outbound_cashflow_balance: Total Cash Flow Out
+      payroll_vat_liability: Payroll Taxes
+      period_cashflow: Cash Flow for period
+      previous_vat_liability: VAT Liability for previous period
+      title: Cash Flow Statement Report
+      view_detailed_breakdown: Detailed
+    cash_reports:
+      cash_flow_forecast_title: Cash Flow Forecast
+      cash_flow_summary_title: Cash Flow Statement
+      cashbook_title: Cashbook Report
+      description: Help you to manage your money and understand your cash flow.
+      receipts_and_payments_day_book_title: Receipts and Payments Day Book
+      title: CASH REPORTS
+      unallocated_payments_title: Unallocated Receipts or Payments
+      unreconciled_bank_transactions_title: Unreconciled Bank Transactions
+    cashbook:
+      buttons:
+        apply: Calculate
+        csv: CSV
+        export: Export
+        pdf: PDF
+      columns:
+        balance: Balance
+        contact: Contact
+        currency: Currency
+        date_entered: Date Entered
+        method: Method
+        money_in: Money In (%{currency}) %{currency_symbol}
+        money_out: Money Out (%{currency}) %{currency_symbol}
+        reference: Reference
+        transaction_date: Transaction Date
+        transaction_number: Trx
+        type: Type
+      filename: cashbook
+      filter:
+        bank_account: Bank Account
+        end_date: To
+        reporting_period: Period
+        start_date: From
+      grid:
+        closing_balance: Closing Balance
+        movement: Movement
+        opening_balance: Opening Balance
+        totals: TOTALS
+      messages:
+        max_date_range_error: Choose two dates that are less than a year apart
+    chart_of_accounts:
+      description: Use this report to view and export a list of your ledger accounts.
+      filename: chart_of_accounts
+      title: Chart of Accounts List
+    corrections:
+      create:
+        error_header: Corrections not available
+        error_message: Sorry. We've had to switch Corrections off while we do some
+          work. We'll turn things back on as soon as we can.
+      search:
+        error_header: We can't show these transactions right now
+        error_message: We'll soon get this sorted. Try again in a short while and
+          we can forget this ever happened.
+      toast_error_message: Sorry. We've had to switch corrections off while we do
+        some work. We'll turn things back on as soon as we can.
+    customer_activity:
+      filename: customer_activity
+      no_records: No activity for the selected date range
+      report_name: customer_activity
+      title: Customer Activity Report
+    customer_addresses:
+      filename: customer_addresses
+      no_records: No addresses for the selected customers and address types
+      report_name: customer_addresses
+      title: Customer Address List
+    customer_statement_summary:
+      filename: customer_statement_summary
+      no_records: No activity for the selected date range
+      report_name: customer_statement_summary
+      title: Statement Summary Report
+    customer_statements_batch:
+      no_records: No activity for the selected date and outstanding amount
+      report_name: customer_statements
+      title: Statements Batch Report
+    datev_export:
+      dialog:
+        coming_soon: COMING SOON
+        description: You can export your audit trail into the DATEV format. Please
+          note that the period needs to be within one calendar year.
+        fields:
+          account_labels: Account labels
+          button_text: Export
+          creditor_debtor: Creditor and debtor
+          end_date: End date
+          export_sum: Also export trail balance report
+          start_date: Start date
+        title: DATEV export
+      no_data_available: No transactions available for the given period
+    detail_reports:
+      audit_trail_selector_title: Audit Trail
+      chart_of_accounts_title: Chart of Accounts
+      description: Detailed lists for you to review, or export and analyse.
+      invoice_profit_analysis_title: Profit Analysis
+      nominal_activity_title: Nominal Activity
+      purchase_day_book_title: Purchase Day Book
+      sales_day_book_title: Sales Day Book
+      sales_revenue_title: Sales Revenue - Products & Services
+      title: DETAILED REPORTS
+      trial_balance_title: Trial Balance
+    ec_sales:
+      contact_name: Customer
+      contact_tax_number: VAT Number
+      country_code: Country Code
+      date: Date
+      description: This report shows all EC Sales transactions within a specified
+        period. Use this report to help you complete your EC Sales List on HMRC's
+        website.
+      filename: ec_sales
+      goods_amount: Goods and Related Services
+      include: Include
+      no_tax_number: Not available
+      reference: Reference
+      services_amount: Standalone Services
+      title: EC Sales List
+      total: Total
+      transaction_type: Type
+      triangulated_goods_amount: Triangulated Goods
+    export_dialog:
+      audit_trail_breakdown:
+        download: Audit Trail Breakdown (%{file_type})
+      audit_trail_summary:
+        download: Audit Trail (%{file_type})
+      auxiliary_balance:
+        download: Auxiliary balance (%{file_type})
+      balance_sheet:
+        download: Balance Sheet (%{file_type})
+      balance_statement:
+        download: Balance Sheet (%{file_type})
+      chart_of_accounts:
+        download: Chart of Accounts List (%{file_type})
+      default:
+        download: Report (%{file_type})
+      description: To generate a new report, based on the latest selection criteria
+        you’ve specified, choose the format you want to use.  Depending on the amount
+        of data included on the report, it may take some time to generate.
+      detailed_receipts_and_payments_day_book:
+        download: Detailed Receipts and Payments Day Book (%{file_type})
+      filename: "%{file_name}.%{file_type}"
+      filesize: "%{file_size}"
+      income_statement:
+        download: Income Statement (%{file_type})
+      ledger_entries:
+        download: Ledger Entries (%{file_type})
+      legal_certificate:
+        download: Legal Certificate (%{file_type})
+      message:
+        export_all_warning: Are you sure you want to export all accounts?
+      nominal_activity:
+        download: Nominal Activity (%{file_type})
+      nominal_activity_detail:
+        download: Nominal Activity Detail (%{file_type})
+      nominal_activity_transaction:
+        download: Nominal Activity Detailed (%{file_type})
+      other_expense_payment_detailed_report:
+        download: Other Payment Detailed Report (%{file_type})
+      other_income_payment_detailed_report:
+        download: Other Receipt Detailed Report (%{file_type})
+      overseas_purchase_of_goods:
+        download: Overseas Purchase of Goods (%{file_type})
+      overseas_sales_of_goods:
+        download: Overseas Sale of Goods (%{file_type})
+      previous_reports: The following report(s) have already been generated and can
+        be accessed immediately.
+      purchase_day_book:
+        download: Purchase Day Book (%{file_type})
+      purchase_day_book_detailed:
+        download: Purchase Day Book - Detailed (%{file_type})
+      receipts_and_payments_day_book:
+        download: Receipts and Payments Day Book (%{file_type})
+      sales_day_book:
+        download: Sales Day Book (%{file_type})
+      sales_day_book_detailed:
+        download: Sales Day Book - Detailed (%{file_type})
+      sales_revenue:
+        download: Product & Service Sales Revenue (%{file_type})
+      sales_revenue_detailed:
+        download: Sales Revenue Detailed - Products & Services (%{file_type})
+      stock_movements:
+        download: Stock Movements (%{file_type})
+      stock_movements_detailed:
+        download: Stock Movements Detailed (%{file_type})
+      title:
+        audit_trail_breakdown: Generate Audit Trail Breakdown Report
+        audit_trail_summary: Generate Audit Trail Report
+        auxiliary_balance: Auxiliary balance report
+        balance_statement: Generate Balance Sheet Report
+        chart_of_accounts: Generate Chart Of Accounts List
+        detailed_receipts_and_payments_day_book: Generate Detailed Receipts and Payments
+          Day Book Report
+        income_statement: Generate Income Statement Report
+        ledger_entries: Export Ledger Entries
+        legal_certificate: Export Legal Certificate
+        nominal_activity: Generate Nominal Activity Report
+        nominal_activity_detail: Generate Detailed Nominal Activity Report
+        nominal_activity_transaction: Generate Detailed Nominal Activity Report
+        other_expense_payment_detailed_report: Generate Other Payment Detailed Report
+        other_income_payment_detailed_report: Generate Other Receipt Detailed Report
+        overseas_purchase_of_goods: Export Overseas Purchase of Goods
+        overseas_sales_of_goods: Export Overseas Sale of Goods
+        purchase_day_book: Generate Purchase Day Book Report
+        purchase_day_book_detailed: Generate Purchase Day Book Detailed Report
+        receipts_and_payments_day_book: Generate Receipts and Payments Day Book Report
+        receipts_and_payments_detailed_day_book: Generate Receipts and Payments Day
+          Book Report
+        sales_day_book: Generate Sales Day Book Report
+        sales_day_book_detailed: Generate Sales Day Book Detailed Report
+        sales_revenue: Generate Sales Revenue - Products & Services Report
+        sales_revenue_detailed: Generate Sales Revenue Detailed - Products & Services
+          Report
+        stock_movements: Generate Stock Movements Report
+        stock_movements_detailed: Generate Stock Movements Detailed Report
+        tax_returns: Generate Detailed %{tax_name} Report
+        unallocated_payments: Generate Unallocated Receipts or Payments Report
+        vat_return_detailed: Generate Vat Return Detailed Report
+      unallocated_payments:
+        download: Unallocated Payments Report (%{file_type})
+      unallocated_receipts:
+        download: Unallocated Receipts Report (%{file_type})
+      vat_return_detailed:
+        download: Vat Return Detailed Report (%{file_type})
+    export_dialog_with_advanced_filter:
+      description: To generate a new export, select a period and choose the format
+        you want to use. Depending on the amount of data included in the export, it
+        may take some time to generate.
+      previous_reports: The following export(s) have already been generated and can
+        be accessed immediately.
+    file_titles:
+      detailed_csv: Detailed CSV
+      detailed_pdf: Detailed PDF
+      payments: Payments
+      receipts: Receipts
+    gdpr:
+      contact_personal_data_title: Contacts Personal Data
+      description: Help you manage the personal data of your contacts
+      title: DATA REPORTS
+    general:
+      created_by_on: Created by %{user} on %{date}
+      page_count: Page <span id='pagenumber'></span> of <span id='pagecount'></span>
+      produced_by_sage_one: Produced by Sage Business Cloud %{service_name}
+      user_who_generated_report: 'Who: %{user}'
+    income_statement:
+      name: income_statement
+    index_descriptions:
+      aged_creditors: Who do I owe money to?
+      aged_debtors: Who owes money to me?
+      audit_trail_selector: What took place during a specified date range?
+      auxiliary_balance: What is the balance for each sub account?
+      balance_sheet: How much are my assets and liabilities worth?
+      balance_statement: How much is my business worth?
+      cash_flow_forecast: How much cash in and out should I expect?
+      cash_flow_summary: How much actual cash came in and out?
+      cashbook: What are the transactions and running balance for a selected bank
+        account?
+      chart_of_accounts: What ledger accounts are set up?
+      contact_personal_data: Which contacts' personal data can now be removed?
+      datev_export: Export your journal entries to the DATEV format.
+      ec_sales: Help me complete my EC Sales List
+      income_statement: How profitable was my business this period?
+      invoice_profit_analysis: How much profit did I make on each of my sales?
+      ledger_entries: Export raw data for all my accounting activity.
+      modelo_390: Calculate my Annual VAT return
+      nominal_activity: What transactions took place for each ledger account?
+      overseas_purchase_of_goods: Help me understand my imports, and enable me to
+        reconcile my VAT return
+      overseas_sales_of_goods: Help me understand my exports, and enable me to reconcile
+        my VAT return
+      post_migration_tasks: Download important documents from your previous service.
+      profit_and_loss: How much profit have I made?
+      purchase_day_book: What were my purchases?
+      receipts_and_payments_day_book: What payments did I send and receive?
+      saft: Export data for a selected financial year for an accountant, auditor,
+        or tax authority
+      sage_pay_ecommerce_payments: Which ecommerce payments did I receive through
+        Sage Pay?
+      sage_pay_payments: Which invoice payments did I receive through Sage Pay?
+      sales_day_book: What were my sales?
+      sales_revenue: What was my revenue from sales of products and services?
+      sales_tax: How much sales tax do I owe?
+      stock_movements: What stock items came in and out during a given period?
+      tax_return: Calculate my VAT return
+      trial_balance: What is the balance for each ledger account?
+      unallocated_payments: What transactions haven't been allocated to invoices?
+      unreconciled_bank_transactions: What transactions haven't been matched?
+      vendors: How much have I paid my 1099 Vendors?
+    index_dropdown:
+      all_reports: All Reports
+      favorites: Favourites
+      got_it: Got it
+      notification_text_sage_intelligence: 'Make smart business decisions - '
+      preview_sage_intelligence: Preview Sage Intelligence
+      sage_intelligence: Sage Intelligence
+      sage_intelligence_normal_text: create and customise reports in just a few clicks.
+    index_sub_descriptions:
+      aged_creditors: 'Shows: Outstanding or unallocated supplier transactions by
+        age.'
+      aged_debtors: 'Shows: Outstanding or unallocated customer transactions by age.'
+      audit_trail_selector: 'Shows: All transactions posted for a specified date range.'
+      auxiliary_balance: 'Shows: The balances of your main debtors and creditors accounts,
+        broken down by individual customers and suppliers.'
+      balance_sheet: 'Shows: Assets, liabilities, and equity, up to a given date.'
+      balance_statement: 'Shows: Fixed and current assets, equity, and debts, up to
+        a given date.'
+      cash_flow_forecast: 'Shows: Funds that might come in and out, using expected
+        payment dates.'
+      cash_flow_summary: 'Shows: Funds that came in and out, for a selected period,
+        and selected bank accounts.'
+      cashbook: 'Shows: Receipts, payments and balances for a selected bank account.'
+      chart_of_accounts: 'Shows: A list of your ledger accounts, their category, and
+        tax rate.'
+      contact_personal_data: 'Shows: A list of contacts that is now outside of your
+        business data retention period.'
+      datev_export: Export to DATEV format
+      ec_sales: Helps you complete your EC Sales List on the HMRC website.
+      income_statement: 'Shows: Income and expenses for a given date range.'
+      invoice_profit_analysis: 'Shows: Profit made on sales invoices, credit notes,
+        quotes, and estimates, using product cost and sales prices.'
+      ledger_entries: Export raw data for all your accounting activity.
+      modelo_390: View and submit an Annual VAT return online.
+      nominal_activity: 'Shows: Balances for each ledger account for a given date
+        range.'
+      overseas_purchase_of_goods: All purchase transactions from the EU and the Rest
+        of World
+      overseas_sales_of_goods: All sale transactions from the EU and the Rest of World
+      post_migration_tasks: Sales PDFs from your previous service, and important upgrade
+        tasks
+      profit_and_loss: 'Shows: Income, expense, and profit, for a given date range.'
+      purchase_day_book: 'Shows: Purchase invoices and credit notes for a given date
+        range.'
+      receipts_and_payments_day_book: 'Shows: Payments and receipts for a selected
+        bank account and date range.'
+      saft: Standard Audit File for Tax export.
+      sage_pay_ecommerce_payments: 'Shows: Payments received for a given date range.'
+      sage_pay_payments: 'Shows: Payments received for a given date range.'
+      sales_day_book: 'Shows: Sales invoices and credit notes for a given date range.'
+      sales_revenue: 'Shows: Sales Revenue for products and services for a given date
+        range'
+      sales_tax: 'Shows: Total sales tax due for each tax rate.'
+      stock_movements: 'Shows: Summary stock movements for a given date range.'
+      tax_return: View and submit a VAT return online to HMRC.
+      trial_balance: 'Shows: Balance for each of your ledger accounts, for a given
+        date range.'
+      unallocated_payments: 'Shows: Transactions from contacts that aren''t fully
+        allocated to invoices.'
+      unreconciled_bank_transactions: 'Shows: Unreconciled transactions for a selected
+        bank account, up to a given date.'
+      vendors: 'Shows: Your total payments for each of your 1099 Vendors for the year,
+        to help you fill out a 1099 Misc Form when this is required.'
+    invoice_profit_analysis:
+      all: All
+      cost: Cost
+      cost_price_warning: "*Cost price is not available for one or more line items,
+        therefore profit may not be accurate."
+      customer: Customer name
+      date: Date
+      description: This report analyses the profit on your sales invoices and quotations
+        using the cost price and sales price of your products.
+      detailed: Show details
+      filename: profit_analysis
+      filename_detailed: profit_analysis_detailed
+      filename_summary: profit_analysis_summary
+      from_date: From
+      include: 'Include:'
+      included:
+        all: All
+        invoices_credit_notes: Invoices / Credit Notes
+        quotes: Quotes / Estimates
+      invoice_credit_note: Number
+      net: Net
+      profit_amount: Profit (Amt)
+      profit_percentage: Profit (%)
+      quantity: Qty/Hrs
+      quote_exp_date: Exp. Date
+      search: Search
+      summary_detailed:
+        detailed: Detailed report
+        summary: Summary report
+      title: Profit Analysis Report
+      title_detailed: Profit Analysis Detailed Report
+      title_summary: Profit Analysis Report
+      to_date: To
+      total: TOTAL
+    journal:
+      journal_title: Journal
+    ledger_entries:
+      fields:
+        artefact_number: Artefact Number
+        auxiliary_account: Auxiliary Account
+        base_currency_code: Currency
+        cr: Credit
+        credit: Credit
+        date: Date
+        debit: Debit
+        dr: Debit
+        journal_code: Journal Code
+        nominal_code: Nominal Code
+        reference: Reference
+        transaction_number: Trx No
+      filename: ledger_entries
+      ledger_entries: Ledger Entries
+    legal_certificate:
+      antifraud:
+        filename: certificate_antifraud
+    management:
+      aged_creditors_title: Aged Creditors
+      aged_debtors_title: Aged Debtors
+      auxiliary_balance_title: Auxiliary Balance
+      balance_sheet_title: Balance Sheet
+      balance_statement_title: Balance Sheet
+      description: For you and your accountant, to understand the current state of
+        your business.
+      income_statement_title: Income Statement
+      profit_and_loss_title: Profit and Loss
+      title: ESSENTIAL REPORTS
+      trial_balance_title: Trial Balance
+    new_report_version_feeback_link: We'd love your feedback <span class='link_grey_part'>on
+      this beta report.</span>
+    new_report_version_link: We are working on improvements - try the <span class='beta_version'>BETA</span>
+      version.
+    nominal_activity:
+      category: Category
+      closing_balance: Closing Balance
+      description: This is where you can view your Nominal Activity Report.
+      filename: nominal_activity
+      ledger_account: Ledger Account
+      opening_balance: Opening Balance
+      other_contact_name: Others
+      period_variance: Period Variance
+      status:
+        active: Exclude deleted
+        all: All
+        deleted: Deleted only
+        status: Status
+      title: Nominal Activity Report
+      totals: Totals
+      transaction_type: Transaction Type
+    nominal_activity_detail:
+      filename: nominal_activity_detail
+    nominal_activity_transaction:
+      credit: Credit
+      date: Date
+      debit: Debit
+      description: Description
+      filename: nominal_activity_detailed
+      invoice_number: Inv No
+      journal_code_code: Jrn Code
+      name: Name
+      reference: Reference
+      running_total: Running Total
+      transaction_number: Trx
+      transaction_type: Type
+    online_payment:
+      description: From Paya
+      index_description: Which payments took place using Paya?
+      index_sub_description: Links you to credit card reports in the Paya Virtual
+        Terminal.
+      title: ONLINE PAYMENT REPORTS
+    overseas_goods:
+      purchases:
+        columns:
+          charged_vat: Charged VAT
+          date: Date
+          estimated_vat: Estimated VAT
+          invoice_total: Total
+          name: Name
+          net: Net
+          rate: VAT Rate
+          reference: Reference
+          transaction_id: Trx No
+          type: Type
+        eu_section_header: EU Purchases
+        filename: overseas_purchase_goods
+        import_invoices_section_header: Import Invoices
+        row_section_header: Rest of World Purchases
+      sales:
+        columns:
+          charged_vat: VAT
+          contact_reference: Contact Reference
+          date: Date
+          invoice_total: Total
+          name: Name
+          net: Net
+          rate: VAT Rate
+          reference: Invoice Number
+          transaction_id: Trx No
+          type: Type
+        eu_section_header: EU Sales
+        filename: overseas_sale_goods
+        import_invoices_section_header: Import Invoices
+        row_section_header: Rest of World Sales
+    post_migration_tasks:
+      archiving: Invoices ZIP
+      description: Important information for upgraded businesses
+      pending: Generating reports, please return later...
+      post_migration_tasks_title: Devis-Factures & Compta Simplifiée Reports
+      post_upgrade_tasks: Upgrade Tasks PDF
+      quotes: Quotes ZIP
+      title: Devis-Factures & Compta simplifiée reports
+    products_services_reports:
+      description: Help you understand stock levels.
+      stock_movements_title: Stock Movements
+      title: PRODUCTS & SERVICES REPORTS
+    profit_and_loss:
+      all_analysis_types: All Analysis Types
+      balance_sheet_message:
+        link_text: " Record and Transactions Settings"
+        message: Postings to Profit and Loss Account were included in the Balance
+          Sheet profit calculation. To view this value separately, change the 'Show
+          Profit and Loss Account value' setting in
+        title: Profit and Loss Account included
+      by_month: By Month
+      by_quarter: By Quarter
+      compare_with: Compare with
+      csv:
+        category: Category
+        code: Code
+        cumulative_values: Cumulative Values
+        'false': 'No'
+        name: Name
+        title: Profit and Loss
+        'true': 'Yes'
+        year: Year
+      description: This report shows your business income and expense, giving the
+        profit for your chosen date range.
+      direct_expenses: Direct Expenses
+      direct_expenses_title: Direct Expenses
+      filename: profit_and_loss
+      financial_year: Financial Year %{financial_year}
+      gross_pl: GROSS PROFIT / LOSS
+      hide_percentage: Show No %
+      net_pl: NET PROFIT / LOSS
+      overheads: Overheads
+      overheads_title: Overheads
+      percentage_each_section_tooltip: The value of each row as a percentage of the
+        total for each section
+      percentage_tooltip: Profit as a percentage of Sales Revenue
+      percentage_total_sales_tooltip: The value of each row as a percentage of total
+        sales
+      percentage_totals_footer:
+        each_section: "% Totals is the value of each nominal as a % of the category
+          total YTD."
+        total_sales: "% Sales is the value of each nominal as a % of the total sales
+          YTD."
+      profit_percentage: "% Profit"
+      quarter_title: Quarter
+      rounded_values_note: "<strong>NOTE:</strong> Values have been rounded to whole
+        numbers for clarity."
+      sales: Sales
+      sales_title: Sales
+      selector:
+        comparison: Comparison
+        financial_year: Financial Year
+      show_each_section_percentage: 'Show %: Profit and Total for Each Section'
+      show_total_sales_percentage: 'Show %: Profit and Total Sales'
+      title: Profit and Loss Report
+      total: Total
+      total_direct_expenses: Total Direct Expenses (%{currency})
+      total_gross_profit_or_loss: GROSS PROFIT/LOSS (%{currency})
+      total_gross_profit_or_loss_tooltip: The value of your sales, minus your expenses
+        (the cost of making a product or providing a service).
+      total_net_profit_or_loss: NET PROFIT/LOSS (%{currency})
+      total_net_profit_or_loss_tooltip: The value of your sales, minus your expenses
+        (the cost of making a product or providing a service), also minus your overheads
+        (like payroll, taxation, and interest). Whether your business earned more
+        than it spent.
+      total_overheads: Total Overheads (%{currency})
+      total_sales: Total Sales (%{currency})
+      totals: Totals
+      use_cumulative_values: Use cumulative values
+      values_up_to: Values up to
+    purchase_day_book:
+      analysis_type: Analysis Type
+      analysis_type_category: Analysis Category
+      description: This report shows purchase transactions for a specified date range.  You
+        can view a certain transaction type, or all of your purchase transactions,
+        listed in date order.
+      filename: purchase_day_book
+      link_to_detailed_report: Detailed
+      title: Purchase Day Book Report
+      transaction_type: Type
+    purchase_day_book_detailed:
+      filename: purchase_day_book_detailed
+      link_to_summary_report: Summary
+      title: Purchase Day Book - Detailed
+    receipts_and_payments_day_book:
+      bank_account: Account
+      description: This report shows receipt or payment transactions for a selected
+        bank account, for a specified date range.
+      filename: receipts_and_payments_day_book
+      payment_type_selector: Incomes/Expenses
+      payment_type_values:
+        expenses: Expenses
+        incomes: Incomes
+      title: Receipts and Payments Day Book Report
+      transaction_type: Type
+      transaction_type_group: Receipt/Payment
+      transaction_type_group_values:
+        all_types: All
+        payments: Payments
+        receipts: Receipts
+    receipts_and_payments_day_book_detailed:
+      no_tax_rate: No tax rate applied
+      title: "%{transaction_type} - Detailed Report"
+      total: Total
+    remote_reports:
+      archive: Archive
+      audit_trail_breakdown: Audit Trail Breakdown
+      audit_trail_summary: Audit Trail
+      auxiliary_balance: Auxiliary balance
+      balance_sheet: Balance Sheet
+      balance_statement: Balance Sheet
+      chart_of_accounts: Chart of Accounts
+      customer_activity: Customer Activity
+      customer_addresses: Customer Address List
+      customer_statement_summary: Customer Statement Summary
+      customer_statements: Customer Statements
+      income_statement: Income Statement
+      ledger_account_export: Chart of Accounts Export
+      ledger_entries: Ledger Entries
+      legal_certificate: Legal Certificate
+      nominal_activity: Nominal Activity
+      nominal_activity_detail: Nominal Activity Detailed
+      nominal_activity_detailed: Nominal Activity Detailed
+      other_expense_payment_detailed_report: Other Payments Detailed
+      other_income_payment_detailed_report: Other Receipts Detailed
+      overseas_purchase_of_goods: Overseas Purchase of Goods
+      overseas_sales_of_goods: Overseas Sale of Goods
+      purchase_day_book: Purchase Day Book
+      purchase_day_book_detailed: Purchase Day Book - Detailed
+      receipts_and_payments_day_book: Receipts and Payments Day Book
+      saft: SAF-T
+      sales_day_book: Sales Day Book
+      sales_day_book_detailed: Sales Day Book - Detailed
+      sales_revenue: Sales Revenue - Products & Services
+      sales_revenue_detailed: Sales Revenue Detailed - Products & Services
+      stock_movements: Stock Movements
+      stock_movements_detailed: Stock Movements Detailed
+      supplier_activity: Supplier Activity
+      supplier_addresses: Supplier Address List
+      tax_return_detailed: Vat Return (Detailed)
+      unallocated_payments: Unallocated Payments
+      unallocated_receipts: Unallocated Receipts
+      url_not_available: Your report has not generated. Please either wait for it
+        to finish or try rerunning the report.
+      vat_return_detailed: Vat Return (Detailed)
+    reporting_period: Period
+    reporting_periods:
+      all_dates: All Dates
+      custom: Custom
+      difference: Difference
+      last_financial_year: Last Financial Year
+      last_month: Last Month
+      last_quarter: Last Quarter
+      last_year: Last Year
+      previous_period: Previous Period
+      previous_year: Previous Year
+      show_year_to_date: Show year-to-date
+      this_financial_year: This Financial Year
+      this_month: This Month
+      this_period: This Period
+      this_quarter: This Quarter
+      this_year: This Year
+      to_date: "%{year}-to-date"
+      year_to_date: Year-to-date
+    saft:
+      errors:
+        missing_ledger_account: DELETED
+      fields:
+        allocation_code: EcritureLet
+        allocation_date: DateLet
+        artefact_reference: Artefact Reference
+        auxiliary_account: CompAuxNum
+        auxiliary_name: CompAuxLib
+        contact_id: IdClient
+        creation_date: Creation Date
+        credit: Credit
+        currency_amount: Montantdevise
+        currency_code: Idevise
+        debit: Debit
+        journal_code: JournalCode
+        journal_name: JournalLib
+        ledger_account_display_name: Account Name
+        ledger_account_nominal_code: Nominal Code
+        payment_date: DateRglt
+        payment_mode: ModeRglt
+        transaction_date: Transaction Date
+        transaction_number: Transaction Number
+        transaction_reference: Transaction Reference
+        transaction_type: NatOp
+        validation_date: Validation Date
+      filename: SAFT
+      saft: Standard Audit File for Tax
+    sage_intelligence_link:
+      link_text: Sage Intelligence
+      text: 'Create your own report like this - preview '
+    sage_pay:
+      description: From Sage Pay
+      sage_pay_ecommerce_payments_title: Ecommerce Payments
+      sage_pay_payments_title: Payments Received
+      title: ONLINE PAYMENTS REPORTS
+    sage_pay_ecommerce_payments:
+      contact: Name
+      date: Date
+      description: This is where you can view imported Sage Pay ecommerce payments.
+      filename: sage_pay_ecommerce_payments
+      net: Net
+      reference: Reference
+      tax: VAT
+      title: Ecommerce Payments
+      total: Total
+      transaction_type: Type
+    sage_pay_payments:
+      allocated_amount: Allocated Amount
+      amount: Payment Amount
+      associated_transaction: Transaction
+      date: Payment Date
+      description: This is where you can view invoice payments received via Sage Pay.
+      filename: sage_pay_payments
+      other_income_payment: Other Income Receipt
+      payment_on_account: Payment On Account
+      reference: Reference
+      title: Payments Received
+    sales_batch_entries:
+      filename: sales_quick_entries
+    sales_day_book:
+      analysis_type: Analysis Type
+      analysis_type_category: Analysis Category
+      description: This report shows sales transactions for a specified date range.  You
+        can view a certain transaction type, or all of your sales transactions, listed
+        in date order.
+      filename: sales_day_book
+      link_to_detailed_report: Detailed
+      title: Sales Day Book Report
+      transaction_type: Type
+    sales_day_book_detailed:
+      filename: sales_day_book_detailed
+      link_to_summary_report: Summary
+      title: Sales Day Book - Detailed
+    sales_invoices_and_credit_notes_batch:
+      filename: sales_invoices_and_credit_notes
+    sales_revenue:
+      access_level_warning: Your access level does not give you permission to view
+        Profit information.
+      all_categories: All Categories
+      all_types: All Types
+      category_name: 'Category: %{category_name}'
+      cost: Cost
+      cost_price_warning: "*Cost price is not available for one or more items, therefore
+        the profit may not be accurate."
+      date: Date
+      detailed: Detailed
+      filename: sales_revenue_products_services
+      invoice_number: Invoice No.
+      item_code: Item Code
+      item_description: Item Description
+      name: Name
+      net: Net
+      profit: Profit
+      profit_percentage: Profit (%)
+      quantity: Qty/Hrs
+      summary: Summary
+      total: Total
+      transaction_number: Trx No.
+      type: Type
+      type_name: 'Type: %{type_name}'
+      unit_price: Unit Price
+    sales_revenue_detailed:
+      access_level_warning: Your access level does not give you permission to view
+        Profit information.
+      all_categories: All Categories
+      all_types: All Types
+      category_name: 'Category: %{category_name}'
+      cost: Cost
+      cost_price_warning: "*Cost price is not available for one or more items, therefore
+        the profit may not be accurate."
+      date: Date
+      detailed: Detailed
+      filename: sales_revenue_detailed_products_services
+      invoice_number: Invoice No.
+      item_code: Item Code
+      item_description: Item Description
+      name: Name
+      net: Net
+      profit: Profit
+      profit_percentage: Profit (%)
+      quantity: Qty/Hrs
+      summary: Summary
+      total: Total
+      transaction_number: Trx No.
+      type: Type
+      type_name: 'Type: %{type_name}'
+      unit_price: Unit Price
+    sales_tax:
+      agency: Agency
+      csv_filename: sales_tax
+      customer: Customer
+      date: Date
+      description: This report shows a summary of your tax liabilities for your chosen
+        date range.
+      detailed_csv_filename: sales_tax_breakdown
+      from: From
+      grand_total: 'Total Liability:'
+      item_description: Description
+      link_to_breakdown: View Detailed
+      link_to_summary: Summary
+      net_output: Net Output
+      number: Number
+      order_id: Order ID
+      origin_city: Origin City
+      origin_line1: Origin Line 1
+      origin_line2: Origin Line 2
+      origin_state: Origin State
+      origin_zip: Origin Zip
+      percentage: Percentage
+      popover_button: Got it
+      reference: Reference
+      sales: Sales
+      sales_tax: Sales Tax
+      shipping: Shipping
+      shipping_city: Shipping City
+      shipping_line1: Shipping Line 1
+      shipping_line2: Shipping Line 2
+      shipping_state: Shipping State
+      shipping_tax: Shipping Tax
+      shipping_zip: Shipping Zip
+      tax: Tax
+      tax_authority: Tax Authority
+      tax_exempt: Tax Exempt
+      tax_output: Tax Output
+      tax_rate: Tax Rate
+      taxable_sales: Taxable Sales
+      title: Sales Tax Report
+      total: TOTALS
+      totals_tax_authorities: 'TOTAL: ALL AUTHORITIES'
+      type: Type
+      until: Until
+    stock_movements:
+      all_categories: All Categories
+      category_name: 'Category: %{category_name}'
+      cost_price_warning: "*Cost price is not available for one or more items, therefore
+        the value out may not be accurate."
+      filename: stock_movements
+      id: Id
+      item_code: Item Code
+      item_description: Item Description
+      quantity_in: Quantity In
+      quantity_out: Quantity Out
+      total: Total
+      value_in: Value In
+      value_out: Value Out
+    stock_movements_detailed:
+      adjustment_in: Adj In
+      adjustment_out: Adj Out
+      cost_price_warning: "*Cost price is not available for this item, therefore the
+        value out may not be accurate."
+      date: Date
+      details: Details
+      filename: stock_movements_detailed
+      goods_in: In
+      goods_out: Out
+      invoice_number: Invoice No.
+      quantity_in: Quantity In
+      quantity_out: Quantity Out
+      reference: Reference
+      total: Total
+      type: Type
+      value_in: Value In
+      value_out: Value Out
+    summary:
+      cashflow_forecast:
+        title: Cash Flow Forecast
+      cashflow_statement:
+        title: Cash Flow Statement
+      current_account:
+        acc_number: Account Number
+        balance: Current Balance
+      customers_by_invoices:
+        add_new_sales_invoice: Add a new sales invoice.
+        all_other_customers: All other customers...
+        report_types:
+          outstanding: Outstanding
+          overdue: Overdue
+      customers_by_outstanding_invoices:
+        no_data_message: No customers have outstanding balances.
+        title: Customers by outstanding invoices
+      customers_by_overdue_invoices:
+        no_data_message: No customers have overdue balances.
+        title: Customers by overdue invoices
+      day: Day
+      due_in: Due in
+      expenses: Expenses
+      general:
+        days: Days
+        due: Due
+        from_before_this_period: From before this period
+        loading: Fetching data...
+        more: more...
+        no_vat_return: A VAT return has not yet been run.
+        overdue: Overdue
+        payable: Payable
+        reclaimable: Reclaimable
+        run_vat_return: Run VAT Return
+        so_far_this_period: So far this period
+        vat_period_ends_in: VAT period ends in
+        vat_returns: VAT Returns
+      getting_started:
+        bank_accounts:
+          link: Set up and connect your online bank accounts
+          title: Connect bank accounts
+        chart_of_accounts:
+          opening_balances: Enter opening account balances
+          results: Review the Trial Balance report
+          title: Set up chart of accounts
+          view: Review the standard chart of accounts
+        check_figures:
+          aged_creditors:
+            link: Aged creditors report
+            tooltip: View outstanding supplier transactions.
+          aged_debtors:
+            link: Aged debtors report
+            tooltip: 'View outstanding customer transactions. '
+          nominal_activity:
+            link: Nominal activity report
+            tooltip: View transactions on your ledger accounts.
+          title: 'Check your figures:'
+          trial_balance:
+            link: Trial balance report
+            tooltip: View the balance on your ledger accounts.
+        customers:
+          import: Create or import customers
+          money: Enter money customers owe to you
+          results: Review the Aged Debtors report
+          title: Set up customers
+        hide_getting_started:
+          link_text: Hide Getting Started
+          text: Don't want to see this 'getting started' panel anymore?
+        optional_extras:
+          about_your_business:
+            subtext: Record key pieces of information about your business
+            text: Enter information about your business
+          analysis_types:
+            link: Set your Analysis Categories
+            tooltip: Set up Analysis Types and categories to analyse your information.
+          business_logo:
+            subtext: Add your logo and payment terms
+            text: Want to customise your invoices?
+          colleagues:
+            subtext: Invite others to work with your information.
+            text: Do you work with colleagues?
+          default_settings:
+            link: Choose your default settings and preferences
+            subtext: Maximise your productivity
+            text: Review default settings and preferences
+            tooltip: Choose preferences to apply when creating records and transactions.
+          foreign_currency:
+            subtext: Enable foreign currency transactions
+            text: Do you buy or sell in foreign currencies?
+          products_services:
+            subtext: Create or import details for super fast sales
+            text: Do you sell products, or services?
+          projects:
+            subtext: Set them up, for powerful business analysis
+            text: Do you have departments, cost codes, or projects?
+          title:
+            subtext: More customisation settings.
+            text: Optional extras
+          user_managements:
+            link: Set up users
+            tooltip: Create and manage the users you want to access Accounting.
+        setup_opening_balances:
+          bank_opening_balances:
+            link: Enter bank account opening balances
+            tooltip: Enter bank account balances from your previous accounting system.
+          nominal_opening_balances:
+            link: Enter nominal account opening balances
+            tooltip: Record the balances of your ledger accounts from your previous
+              accounting system.
+          outstanding_customer:
+            link: Enter outstanding customer transactions
+            tooltip: Record outstanding customer transactions from your previous accounting
+              system.
+          outstanding_supplier:
+            link: Enter outstanding supplier transactions
+            tooltip: Record supplier transactions from your previous accounting system.
+          title: 'Setting up opening balances:'
+        setup_records:
+          bank_accounts:
+            icon: pound
+            link: Set up bank accounts
+            tooltip: Create records for the bank accounts, including credit card and
+              loan accounts that your business holds.
+          customer_records:
+            link: Set up customer records
+            tooltip: Create records for the customers who buy from you regularly.
+          products_services:
+            link: Set up your products and services
+            tooltip: Set up records for the products and services you sell.
+          supplier_records:
+            link: Set up supplier records
+            tooltip: Create records for the suppliers you use regularly.
+          title: 'Setting up your records:'
+        suppliers:
+          import: Create or import suppliers
+          money: Enter money you owe to suppliers
+          results: Review the Aged Creditors report
+          title: Set up suppliers
+        title: Getting Started
+      index:
+        your_summary_screen: This is your summary screen
+      micro:
+        bank_balance: Bank Balance
+        banking: Banking
+        email_us: E-mail us
+        expense: Expenses
+        income: Sales
+        loss: Loss
+        need_some_help: Need some help?
+        new_expense: New Expense
+        new_income: New Sales
+        on_last_period: on last %{period}
+        period:
+          month: this month
+          year: this year
+        profit: Profit
+        read_helpful_articles: Read helpful articles
+        sage_one_balance: Balance
+        this_month: This month
+        this_period: this %{period}
+        this_year: This year
+        view: View
+      overdue: Overdue
+      profit: Profit
+      purchases:
+        analysis_graph:
+          net_total: Net Purchases
+        ledger_account_breakdown:
+          footnote: For last 30 days
+          other: Other
+          title: Breakdown by Ledger Account
+        outstanding_invoices: Outstanding Purchase Invoices
+        overdue_invoices:
+          link: Create new purchase invoice
+          text: No overdue purchase invoices
+          title: Overdue Purchase Invoices
+        title: Purchases
+        top_creditors:
+          text: You do not have any creditors at the moment.
+          title: Top 5 Creditors
+        top_suppliers:
+          footnote: For last 30 days
+          link: Create new supplier
+          text: You have not made any purchases in the last 30 days.
+          title: Top 5 Suppliers
+      quotes:
+        conv: Conversion in invoice
+        count: Number of open quotes and estimates
+        expire_in_1: Expire tomorrow
+        expire_in_n: Expire in
+        sum: Total net amount
+        title: Quotes and Estimates
+        top_5_open_quotes: Top 5 Open Quotes and Estimates
+      sales:
+        analysis_graph:
+          net_total: Net Sales
+        expired: Expired
+        lost: Lost
+        outstanding_invoices: Outstanding Sales Invoices
+        overdue_invoices:
+          link: Create new sales invoice
+          text: No overdue sales invoices
+          title: Overdue Sales Invoices
+        pending: Pending
+        quotes: Quotes & Estimates
+        title: Sales
+        top_customers:
+          footnote: For last 30 days
+          link: Create new customer
+          text: You have not had any sales in the last 30 days.
+          title: Top 5 Customers
+        top_debtors:
+          text: You do not have any debtors at the moment.
+          title: Top 5 Debtors
+        won: Won
+      sales_invoices_by_status:
+        no_invoices_message_1: 'As soon as you '
+        no_invoices_message_2: |-
+          ,
+           a breakdown of invoices will be shown here.
+        no_invoices_message_link: add an invoice
+        status:
+          current: Current
+          draft: Draft
+          overdue: Overdue
+        subtitle:
+          one: In %{count} invoice owed to you
+          other: In %{count} invoices owed to you
+      top_5_unpaid_sales_invoices: Top 5 Unpaid Sales Invoices
+      ytd: Year to Date
+    supplier_activity:
+      filename: supplier_activity
+      no_records: No activity for the selected date range
+      report_name: supplier_activity
+      title: Supplier Activity Report
+    supplier_addresses:
+      filename: supplier_addresses
+      no_records: No addresses for the selected suppliers and address types
+      report_name: supplier_addresses
+      title: Supplier Address List
+    switch_back_old_report: Switch back to the old report.
+    tax_reports:
+      datev_export_title: DATEV Export
+      description: Help you export, create VAT returns and EC Sales Lists.
+      ec_sales_title: EC Sales Analysis
+      ledger_entries_title: Ledger Entries Export
+      overseas_purchase_of_goods_title: Overseas Purchase of Goods
+      overseas_sales_of_goods_title: Overseas Sale of Goods
+      saft_title: SAF-T Export
+      sales_tax_title: Sales Tax Report
+      tax_return_title: VAT Return
+      title: VAT REPORTS AND EXPORTS
+      vendors_title: 1099 Vendor Report
+    tax_return_detail:
+      box_detail:
+        adjustment: Adjustment Amount
+        adjustment_reason: 'Adjustment Reason: '
+        amount: Amount
+        box_total: Total
+        category: Ledger Account
+        date: Date
+        name: Name
+        rate: Rate
+        reference: Reference
+        reverse_charge_total: Reverse Charge VAT
+        tax_rate_subtotal: 'Total for %{tax_rate}: '
+        titles:
+          box_1: Box 1 - VAT due in this period on sales and other outputs
+          box_2: Box 2 - VAT due in this period on acquisitions from other EC Member
+            States
+          box_3: Box 3 - Total VAT due (the sum of boxes 1 and 2)
+          box_4: Box 4 - VAT reclaimed in this period on purchases and other inputs
+            (including acquisitions from the EC)
+          box_5: Box 5 - Net VAT to be paid to Customs or reclaimed by you (Difference
+            between boxes 3 and 4)
+          box_6: Box 6 - Total value of sales and all other outputs excluding any
+            VAT. Include your box 8 figure
+          box_7: Box 7 - Total value of purchases and all other inputs excluding any
+            VAT. Include your box 9 figure
+          box_8: Box 8 - Total value of all supplies of goods and related services,
+            excluding any VAT, to other EC Member States
+          box_9: Box 9 - Total value of all acquisitions of goods and related services,
+            excluding any VAT, from other EC Member States
+        total: 'Total for Box '
+        transaction: TrxID
+        transaction_number: Number
+        transaction_type: Type
+        unadjusted_total: Transaction Total
+        vca_scheme_change_clearup: Prior Scheme Transfer
+        vca_scheme_change_clearup_flat_rate: Prior Scheme Transfer (Standard Liability
+          Shown - Box total will reflect your flat rate %)
+      box_name: BOX
+      from_date: 'VAT Detailed Report for Period '
+      include_prior_transactions: 'Note: This report includes transactions from prior
+        periods'
+      migrated: This VAT return is based on data migrated from your old accounting
+        system.
+      not_applicable: N/A
+      title: VAT Report (Detailed)
+      to_date: " to "
+    tax_return_detailed:
+      report_name: vat_return_detailed
+    tax_return_summary:
+      draft_tax_return: This is a draft VAT return and has yet to be submitted.
+      flat_rate_information:
+        flat_rate_difference: "%{difference_key} %{difference}"
+        flat_rate_difference_note: 'Note: These figures do not include any adjustments'
+        flat_rate_vat: Based on a flat rate of %{rate}% the actual VAT due is %{flat_rate_vat}
+        net_vat: On a Standard Scheme your VAT due would have been %{net_vat}
+        not_saved_money_using_flat_rate: Using a flat rate VAT scheme has cost you
+        saved_money_using_flat_rate: Using a flat rate VAT scheme has saved you
+        title: Flat Rate
+      from_date: 'From: '
+      include_prior_transactions: 'Includes prior transactions: '
+      payment_information:
+        headers:
+          amount: Amount
+          date: Date
+          reference: Reference
+      payment_summary: Payment Summary
+      reclaim_summary: Reclaim Summary
+      status_summary_tables:
+        payment_summary: Payment Summary
+        refund_summary: Refund Summary
+        submit_by_whom: " by %{submit_by}"
+        submit_date: Submitted %{submit_date}
+        title: Submission Summary
+      submission_information:
+        correlation_id: 'Correlation ID: %{correlation_id}'
+        status: "%{status} on "
+        title: Submission Summary
+      summary_report_period: 'VAT Return From: %{start_date} To: %{end_date}'
+      tax_registration_number: 'VAT Registration Number: %{country_code} %{tax_number}'
+      title: VAT Return
+      to_date: 'To: '
+      total_uppercased: TOTAL
+    trial_balance:
+      brought_forward:
+        credit: Credit
+        debit: Debit
+        title: Brought Forward
+      credits: Credits
+      debits: Total Debits
+      description: This report displays the balance on your nominal accounts for a
+        specified date range. You can include brought forward values and include current
+        year’s profit and loss values only.
+      filename: trial_balance
+      include_current_year_profit_and_loss: Summarise profit and loss values
+      ledger_account: Name
+      ledger_account_class_subtotal: TOTAL CLASS %{classification}
+      name: Name
+      nominal_code: Nominal Code
+      reporting_period:
+        credit: Credit
+        debit: Debit
+        title: Selected Period
+      show_brought_forward_label: Show Brought Forward values
+      this_period_only: This period only
+      title: Trial Balance
+      total: Total
+      totals:
+        credit: Credit
+        debit: Debit
+        title: Totals
+    unallocated_payments:
+      account_name_and_balance: "%{contact_name}, Account balance: %{balance}"
+      fields:
+        contact_name: Name
+        date: Date
+        reference: Ref
+        tax_rate_name: VAT Rate
+        total_amount: Total amount
+        unallocated_amount: Unallocated amount
+      payments: Unallocated payments
+      payments_filename: unallocated_payments
+      receipts: Unallocated receipts
+      receipts_filename: unallocated_receipts
+    unreconciled_bank_transactions:
+      account_balance: Account Balance
+      balance: Balance
+      bank_account: Bank
+      date: Date
+      description: This report shows all unreconciled bank transactions. You can view
+        these transactions by bank account up to a specified date.
+      end_date: To
+      filename: unreconciled_bank_transactions
+      name: Name
+      payment: Payment
+      receipt: Receipt
+      reconciled_balance: Reconciled Balance
+      reference: Reference
+      search: Search
+      title: Unreconciled Bank Transactions Report
+      total: Total
+      type: Type
+    vat_returns:
+      calculation_running: A VAT Return calculation is already running and should
+        be complete shortly. Please try again in a few minutes.
+      filename: summary_report
+    vendors:
+      buttons:
+        apply: Calculate
+        csv: CSV
+        export: Export
+        pdf: PDF
+      columns:
+        address: Address
+        business_name: Business Name
+        tax_id: Vendor Tax ID
+        total_payments: Total Payments
+      filename: 1099_vendors
+      filter:
+        search: Type to search
+        year: Calendar Year
+        year_label: "%{year} Calendar Year"
+  resource_suggest_create:
+    contacts:
+      create: Add a contact
+      label: Contact
+      search: Search for a Contact
+    customers:
+      create: Add a customer
+      label: Customer
+      search: Search for a Customer
+    new:
+      ledger_account: Create Ledger Account
+    products_services:
+      create: Create item
+      label: Product / Service
+      search: ''
+    suppliers:
+      create: Add a supplier
+      label: Supplier
+      search: Search for a Supplier
+  s1_artefacts:
+    errors:
+      view_in_new_window:
+        message: Please logout of Sage Accounting to view this %{type}.
+        title: Logout to view this %{type}
+  saft_export:
+    export: Export
+    financial_year: Financial year
+    financial_year_detailed: From %{fy_start_date} to %{fy_end_date}.
+    lockdown_checkbox: Lock Transactions before %{lockdown_date}
+    lockdown_extra_info: Useful if your report is for audit. Change this in settings.
+    message_title: Generating your report may take a few minutes.
+    report_end_date: You can change your report end date.
+    report_end_date_date: End Date
+    report_end_date_range: Must be inside financial year limits.
+    title: SAF-T Export
+  sales_artefact:
+    delivery_address_not_filled: Delivery Address is required.
+    discount_amount: Amount
+    discount_percentage: "%"
+    invoice_address_not_filled: Invoice Address is required.
+    issued_false: 'No'
+    issued_true: 'Yes'
+    price_list: Select a price
+  sales_corrective_invoice:
+    confirm:
+      helper_text:
+        confirm_no_vat: |
+          **For example, do not use 'No VAT' for**:
+          &bull; **Overseas sales** - instead, enter the customer's address and any VAT number on their record. This applies a zero rate and keeps your returns and reports correct.
+          &bull; **Customers who aren't VAT-registered.** They can't reclaim VAT, but they should always be charged applicable VAT.
+        confirm_vat_only: "**For example, do not create VAT-only corrective invoices
+          for goods previously sold** if a customer has just become VAT registered."
+      messages:
+        confirm_no_vat: |
+          **'No VAT' has been selected on this corrective invoice.**
+          This is for special situations only - check with an accountant to be sure.
+        confirm_vat_only: |
+          **This corrective invoice only has a VAT value.**
+          This is for special situations only - check with an accountant to be sure.
+        total_zero: |
+          This Corrective Invoice has a value of %{currency_amount}.
+          Would you like to save it anyway, or continue editing?
+      title:
+        confirm_no_vat: Choosing 'No VAT'
+        confirm_vat_only: VAT-only Corrective Invoices
+        total_zero: Zero Value Corrective Invoice
+  sales_credit_note:
+    confirm:
+      helper_text:
+        confirm_no_vat: |
+          **For example, do not use 'No VAT' for:**
+          &bull; **Overseas sales** - instead, enter the customer's address and any VAT number on their record. This applies a zero rate and keeps your returns and reports correct.
+          &bull; **Customers who aren't VAT-registered.** They can't reclaim VAT, but they should always be charged applicable VAT.
+
+          **[Read guidance from HMRC](https://www.gov.uk/guidance/rates-of-vat-on-different-goods-and-services)** on when to select Zero Rated or Exempt instead.
+        confirm_vat_only: "**For example, do not create VAT-only credit notes for
+          goods previously sold** if a customer has just become VAT registered."
+      messages:
+        confirm_no_vat: |
+          **'No VAT' has been selected on this credit note.**
+          This is for special situations only - check with an accountant to be sure.
+        confirm_vat_only: |
+          **This credit note only has a VAT value.**
+          This is for special situations only - check with an accountant to be sure.
+        total_zero: |
+          This Credit Note has a value of %{currency_amount}.
+          Would you like to save it anyway, or continue editing?
+      title:
+        confirm_no_vat: Choosing 'No VAT'
+        confirm_vat_only: VAT-only Credit Notes
+        total_zero: Zero Value Credit Note
+    credit_note_number:
+      draft: DRAFT
+  sales_estimate:
+    confirm:
+      messages:
+        total_zero: |
+          This Estimate has a value of %{currency_amount}.
+          Would you like to save it anyway, or continue editing?
+      title:
+        total_zero: Zero Value Estimate
+  sales_invoice:
+    confirm:
+      helper_text:
+        confirm_no_vat: |
+          **For example, do not use 'No VAT' for**:
+          &bull; **Overseas sales** - instead, enter the customer's address and any VAT number on their record. This applies a zero rate and keeps your returns and reports correct.
+          &bull; **Customers who aren't VAT-registered.** They can't reclaim VAT, but they should always be charged applicable VAT.
+
+          **[Read guidance from HMRC](https://www.gov.uk/guidance/rates-of-vat-on-different-goods-and-services)** on when to select Zero Rated or Exempt instead.
+        confirm_vat_only: "**For example, do not create VAT-only invoices for goods
+          previously sold** if a customer has just become VAT registered."
+      messages:
+        confirm_no_vat: |
+          **'No VAT' has been selected on this invoice.**
+          This is for special situations only - check with an accountant to be sure.
+        confirm_vat_only: |
+          **This invoice only has a VAT value.**
+          This is for special situations only - check with an accountant to be sure.
+        total_zero: |
+          This Invoice has a value of %{currency_amount}.
+          Would you like to save it anyway, or continue editing?
+      title:
+        confirm_no_vat: Choosing 'No VAT'
+        confirm_vat_only: VAT-only Invoices
+        total_zero: Zero Value Invoice
+    header_note: Corresponds to the date of the invoice
+    invoice_number:
+      draft: DRAFT
+      pro_forma: PROFORMA
+  sales_quote:
+    confirm:
+      messages:
+        total_zero: |
+          This Quote has a value of %{currency_amount}.
+          Would you like to save it anyway, or continue editing?
+      title:
+        total_zero: Zero Value Quote
+    quote_number:
+      draft: DRAFT
+    quote_statuses:
+      converted: Invoiced
+      declined: Declined
+      draft: Draft
+      expired: Expired
+      pending: Pending
+    quote_types:
+      all: Estimates & Quotes
+      estimate: Estimates
+      quote: Quotes
+  services:
+    link: "%{name} Settings"
+    service_description: Use this area to manage and make changes to your settings
+      in the %{name} application
+  settings:
+    accounts:
+      invoice:
+      tax:
+        profiles_link_desc: Edit your tax settings
+        sales_tax_link_desc: Edit your tax settings
+        title: Tax Settings
+    default_settings:
+      price_usage:
+        products:
+          message: This price is used by %{count} products, are you sure you want
+            to remove it?
+          title: Delete Price Name
+        services:
+          message: This rate is used by %{count} services, are you sure you want to
+            remove it?
+          title: Delete Rate Name
+    email_defaults:
+      default_messages:
+        corrective_invoice: |
+          Thank you for your business - we're pleased to attach your corrective invoice PDF, which modifies a sales invoice you have already received. Full details, including payment terms are included.
+          If you have any questions, please don't hesitate to contact us.
+          Kind regards,
+          %{business_name}
+          %{telephone}
+        credit_note: |
+          Thank you for your business - we're pleased to attach a credit note for you in PDF.
+          You can use this credit note to count towards future purchases with us.
+          If you have any questions, please don't hesitate to contact us.
+          Kind regards,
+          %{business_name}
+          %{telephone}
+        estimate: |
+          Thank you for your enquiry - we hope you'll like the estimate attached in PDF.
+          Please let us know if you'd like to go ahead and accept it.
+          If you have any questions or would like us to amend the estimate, please just let us know.
+          Looking forward to hearing from you.
+          Kind regards,
+          %{business_name}
+          %{telephone}
+        invoice: |
+          Thank you for your business - we're pleased to attach your invoice in PDF.
+          Full details, including payment terms, are included.
+          If you have any questions, please don't hesitate to contact us.
+          Kind regards,
+          %{business_name}
+          %{telephone}
+        quote: |
+          Thank you for your enquiry - we hope you'll like the quote attached in PDF.
+          Please let us know if you'd like to go ahead and accept it.
+          If you have any questions or would like us to amend the quote, please just let us know.
+          Looking forward to hearing from you.
+          Kind regards,
+          %{business_name}
+          %{telephone}
+        remittance: |
+          I've attached a Remittance Advice in PDF from Sage Business Cloud Accounting for you.
+          If you have any questions, please don't hesitate to contact me.
+          Kind regards,
+          %{business_name}
+          %{telephone}
+        statement: |
+          We're pleased to attach a statement of account for you in PDF, including any recent invoices and payments.
+          If you have any questions, please don't hesitate to contact us.
+          Kind regards,
+          %{business_name}
+          %{telephone}
+        table: |
+          I've attached some data in PDF from Sage Business Cloud Accounting for you.
+          If you have any questions, please don't hesitate to contact me.
+          Kind regards,
+          %{business_name}
+          %{telephone}
+      descriptions:
+        corrective_invoice: When you email Sales Corrective Invoices, we'll put this
+          text in the Message field.
+        credit_note: When you email Sales Credit Notes, we'll put this text in the
+          Message field.
+        customise: " You can then customise it before sending it to the customer."
+        estimate: When you email Sales Estimates, we'll put this text in the Message
+          field.
+        invoice: When you email Sales Invoices, we'll put this text in the Message
+          field.
+        quote: When you email Sales Quotes, we'll put this text in the Message field.
+        remittance: When you email Remittance Advice, we'll put this text in the Message
+          field.
+        statement: When you email Statements, we'll put this text in the Message field.
+        table: You can email selected data from most tables by using the option in
+          the header bar. We'll put this text in the Message field.
+        where: Where is this message used?
+      email_defaults:
+        desc: Save time by setting up default email messages to use when sending documents.
+          You can easily customise these messages whenever you email an invoice, credit
+          note, quote or estimate.
+        title: Email Defaults
+      label: Default Email Message
+      message:
+        placeholder: Define your own default message
+      name: Email Defaults
+      pdf_attached:
+        desc: When sending an email we can automatically include a pdf version of
+          your invoice, quote, credit note or estimate as an attachment. Do you want
+          us to do this?
+        no_do_not_attach: No - I can attach documents to an email when needed.
+        title: Document Attachments
+        yes_attach: Yes - Always attach the document as a PDF
+      reset: Reset to default message
+      send_bcc:
+        desc: When sending a document by email we can send you a copy. Do you want
+          us to do this?
+        no_do_not_send: No - I don't want to receive a copy of that email
+        title: Send me a copy
+        yes_send: Yes - Always send a copy of the email to
+      tabs:
+        corrective_invoice: Corrective Invoice
+        credit_note: Credit Notes
+        estimate: Estimates
+        invoice: Invoices
+        quote: Quotes
+        remittance: Remittance Advice
+        statement: Statements
+        table: Tables of Data
+    services:
+      wizard:
+        selection_empty: Please call 0845 111 66 11 to cancel your subscription
+        success: Your services have been updated successfully
+        summary_help: Please review the details of the changes to your services, including
+          total cost per month to you. If you are happy with the details click submit,
+          otherwise click back to modify.
+    user:
+      pod:
+        title: User Settings
+    user_management:
+      details:
+        title: Details
+      permissions:
+        title: User Permissions
+      pod:
+        title: Advanced Permissions
+  sop_authentication:
+    accept:
+      direct: Accept Invitation
+      providers:
+        azure: Accept with Azure
+        developer: Accept with Developer
+        facebook: Accept with Facebook
+        google: Accept with Google
+    activation:
+      description: Hello %{name}, you have been invited to use Sage Business Cloud
+        Accounting.
+      provider_selection: Please complete your registration using one of the options
+        below.
+      title: Your invitation to %{app_title}
+    blocked:
+      message: Your access has been blocked. Please contact support.
+    signin:
+      already_registered: Already have an account?
+      facebook:
+        existing: Please sign in with your existing user account and we will link
+          it with your Facebook account.
+        link: This will allow you to sign in to your Sage Business Cloud services
+          using your existing credentials or your Facebook account.
+      google:
+        existing: Please sign in with your existing user account and we will link
+          it with your Google account.
+        link: This will allow you to sign in to your Sage Business Cloud services
+          using your existing credentials or your Google account.
+        providers:
+          developer: Sign In (Developer Mode)
+          sageid: Sign In
+      not_registered: Need to sign up for an account?
+      providers:
+        azure: Sign In with Azure
+        azure_html: <i class="icon"></i>Sign In with Azure
+        developer: Sign In (Developer Mode)
+        developer_html: <i class="icon"></i>Sign In (Developer Mode)
+        facebook: Sign In with Facebook
+        facebook_html: <i class="icon"></i>Sign In with Facebook
+        google: Sign In with Google
+        google_html: <i class="icon"></i>Sign In with Google
+        sageid: Sign In with SageID
+        sageid_html: <i class="icon"></i>Sign In with SageID
+      signin: Sign In
+      title: Sign In to %{app_title}
+    signup:
+      already_registered: Already have an account?
+      continue: Continue
+      direct: Sign Up Directly
+      providers:
+        azure: Sign Up with Azure
+        developer: Sign Up (Developer Mode)
+        facebook: Sign Up with Facebook
+        google: Sign Up with Google
+        sageid: Sign Up with SageID
+      signup: Sign Up
+      terms_and_conditions:
+        acceptance: I have read and accepted the %{tc_link}.
+        link: terms and conditions
+      title: Sign Up for %{app_title}
+    sso_activate:
+      expired:
+        header: Email Confirmation Failure
+        message_html: "<p>There has been a problem when we tried to confirm your email
+          address. The link in the email could have expired or you may already have
+          an existing account.</p><p>If you cannot sign in then please email <strong>sagebusinesscloudsupport@sage.com</strong>
+          or call the Sage Customer Service Team on <strong>0845 111 6611 - UK</strong>
+          or <strong>1890 812 811 - Ireland</strong></p>"
+        title: We cannot confirm your email address.
+      failure:
+        button: Continue
+        header: Email Confirmation Failure
+        message_html: "<p>If you cannot sign in then please email <strong>sagebusinesscloudsupport@sage.com</strong>
+          or call the Sage Customer Service Team on <strong>0845 111 6611 - UK</strong>
+          or <strong>1890 812 811 - Ireland</strong></p>"
+        title: There has been a problem
+      success:
+        button: Continue
+        header: Email Confirmation Success
+        message_html: "<p>If you're ready to subscribe to Accounting, you can do this
+          right now; you don’t have to wait for your trial period to expire.</p><p>Go
+          to the Settings area and click on Billing Settings. In this section, you
+          will find the Direct Debit tab. Just click the button and follow the on-screen
+          instructions to set up your subscription.</p><p>But don’t worry, we won’t
+          actually bill you until your trial period has ended.</p>"
+        title: Thank you for confirming your email address
+    sso_password_reset:
+      reset_expired:
+        button: Continue
+        header: Password change confirmation failure
+        message_html: "<p>There has been a problem when we tried to confirm your password
+          change. The link in the email could have expired or you may already have
+          confirmed your password change.</p><p>If you can't sign in then please email
+          <strong><a href='mailto:sagebusinesscloudsupport@sage.com'>sagebusinesscloudsupport@sage.com</a></strong>
+          or call the Sage Customer Service Team on <strong>0845 111 6611 - UK</strong>
+          or <strong>1890 812 811 - Ireland</strong>"
+        title: We cannot confirm your password change.
+      reset_success:
+        button: Continue
+        header: Password change confirmation success
+        message_html: "<p>You can now continue to use your service using your new
+          password.</p><p>If you have any queries about your activation, please email
+          <strong><a href='mailto:sagebusinesscloudsupport@sage.com'>sagebusinesscloudsupport@sage.com</a></strong>
+          or call the Sage Customer Service Team on <strong>0845 111 6611 - UK</strong>
+          or <strong>1890 812 811 - Ireland</strong>"
+        title: Thank you for confirming your password change.
+      success:
+        button: Continue
+        header: Password change confirmation success
+        message_html: "<p>A password activation email has been sent to your email
+          account.</p><p>To continue to use your service using your new password please
+          click the activation link in the email we have sent you.</p><p>If you have
+          any queries about your activation, please email <strong><a href='mailto:sagebusinesscloudsupport@sage.com'>sagebusinesscloudsupport@sage.com</a></strong>
+          or call the Sage Customer Service Team on <strong>0845 111 6611 - UK</strong>
+          or <strong>1890 812 811 - Ireland</strong>"
+        title: Thank you for changing your password
+  sop_settings:
+    about_your_business:
+      link_desc: Decide what information about your business is shown on sales and
+        purchase documents.
+      link_text: About your Business
+    accounts_settings:
+      description: Use this area to manage and make changes to your financial and
+        invoice settings.
+      title: Financial Settings
+    analysis_types:
+      description: Set up Analysis Types to meet your business needs, for example,
+        Departments or Cost Centres.
+      link_desc: Set-up and oversee analysis types to manage your accounts in more
+        detail.
+      link_text: Analysis Types
+      title: Analysis Types
+    bank_opening_balances:
+      link_desc: Enter the balance for each bank account.
+      link_text: Bank
+    business_preferences:
+      description: Customise invoice templates and set up your business to receive
+        online customer payments.
+      title: Invoice & Business Preferences
+    check_settings:
+      link_desc: Make payments by printing directly onto special check paper.
+      link_text: Check Printing Settings
+    connect_settings:
+      title: Connect
+    currency:
+      link_desc: Handle foreign currency transactions and manage your exchange rates.
+      link_text: Currencies
+    customer_opening_balances:
+      link_desc: Enter money owed by each customer.
+      link_text: Customer
+    datev_export_settings:
+      accountants_pod:
+        accountant_number:
+          label: Accountant Number
+          placeholder: e.g. 1234567
+        client_number:
+          label: Client Number
+          placeholder: e.g. 12345
+        title: From the Accountants
+      link_text: Datev Export
+      message_box:
+        description: You haven't entered an accountant number or a client number yet.
+          You can get this information from your accountant.
+        title: Attention
+      missing_attributes_for_datev_export: You haven't saved an accountant number
+        and a client number yet. You need both for the DATEV export!
+      next_numbers_pod:
+        description: These numbers will be handled automatically and shouldn't be
+          changed usually.
+        next_creditor_number:
+          label: Next creditor number
+        next_debtor_number:
+          label: Next debitor number
+        title: Next numbers
+    default_settings:
+      link_desc: Configure the defaults shown on contacts, items and bank transactions.
+      link_text: Record and Transactions Settings
+    email_defaults:
+      link_desc: Customise the default email message when you send an invoice, statement
+        or other document.
+      link_text: Email Messages
+    financial:
+      link_desc: Record VAT scheme details and manage your financial start and year
+        end date.
+      link_text: Accounting Dates & VAT
+    financial_settings:
+      accounts_start_date:
+        warning: An accounts start date is required before adding opening balances
+      currency_settings:
+        custom_exchange_rates_used: Exchange rates are editable
+        live_exchange_rates_used: Live exchange rates enabled
+      lockdown_date:
+        warning:
+          prompt: Setting this lock down date will prevent transactions with an earlier
+            date from being entered or changed. Do you want to continue?
+          title: Year End Lock Down Changed
+      tax_scheme:
+        prompt: Please select a tax scheme
+      tax_scheme_change:
+        warning:
+          cancel: Cancel
+          confirm: Got it!
+          prompt: To ensure we bill you correctly for your subscription, please send
+            us an email at <strong><a href='mailto:sagebusinesscloudsupport@sage.com'
+            target='_blank'>sagebusinesscloudsupport@sage.com</a></strong>
+          title: Changing VAT Scheme
+      tax_scheme_not_set:
+        warning: A tax scheme is required before adding opening balances
+    google_drive:
+      link_desc: Manage the connection to your Google Account.
+      link_text: Google Drive
+    invoice_settings:
+      customer_credit_days: "%{days} days"
+      default_delivery_address:
+        options:
+          delivery_address: Delivery Address
+          delivery_address_same_as_main: Same as invoice address
+          none: No address
+      default_settings_link:
+        text: Terms (from %{link})
+      document_headers:
+        desc: Depending on the <a href='%{logo_and_template_link}'>%{logo_and_template_title}</a>
+          selected, these headings can be shown at the top of each document.
+        title: Document Headings
+      line_item_headers:
+        desc: Rename columns shown on documents.
+        title: Line Items
+      payment_info:
+        bank_account: Bank Account
+        desc: Standard payment infomation you’d like to print on each sales document.
+        none: None
+        title: Payment Collection
+      template:
+        add_logo: Add a logo
+        association_logo: Association Logos
+        association_logo_recommendations: Recommended size 180 x 200 pixels.
+        association_logo_text: Add secondary logos i.e. for accreditations or trade
+          memberships. Logos can be a maximum of 1mb in size. JPG, PNG or GIF formats.
+        auto_entrepreneur:
+          desc: Set information about your business status on a Sales Invoice
+          option_false: "- I'm not registered as an auto-entrepreneur"
+          option_true: "- I'm registered as an auto-entrepreneur"
+          options_desc: Does your business have auto-entrepreneur status?
+          title: Auto-entrepreneur / Micro-entrepreneur
+        breakdown: Tax Display Breakdown
+        business_logo_recommendations: Recommended size 280 x 200 pixels.
+        business_logo_text: Add a business logo that represents your business. Logos
+          can be a maximum of 1mb in size. JPG, PNG or GIF formats.
+        choose_template: Choose Template
+        company_logo: Company Logo
+        contact_details_and_addresses:
+          contact_details:
+            business_name: Business Name
+            checkbox_label: Show <strong>%{element}</strong>
+            email_address: Email Address
+            mobile: Mobile
+            telephone: Telephone
+            title: Contact Details
+            website: Website
+          customer_information:
+            checkbox_label: Show <strong>%{element}</strong>
+            due_date: Due Date
+            title: Customer Information
+          default_delivery_address:
+            title: Default Delivery Address
+          desc: Selected details appear at the top of all types of document. Complete
+            any missing contact details in %{link}.
+          link:
+            text: Edit Business Address
+          title: Contact Details & Addresses
+        default_delivery_address: Default Delivery Address
+        delivery_address:
+          desc: Choose whether to show a delivery address on invoice and quotes.
+          title: Delivery Address
+        document_layout: Select the layout for your documents.
+        eu_sales_description:
+          desc: Descriptions for each EU tax rate.
+          title: EU sales descriptions
+        file_too_big_warning: "%{file} is larger than 1mb"
+        font: Font
+        font_names:
+          large: Large
+          medium: Medium
+          small: Small
+        font_size: Font Size
+        fonts: Fonts
+        footer_details:
+          column_titles:
+            column_1: Column 1
+            column_2: Column 2
+            column_3: Column 3
+          desc: Standard information you'd like to print on each document, such as
+            details of business owner or directors.<br/><br/>You can add up to three
+            columns of information. Only columns you enter details into will appear
+            on your documents.
+          not_available_for_template_html: Footer details are not available for your
+            selected layout. Go to the <a href="%{link}" target="_blank">Logo & Document
+            Template</a> page to choose another layout.
+          title: Footer Details
+        header: Template Settings
+        image_dimensions_too_small: "%{file} ( %{width} x %{height} ) is smaller than
+          recommended"
+        insurance_settings:
+          desc: Information about the professional insurance you want to appear on
+            your documents. Insurers can be added through creating a supplier.
+          title: Professional Insurance
+        invoice_numbering: Invoice Numbering
+        invoice_terms_and_conditions: Invoice Terms and Conditions
+        legacy_based:
+          desc: The latest templates are above and the original templates are still
+            available if you need them.
+          title: Can't find your template?
+        logo_file_ok: "%{file} looks good!"
+        notes:
+          desc: Standard information you'd like to print on each document, such as
+            bank details for payment. You can edit these further when you create each
+            document.
+          tab_titles:
+            credit_note: Credit Note
+            invoice: Invoice
+          title: Notes
+        numbering: Numbering
+        payment_settings:
+          desc: Set the percentage shown on a Sales Invoice for when it’s paid early
+            or late.
+          title: Discount & Penalty Rates
+        percent_total_of_invoice: "% of invoice total"
+        prefixes: Prefixes
+        prefixes_and_numbering:
+          desc: A standard prefix and unique number for each document you create.
+          title: Prefixes & Numbering
+        product_based:
+          desc: Shows product codes, quantities and unit prices.
+          title: Product based
+        quote_options: Estimate & Quote Options
+        select_font: Select a font for your documents.
+        separate_numbering:
+          checkbox: 'Number Invoices and Credit Notes separately:'
+        service_based:
+          desc: Provides space for large amounts of descriptive text, with a VAT rate
+            and amount per line.
+          title: Service based
+        show_contact_on_delivery: Show <strong>contact details</strong>
+        show_days_and_label_overdue: Show days overdue and label overdue invoices
+          in red
+        show_delivery_picked: Show <strong>picked column</strong>
+        show_delivery_signature: Show <strong>signature lines</strong>
+        show_note_on_delivery: Show <strong>document notes</strong>
+        show_overdue_in_statement:
+          desc: Add extra details to customer and supplier statements
+          title: Statements
+        show_table_of_owed_by_age: Show a table of balances owed by age <br/> <span
+          class="invoice-settings-checkbox__label-not-bold">More about this in <a
+          href="/settings/default_settings">Record and Transaction Settings</a> </span>
+        terms_and_conditions:
+          desc: Standard terms of sales for your customers, such as payment due details.
+            You can edit these further when you create each document.
+          tab_titles:
+            delivery_note: Delivery Note
+            estimate: Estimate
+            invoice: Invoice
+            quote: Quote
+          title: Terms & Conditions
+        theme_color:
+          desc: Select an accent colour for your documents
+          example_grid:
+            data:
+            - - PROD001
+              - Item
+              - 1.0
+            - - PROD001
+              - Item
+              - 1.0
+            header:
+            - Code
+            - Description
+            - Quantity
+          feedback_prompt: "**We'd love your feedback** on these new colours."
+          title: Theme Colour
+    invoices_and_quotes:
+      link_desc: Configure the defaults shown on invoices and other sales and purchase
+        forms.
+      link_text: Invoice Form Settings
+    journal_codes:
+      link_desc: Create, view, and manage your journal codes. Journal codes allow
+        you to group your accounting entries.
+      link_text: Journal Codes
+    ledger_accounts:
+      link_desc: Create, view and manage your nominal accounts.
+      link_text: Chart of Accounts
+    logo_and_theme:
+      link_desc: Add your company logo and select your document style to reflect your
+        brand.
+      link_text: Logo & Document Template
+    nominal_opening_balances:
+      link_desc: Enter the balance for each ledger account.
+      link_text: Nominal Ledger
+    opening_balances:
+      description: Use these options to record balances to bring across from your
+        previous accounting system
+      link_text: Opening Balances
+      title: Opening Balances
+    payroll_settings:
+      link_desc: Manage your Payroll Integration.
+      link_text: Payroll Integration
+    sage_integration_cloud_settings:
+      link_desc: Manage connected apps and browse the Sage Business Cloud Marketplace.
+      link_text: Apps
+      popover_button: Got it
+      popover_text: Explore apps from our partners that can improve the productivity
+        of your business through easy to set-up integrations.
+      popover_title: New! Sage Marketplace
+    sage_pay_settings:
+      link_desc: Manage your Sage Pay settings.
+      link_text: Sage Pay
+    stripe_integration:
+      link_desc: Easy card payments straight from customer invoices. Sign up to Stripe
+        or manage your settings.
+      link_text: Card Payments
+    supplier_opening_balances:
+      link_desc: Enter money owed to each supplier.
+      link_text: Supplier
+    user_managements:
+      link_desc: Manage users and permissions
+      link_text: User Management
+    user_preferences:
+      description: Personalise the user interface to suit your style of working, for
+        example, navigation and timezone settings.
+      feeback_link: We'd love your feedback <span class='link_grey_part'>on this beta
+        feature.</span>
+      grid:
+        default_grid_size: Show me
+        description: items in each table unless I override it.
+        help_desc: Set how many rows of data you’d like to see in tables.
+        title: Tables of data
+      link_desc: Make changes to suit your style of working.
+      link_text: Navigation and Data Grids
+      model: User Preferences
+      navigation:
+        advanced: Advanced <span>- Best for accountants (e.g. Contacts and Reports
+          together under Sales and Purchases).</span>
+        help_desc: Choose whether to use standard or advanced navigation.
+        standard: Standard <span>- Best for business users (e.g. Contacts and Reporting
+          in separate sections).</span>
+        title: Navigation
+      show_getting_started:
+        help_desc_1: Choose whether to display the Getting Started panel on the Summary
+          page.
+        help_desc_2: This guide explores Accounting's top features and helps you get
+          things set up quickly and easily.
+        text: Show the Getting Started panel
+        title: Getting Started
+      timezone_settings:
+        adelaide_and_darwin: Adelaide, Darwin
+        alaska: Alaska
+        arizona_and_central_america: Arizona, Chihuahua, La Paz, Mazatlan
+        astana_dhaka_central_russia: Astana, Dhaka, Novosibirsk
+        australian_east_coast_and_vladivostok: Brisbane, Canberra, Guam, Hobart, Melbourne,
+          Sydney, Vladivostok
+        baja_california: Baja California
+        cape_verde: Cabo Verde Is.
+        caracas: Caracas
+        carribean_and_atlantic_time: Asuncion, Atlantic Time, Cuiaba, Georgetown,
+          San Juan
+        central_asia: Ashgabat, Islamabad, Karachi, Tashkent
+        central_europe_and_pretoria: Athens, Cairo, Helsinki, Istanbul, Pretoria
+        central_time_us_canada: Central Time (US & Canada)
+        coordinated_universal_time_11: Co-ordindated Universal Time-11
+        coordinated_universal_time_2: Co-ordinated Universal Time-2
+        eastern_europe_and_gulf_states: Baghdad, Kuwait, Minsk, Moscow, Nairobi
+        eastern_standard_time_us_canada: Eastern Standard Time (US & Canada)
+        far_east_and_western_australia: Beijing, Chongqing, Hong Kong, Kuala Lumpur,
+          Perth, Singapore, Taipai
+        hawaii: Hawaii
+        help_desc: Affects the date and time printed on PDF reports, for example.
+        india_and_sri_lanka: Chennai, Kolkata, Mumbai, New Delhi, Sri Jayawardenepura
+        international_date_line_west: International Date Line West
+        japan_and_far_east_russia: Osaka, Seoul, Tokyo, Yakutsk
+        kabul: Kabul
+        kathmandu: Kathmandu
+        kiritimati: Kiritimati Island
+        mexico_and_saskatchewan: Guadalajara, Mexico City, Monterrey, Saskatchewan
+        middle_east_and_yerevan: Abu Dhabi, Baku, Muscat, Port Louis, Tbilisi, Yerevan
+        mountain_time: Mountain Time (MST)
+        new_zealand: Auckland, Fiji, Wellington
+        newfoundland: Newfoundland
+        nukualofa: Nuku'alofa
+        pacific_islands_solomon_islands: Chokurdakh, New Caledonia, Solomon Islands
+        pacific_time_us_canada: Pacific Time (US & Canada)
+        selected_timezone: Selected Timezone
+        south_america_central_and_indiana_east: Bogota, Lima, Quito, Indiana (East)
+        south_america_east_coast: Brasilia, Buenos Aires, Cayenne, Fortaleza, Greenland,
+          Salvador
+        tehran: Tehran
+        thailand_vietnam_indonesia: Bangkok, Hanoi, Jakarta, Krasnoyarsk
+        timezone: "%{offset_text} - %{identifier}"
+        title: Timezone
+        uk_ireland_and_portugal: Dublin, Edinburgh, Lisbon, London
+        western_europe: Amsterdam, Berlin, Madrid, Paris
+      title: Customise
+    year_end:
+      link_desc: Lock the previous financial year, post the necessary journals, and
+        open a new one.
+      link_text: Financial year end
+  sop_settings/default_settings:
+    product:
+      global_pricing_labels:
+      - Sales Price
+      - Trade
+      - Wholesale
+    service:
+      global_pricing_labels:
+      - Rate
+  sop_settings/manage_businesses:
+    switch:
+      success: You have successfully switched businesses
+      switching_to_current_business: You are already in %{business_name}
+  statement:
+    contact:
+      activity: Activity
+      addresses: Addresses
+      ageing_summary:
+        days_owed_more_than_x: More than %{number_from} days
+        days_owed_up_to_x: Up to %{number_to} days
+        days_owed_x_to_y: "%{number_from}-%{number_to} days"
+        how_long_have_i_owed: How long have I owed this money?
+      amount: Amount
+      amount_multi_currency: Amount<span data-currency="%{currency_symbol}">&nbsp;</span>
+      as_of: As of %{end_date}
+      at: At %{end_date}
+      balance: Balance
+      balance_multi_currency: Balance<span data-currency="%{currency_symbol}">&nbsp;</span>
+      bbf: Balance brought forward
+      csv_filename: contact_statement
+      date: Date
+      debt_summary: Debt Summary
+      default_message: Save this message as the default
+      dialog_description: This is where you can send this statement to your customer
+        as a PDF file attachment.
+      dialog_file_description: "%{contact_name} statement"
+      dialog_title: Email Statement
+      discount: Discount
+      due_date: Due Date
+      email_file_description: Statement from %{business} to %{end_date}
+      email_filename: Statement.pdf
+      email_success: Email sent
+      expense: Expense
+      expense_payment: Expense Payment
+      income: Income
+      income_payment: Income Payment
+      invoices: Invoices
+      invoices_multi_currency: Invoices<span data-currency="%{currency_symbol}">&nbsp;</span>
+      overdue: Overdue
+      overdue_multi_currency: Overdue
+      owed: Owed
+      owed_multi_currency: Owed
+      paid: Paid
+      paid_multi_currency: Paid<span data-currency="%{currency_symbol}">&nbsp;</span>
+      payments: Payments
+      payments_multi_currency: Payments<span data-currency="%{currency_symbol}">&nbsp;</span>
+      purchase_corrective_credit_note: Purchase Corrective Credit Note
+      purchase_corrective_invoice: Purchase Corrective Invoice
+      purchase_credit_note: Purchase Credit Note
+      purchase_invoice: Purchase Invoice
+      purchase_invoice_payment: Purchase Invoice Payment
+      purchase_payment: Payment
+      purchase_refund: Refund
+      reference: Reference
+      sales_corrective_credit_note: Sales Corrective Credit Note
+      sales_corrective_invoice: Sales Corrective Invoice
+      sales_credit_note: Sales Credit Note
+      sales_invoice: Sales Invoice
+      sales_invoice_payment: Sales Invoice Payment
+      sales_receipt: Receipt
+      sales_refund: Refund
+      statement: Statement
+      statement_period:
+        activity: 'Period: %{start_date} to %{end_date}'
+        outstanding: 'Date: %{end_date}'
+      statement_type:
+        activity: All activity
+        outstanding: Outstanding items only
+      summary: Summary
+      supplier_payment: Supplier Payment
+      total_invoiced: Total Invoiced
+      total_invoiced_multi_currency: Total Invoiced<span data-currency="%{currency_symbol}">&nbsp;</span>
+      total_paid: Total Paid
+      total_paid_multi_currency: Total Paid<span data-currency="%{currency_symbol}">&nbsp;</span>
+  states:
+    alabama: Alabama
+    alaska: Alaska
+    alberta: Alberta
+    all: All
+    american_samoa: American Samoa
+    arizona: Arizona
+    arkansas: Arkansas
+    british_columbia: British Columbia
+    california: California
+    colorado: Colorado
+    connecticut: Connecticut
+    delaware: Delaware
+    district_of_columbia: District of Columbia
+    federated_states_of_micronesia: Federated States of Micronesia
+    florida: Florida
+    georgia: Georgia
+    guam: Guam
+    hawaii: Hawaii
+    idaho: Idaho
+    illinois: Illinois
+    indiana: Indiana
+    iowa: Iowa
+    kansas: Kansas
+    kentucky: Kentucky
+    louisiana: Louisiana
+    maine: Maine
+    manitoba: Manitoba
+    marshall_islands: Marshall Islands
+    maryland: Maryland
+    massachusetts: Massachusetts
+    michigan: Michigan
+    minnesota: Minnesota
+    mississippi: Mississippi
+    missouri: Missouri
+    montana: Montana
+    nebraska: Nebraska
+    nevada: Nevada
+    new_brunswick: New Brunswick
+    new_hampshire: New Hampshire
+    new_jersey: New Jersey
+    new_mexico: New Mexico
+    new_york: New York
+    newfoundland_and_labrador: Newfoundland and Labrador
+    north_carolina: North Carolina
+    north_dakota: North Dakota
+    northern_mariana_islands: Northern Mariana Islands
+    northwest_territories: Northwest Territories
+    nova_scotia: Nova Scotia
+    nunavut: Nunavut
+    ohio: Ohio
+    oklahoma: Oklahoma
+    ontario: Ontario
+    oregon: Oregon
+    palau: Palau
+    pennsylvania: Pennsylvania
+    prince_edward_island: Prince Edward Island
+    puerto_rico: Puerto Rico
+    quebec: Québec
+    rhode_island: Rhode Island
+    saskatchewan: Saskatchewan
+    south_carolina: South Carolina
+    south_dakota: South Dakota
+    tennessee: Tennessee
+    texas: Texas
+    utah: Utah
+    vermont: Vermont
+    virgin_islands: Virgin Islands
+    virginia: Virginia
+    washington: Washington
+    west_virginia: West Virginia
+    wisconsin: Wisconsin
+    wyoming: Wyoming
+    yukon: Yukon
+  stock_movement:
+    purchase_corrective_credit_note_details: Purchase Corrective Invoice - Credit
+      from %{company}
+    purchase_corrective_invoice_details: Purchase Corrective Invoice - Charge from
+      %{company}
+    purchase_credit_note_details: Purchase Credit Note from %{company}
+    purchase_invoice_details: Purchase Invoice from %{company}
+    sales_corrective_credit_note_details: Sales Corrective Invoice - Credit to %{company}
+    sales_corrective_invoice_details: Sales Corrective Invoice - Charge to %{company}
+    sales_credit_note_details: Sales Credit Note to %{company}
+    sales_invoice_details: Sales Invoice to %{company}
+  stripe_integration:
+    account_name: Account Disconnected
+    invoicing:
+      refund:
+        connected:
+          button: Refund in Stripe
+          message: To give **%{cardholderName}** a refund, you must do this within
+            the Stripe Dashboard.  When viewing the payment in Stripe, click “Refund”,
+            and enter a partial or full refund amount. This will then be automatically
+            updated in Sage.
+        connected_title: Refund Card Payment
+        disconnected:
+          body: "**Important:** Signing into an old account will disconnect any new
+            accounts that have since been connected to Sage."
+          button: Sign In
+          message: You must be signed into the original account that was used for
+            this payment before issuing a refund. This is so that your accounts in
+            Sage can be automatically updated.
+          message_title: Stripe Account Disconnected
+        disconnected_title: Sign into original Stripe Account
+      stripe_transaction_dialog:
+        form:
+          address_one: Address 1
+          address_two: Address 2
+          card: Card Details
+          city: Town/City
+          name: Card Holder
+          part_payment: Take part payment
+          postal_code: Post Code
+          save_text: Charge £%{amount}
+          state: County
+        title: Take a Payment
+    payment:
+      failure: Sorry, there was a problem taking payment. If the problem continues,
+        please contact support.
+      success: Payment taken for this invoice.
+    powered_by_stripe: powered by Stripe
+    refund:
+      success: Stripe Transaction Successfully Refunded
+    sales_invoice:
+      stripe_pay: Take a Payment with Stripe
+    settings:
+      alt_screenshot: stripe payment button screenshot
+      coming_soon:
+        description: Here's a sneak peek at the features we're working on.
+        title: Coming Soon
+      connected:
+        account_failure: The Stripe account that you're trying to connect is already
+          connected to another Accounting business
+        account_name: Account Name
+        description: Choose where your stripe fees will be recorded and disconnect
+          your account if you wish to no longer use Stripe.
+        disconnect: Disconnect Account
+        email: Account Email
+        failure: Sorry, there was a problem connecting Stripe to Sage. Please try
+          connecting again later.
+        ledger: Where will your Stripe fees be recorded?
+        payouts: Where will your payouts be transfered?
+        payouts_help: To change where your money is transfered, please update your
+          bank details in the Stripe Dashboard as well.
+        success: Stripe Account connected to Sage
+        take_payments: Your Stripe account is currently connected with Sage and you
+          can now take card payments from your customers. All your Stripe transactions
+          will appear in this [**Stripe Bank Account**](%{account_url}).
+      disconnect_dialog:
+        body: By disconnecting this account, you will no longer be able to take payment
+          on invoices with Stripe.
+        cancel_label: No, Keep Stripe
+        confirm_label: Yes, Disconnect Stripe
+        confirm_message: Are you sure that you wish to continue?
+        title: Disconnect Stripe
+      disconnected:
+        create_account: Create Account
+        description: Sign up for a new Stripe account, or log in if you already have
+          one.
+        failure: Stripe Account disconnection failed
+        icon_rows:
+          alt_bank_transfer: bank transfer icon
+          alt_coinstack: coin stack icon
+          alt_padlock: padlock icon
+          alt_reconcile: reconcile icon
+          fees_description: |
+            UK and European payments cost 1.4% + 20p
+            Non-European payments cost 2.9% + 20p
+            So, a customer with a UK card paying you £100, would cost £1.60.
+          fees_title: Clear and simple fees, with no surprises
+          payout_description: Payments are collected into your Stripe account, and
+            you choose how often money is automatically transferred to your bank account.
+            This is your
+          payout_schedule: " 'Payout Schedule'"
+          payout_title: Automatic bank account transfers
+          reconcile_description: Get transaction data automatically matched straight
+            to invoices after a scheduled payout. Invoice statuses are always up-to-date,
+            and fees already accounted for.
+          reconcile_title: Automatic Reconciliation
+          secure_payments_description: Sage and Stripe use the same industry-standard
+            security as all the major banks, so your data and money are always safe.
+          secure_payments_title: Secure, safe, and trusted
+        signin: Sign In
+        signin_dialog:
+          message: |-
+            So that we can accurately reconcile your transactions, please make sure that this Stripe account is only used for payments from Sage.
+
+            If your account has payments from another source, please create a new Stripe account.
+          signin_button: Sign In to Stripe
+          title: Sign In to Stripe
+        signin_text: Already have a stripe account?
+        signup_dialog:
+          button: Create Account
+          message: So that we can accurately reconcile your transactions, please make
+            sure that this Stripe account is only used for payments from Sage.
+          title: Create Account
+        success: Stripe Account disconnected from Sage
+        upsale: Customer ready to pay? Take card payments for any invoice in person
+          or over the phone - just enter the customer's details, and Stripe does the
+          rest.
+      failure: Sorry, there was a problem updating your Stripe settings, please try
+        again later or contact Sage support.
+      saved: Saved Stripe settings successfully.
+      title: Manage Connection
+    stripe_label: " (Stripe)"
+    tooltips:
+      foreign_details: There are an additional %{value} of transactions included in
+        this payout that have not been recorded in Sage Business Cloud.
+      manual_payout: Transaction data can only be displayed from an automatically
+        scheduled payout.
+      mixed_after_manual: There are an additional %{value} of transactions included
+        in this payout that have not been recorded in Sage Business Cloud. This total
+        is also impacted by a previous manual payout.
+      payout_after_manual: This payout total is impacted by a previous manual payout.
+        Log in to your Stripe Dashboard for more details.
+    transactions:
+      read_only: Not allowed to update/delete Stripe transaction
+  stripe_payments:
+    credit_card: Credit Card
+    errors:
+      approve_with_id: Payment cannot be authorized, try again. If it still can’t
+        be processed, the customer needs to contact their bank.
+      card_not_supported: The card does not support this type of purchase. The customer
+        needs to contact their bank to make sure their card can be used to make this
+        type of purchase.
+      card_velocity_exceeded: The customer has exceeded the balance or credit limit
+        available on their card. They should contact their bank for more information.
+      currency_not_supported: The card does not support the specified currency. The
+        customer should check with their bank that the card can be used for the type
+        of currency specified.
+      duplicate_transaction: A transaction with identical amount and credit card information
+        was submitted very recently. Check to see if a recent payment already exists.
+      expired_card: The card has expired. You should use another card.
+      incorrect_cvc: The CVC number is incorrect. You should try again using the correct
+        CVC.
+      incorrect_number: The card number is incorrect. You should try again using the
+        correct card number.
+      incorrect_zip: The ZIP/postal code is incorrect. You should try again using
+        the correct billing ZIP/postal code.
+      insufficient_funds: The card has insufficient funds to complete the purchase.
+        The customer should use an alternative payment method.
+      invalid_account: The card, or account the card is connected to, is invalid.
+        The customer needs to contact their bank to check that the card is working
+        correctly.
+      invalid_amount: The payment amount is invalid, or exceeds the amount that is
+        allowed. The customer needs to check with their bank that they can make purchases
+        of that amount.
+      invalid_cvc: The CVC number is incorrect. You should try again using the correct
+        CVC.
+      invalid_expiry_year: The expiration year is invalid. The customer should try
+        again using the correct expiration date.
+      invalid_number: The card number is incorrect. You should try again using the
+        correct card number.
+      issuer_not_available: The card issuer could not be reached, so the payment could
+        not be authorized. The payment should be attempted again. If it still cannot
+        be processed, the customer needs to contact their bank.
+      network_error: Sorry, we couldn't complete your request right now. The problem
+        should be fixed soon, so please try again later.
+      new_account_information_available: The card, or account the card is connected
+        to, is invalid. The customer needs to contact their bank to check that the
+        card is working correctly.
+      not_permitted: The payment is not permitted. The customer needs to contact their
+        bank for more information.
+      pending_trx: The invoice status has not been updated following a previous payment.
+        Please contact support.
+      pickup_card: The card cannot be used to make this payment (it is possible it
+        has been reported lost or stolen). The customer needs to contact their bank
+        for more information.
+      processing_error: An error occurred while processing the card. The payment should
+        be attempted again. If it still cannot be processed, try again later.
+      reenter_transaction: The payment could not be processed by the issuer for an
+        unknown reason. The payment should be attempted again. If it still cannot
+        be processed, the customer needs to contact their bank.
+      restricted_card: The card cannot be used to make this payment (it is possible
+        it has been reported lost or stolen). The customer needs to contact their
+        bank for more information.
+      testmode_decline: A Stripe test card number was used. A genuine card must be
+        used to make a payment.
+      unknown: The card has been declined for an unknown reason. The customer needs
+        to contact their bank for more information.
+      withdrawal_count_limit_exceeded: The customer has exceeded the balance or credit
+        limit available on their card. The customer should use an alternative payment
+        method.
+    errors_for_end_customer:
+      approve_with_id: Payment cannot be authorized, please try again. If it still
+        can’t be processed, you will need to contact your bank.
+      card_not_supported: Your card has been declined for an unknown reason. Please
+        contact your bank for more information.
+      card_velocity_exceeded: You have exceeded the balance or credit limit available
+        on your card. You should contact your bank for more information.
+      currency_not_supported: Your card does not support the specified currency. Please
+        check with your bank that your card can be used for the type of currency specified.
+      duplicate_transaction: A transaction with identical amount and credit card information
+        was submitted very recently. Please check your bank statement to see if the
+        payment already exists.
+      expired_card: Your card has expired. Please pay with an alternative card.
+      incorrect_cvc: Your CVC number is incorrect. Please try again with the correct
+        CVC number.
+      incorrect_number: Your card number is incorrect. Please try again with the correct
+        card number.
+      incorrect_zip: Your ZIP/postal code is incorrect. You should try again using
+        the correct billing ZIP/postal code.
+      insufficient_funds: Your card has insufficient funds to complete the purchase.
+        Please use an alternative payment method.
+      invalid_account: Your card has insufficient funds to complete the purchase.
+        Please use an alternative payment method.
+      invalid_amount: Your payment amount is invalid, or exceeds the amount that is
+        allowed. Please check with your bank that you can make purchases of that amount.
+      invalid_expiry_year: The expiration year is invalid. You should try again using
+        the correct expiration date.
+      issuer_not_available: The card issuer could not be reached, so the payment could
+        not be authorized. The payment should be attempted again. If it still cannot
+        be processed, please contact your bank.
+      new_account_information_available: Your card, or account that the card is connected
+        to is invalid. Please try again with a different card.
+      not_permitted: The payment is not permitted. Please contact your bank for more
+        information.
+      pickup_card: Your card cannot be used to make this payment (it is possible it
+        has been reported lost or stolen). Please contact your bank for more information.
+      reenter_transaction: The payment could not be processed by the issuer for an
+        unknown reason. The payment should be attempted again. If it still cannot
+        be processed, please contact your bank.
+      unknown: Your card has been declined for an unknown reason. Please contact your
+        bank for more information.
+      withdrawal_count_limit_exceeded: Your have exceeded the balance or credit limit
+        available on their card. Please use an alternative payment method.
+    stripe_transaction_dialog:
+      amount_charged: Amount Charged
+      card_details: Card Details
+      card_holder: Card Holder
+      cvc_check: CVC Check
+      date: Date
+      dialog_title:
+        dispute: "**Dispute**"
+        dispute_list: "%{date} **Payout: Disputes**"
+        manual_payout: "**Manual Payout**"
+        payment: "**Payment**"
+        payment_list: "%{date} **Payout: Payments**"
+        payout: "%{date} **Payout**"
+        refund: "**Refund**"
+        refund_list: "%{date} **Payout: Refunds**"
+      disputed: Disputed
+      disputed_on: Disputed On
+      expires: Expires
+      failed: Failed
+      invoice: Invoice
+      linked_transactions: Linked Transactions
+      manual_payout:
+        check: Check to see if you’ve changed your payout schedule or made a manual
+          payout in Stripe.
+        description: We can only display transaction data from an 'automatic' payout.
+        solution: If you have changed your payout schedule, change it back to 'automatic'
+          and we'll get the transaction data for this payout when it's time for your
+          next payout.
+        warning: We can't show transactions
+      no_connection: Card details unavailable as the Stripe account has been disconnected.
+      number: Number
+      origin: Origin
+      paid: Paid
+      partial_refund: Partial Refund
+      passed: Passed
+      payment: Payment
+      payment_details: Payment Details
+      payout: "%{date} Payout"
+      payout_details:
+        amount: Amount
+        count: Count
+        foreign_total: Total
+        foreign_total_title: Transactions taken from another source
+        local_total_title: Transactions taken in Accounting
+        paid: Paid
+        received: Received
+        stripe_fees: Stripe Fees
+        subtotal_title: Subtotal
+        tooltip: There are transactions included in this payout that have not been
+          recorded in Sage Business Cloud.
+        total_amount_title: Total Payout Amount
+        total_paid_title: "**Total Paid** \n (Refunds/Disputes)"
+        total_title: Total Received
+        transaction_type: Transaction type
+        transaction_type_names:
+          dispute: Disputes
+          payment: Payments
+          refund: Refunds
+      payout_page:
+        header_text:
+          cancelled: Payout was expected to arrive on **%{date}** but payment was
+            cancelled.
+          failed: |-
+            Payout was expected to arrive on **%{date}** but payment failed.
+            This can be due to **[multiple reasons](%{help_link})**. Please make sure a **[valid bank account](%{settings_link})** is saved.
+          in_transit: Payout In Transit
+          paid: Payout Transferred
+        payout_summary: Payout Summary
+      received: Received
+      redirect_button: View in Stripe
+      refund_details: Refund Details
+      save: View in Stripe
+      stripe_fee: Stripe Fee
+      total_received: Total Received
+      total_refund: Refunded
+      transferred: Transferred
+      trx_date_time: Transaction Date & Time
+      type: Type
+    stripe_transactions:
+      activity: Activity
+      amount: Amount
+      arrival_date: Arrival Date
+      business_name: Business Name
+      card_holder: Card Holder
+      date: Date
+      date_time: Date & Time
+      feedback_add_text: " on this new feature"
+      ledger_account: Ledger Account
+      next_payout: Next Payout
+      paid: Paid
+      payout_statuses:
+        canceled: Cancelled
+        failed: Failed
+        failed_tooltip: |
+          Review your bank details in Stripe to
+          make sure a valid account is saved.
+        in_transit: In Transit
+        paid_out: Paid Out
+        unknown: Unknown
+      payout_total: Payout Total
+      payouts: Payouts
+      received: Received
+      refund_disputes_header: Refunds / Disputes
+      status: Status
+      stripe_balance: Stripe Balance
+      stripe_fees: Fees
+      transaction_type: Transaction Type
+      view_stripe_dashboard: View Stripe Dashboard
+  suggest:
+    contacts: Search for a Contact
+  summary: Summary
+  supplier_remittance:
+    report:
+      email: Email Remittance
+      headers:
+        currency_paid: Amount Paid
+        currency_paid_multi_currency: Amount Paid<span data-currency="%{currency_symbol}">&nbsp;</span>
+        date: Date
+        extra_reference: Your Ref
+        reference: Our Ref
+        total: Total Amount
+        total_multi_currency: Total Amount<span data-currency="%{currency_symbol}">&nbsp;</span>
+      print: Print Remittance
+      title: Remittance Advice
+      totals:
+        total: 'Total Paid:'
+        total_multi_currency: Total Paid<span data-currency="%{currency_symbol}">&nbsp;</span>
+  table:
+    no_data: No Results To Display
+    titles:
+      account_number: Account Number
+      advanced_uk/analysis_type_category:
+        code: Code
+        in_use?: In use?
+        name: Name
+      advanced_uk/bank_opening_balance:
+        amount: Opening Balance
+      advanced_uk/other_expense_payment_line_item:
+        description: Details
+      advanced_uk/other_expense_payment_refund_line_item:
+        description: Details
+      advanced_uk/other_income_payment_line_item:
+        description: Details
+      advanced_uk/other_income_payment_refund_line_item:
+        description: Details
+      amount: Amount
+      analysis_type_0: ''
+      analysis_type_1: ''
+      analysis_type_2: ''
+      bank_account: Bank Account
+      credit: Credit
+      currency_id: Currency
+      date: Date
+      debit: Debit
+      description: Description
+      details: Details
+      'false': 'No'
+      included_on_vat_return: Include on VAT Return
+      inverse: Inverse
+      journal:
+        code: Journal Code
+        date: Journal Date
+        description: Description
+        entry: Journal Entry
+      ledger_account: Ledger Account
+      rate: Rate
+      sort_code: Sort Code
+      'true': 'Yes'
+      type_id: Type
+  tabs:
+    advanced_uk/customer_receipt:
+      title: Customer Receipt
+    advanced_uk/customer_refund:
+      title: Customer Refund
+    advanced_uk/other_payment:
+      title: Other Payment
+    advanced_uk/other_receipt:
+      title: Other Receipt
+    advanced_uk/supplier_payment:
+      title: Supplier Payment
+    advanced_uk/supplier_refund:
+      title: Supplier Refund
+    fuji_banking/bank_accounts:
+      activity: Activity
+      address_and_contacts: Address & Contacts
+      reconciliations: Reconciliations
+    titles:
+      fuji_contacts/contacts:
+        about: About
+        activity: Activity
+        addresses: Addresses
+        contacts_addresses: Contacts and Addresses
+        details: Details
+        notes: Notes
+        options: Options
+        payment_details: Payment Details
+        transaction_allocation: Transaction allocation
+  tax:
+    tax_return:
+      delete_tax_return_success: Deleted tax return successfully
+      draft_saved: Tax return saved as draft
+      filed: Tax return marked as filed
+      payment_recorded: Tax return payment recorded
+      payment_recorded_failed: We can't record your payment right now, please try
+        again later
+  tax_breakdown:
+    adjust_tax: Adjust VAT
+    adjust_tax_title: Adjust VAT @ %{percentage}%
+    dialog:
+      description: A detailed breakdown of VAT per VAT Rate.
+      description_multi_currency: A detailed breakdown of VAT per VAT Rate in %{currency_code}.
+      title: VAT Analysis
+    equals: equals %{amount}%
+    net_total: Net Total
+    no_rate_selected: No rate selected
+    report:
+      headers:
+        amount: Amount
+        goods: Goods and Related Services
+        net: Net
+        rate: VAT Rate
+        services: Services
+        tax: VAT
+        total: Total
+    tax: VAT
+    tax_breakdown: VAT Breakdown
+    tax_calculation_changed:
+      credit_note: credit note
+      invoice: invoice
+      message_to_cash: Since the original %{type} was created, this supplier's VAT
+        setting has changed from invoice to cash.
+      message_to_invoice: Since the original %{type} was created, this supplier's
+        VAT setting has changed from cash to invoice.
+      title: Tax Calculation Changed
+    tax_calculation_method:
+      cash: VAT due on receipts/payments
+      invoice: VAT due on invoice/debits
+    tax_total: VAT Total
+    view_analysis: View VAT Analysis
+  tax_breakdown_types:
+    combined: Combined Tax Rates
+    individual: Individual Tax Rates
+    summary: One-Line Summary
+  tax_period_rates:
+    valid_for_period_false: 'No'
+    valid_for_period_true: 'Yes'
+  tax_rates_dialog_pattern:
+    add_first_item: Create a combined tax rate
+    add_item: Add component
+    alert_title: Tax rate cannot be deleted
+    combined_tax_rate_title: Combined Tax Rate
+    components_header: Components
+    confirm_message: Are you sure you wish to delete this tax rate?
+    confirm_no: Cancel
+    confirm_title: Delete tax rate?
+    confirm_yes: Delete Tax Rate
+    creating_tax_rate_action: New Tax Rate
+    creating_tax_rate_description: You may need to add a tax rate if you are planning
+      to sell products or services to customers that live in a different region or
+      state. It is possible to create a number of single tax rates or combined tax
+      rates. You can also combine existing single tax rates.
+    creating_tax_rate_title: Creating a New Tax Rate
+    footer_text: Remove all components to revert this tax rate to a single tax rate.
+    new_tax_rate_title: New Tax Rate
+    placeholders:
+      agency: Agency
+      multiple_tax_rates: Multiple
+      name: Name
+    show_tax_rate_description: Showing this tax rate will make it available for use
+      throughout the application
+    tax_rate_details_title: Edit Tax Rate
+    tax_rate_percentage_from: From
+    tax_rate_percentage_rate: Rate
+    tax_rate_percentage_to: through to
+    tax_rate_percentage_update_action: Update Rate
+    title: Tax Rates Management
+  tax_return:
+    adjust: Adjust
+    adjustment_dialog:
+      adjustment: "%{adjustment} adjustment"
+      calculated_figure: Calculated Figure
+      label:
+        amount: Change figure to
+        change_reason: Reason for Change
+      title:
+        MODELO390: Ajuste de IVA Anual
+    button:
+      calculate: Calculate
+      cancel: Cancel
+      content: Provincial sales tax returns are coming soon. Stay Tuned!
+      download_summary_report: Download Summary
+      draft: Save as Draft
+      edit_draft: Edit Draft
+      recalculate: Recalculate
+      record_payment: Record Payment
+      record_refund: Record Refund
+      title: Coming Soon!
+    controller:
+      MODELO390: modelo390
+    corporate_representative:
+      business_number: NIF
+      date_of_power: Fecha Poder
+      description:
+        line_1: El (los) representante(s) legal(es) de la Entidad declarante, manifiesta
+          que todos los datos consignados se corresponden con la
+        line_2: información contenida en los libros oficiales exigidos por la lalegislación
+          mercantil y en la normativa del Impuesto.
+      description_title: Declaración de los Representantes legales de la Entidad
+      empty_row: Esta sección no es necesaria para las empresas cuyo NIF empiece con
+        un número o con las letras 'X', 'Y', 'E' o 'H'.
+      name: Nombre
+      notary: Notaría
+      power_one: Por poder 1
+      power_three: Por poder 3
+      power_two: Por poder 2
+      title: Personas Jurídicas
+      without_legal_responsability_empty_row: Estos detalles no son necesarios para
+        las empresas con un código NIF que comienza con 'A'.
+      without_legal_responsability_empty_row_title: Individuos y entidades sin personalidad
+        jurídica
+    date_range_picker:
+      date_from: Tax period from
+      date_to: Tax period to
+    defaults:
+      tax_frequency: Set a frequency
+      tax_number: Set a tax number
+    deletion_confirmation_dialog:
+      message: Are you sure you wish to delete this tax return?
+      title: Delete Tax Return?
+    dialog:
+      pay:
+        title: Record Payment of VAT Return
+      reclaim:
+        title: Record Reclaim of VAT Return
+      title: VAT Adjustment
+    edit_tax_settings_dialog:
+      button: Edit Your Tax Settings
+      title: Edit your tax settings
+    label:
+      tax_frequency: 'Tax frequency:'
+    modelo130:
+      sections:
+        section1:
+          business_name:
+            row_description: Apellidos y Nombre
+          description: Declarante
+    modelo303:
+      sections:
+        section1:
+          business_name:
+            row_description: Apellidos y Nombre o Razón social o denominación
+          description: Identificación
+    modelo390:
+      boxes:
+        box_1:
+          editable: 'true'
+          line_number: '1'
+          title: Régimen ordinario
+        box_102:
+          editable: 'true'
+          line_number: '102'
+          negative_adjustment: 'true'
+          title: Operaciones realizadas por sujetos pasivos acogidos al régimen especial
+            del recargo de equivalencia
+        box_103:
+          editable: 'true'
+          line_number: '103'
+          negative_adjustment: 'true'
+          title: Entregas intracomunitarias exentas
+        box_104:
+          editable: 'true'
+          line_number: '104'
+          negative_adjustment: 'true'
+          title: Exportaciones y otras operaciones exentas con derecho a deducción
+        box_105:
+          editable: 'true'
+          line_number: '105'
+          negative_adjustment: 'true'
+          title: Operaciones exentas sin derecho a deducción
+        box_106:
+          editable: 'true'
+          line_number: '106'
+          negative_adjustment: 'true'
+          title: Entregas de bienes inmuebles, operaciones financieras y relativas
+            al oro de inversión no habituales
+        box_107:
+          editable: 'true'
+          line_number: '107'
+          negative_adjustment: 'true'
+          title: Entregas de bienes de inversión
+        box_108:
+          line_number: '108'
+          title: Total volumen de operaciones (Art. 121 Ley IVA)
+        box_109:
+          editable: 'true'
+          line_number: '109'
+          negative_adjustment: 'true'
+          title: Adquisiciones intracomunitarias exentas
+        box_110:
+          editable: 'true'
+          line_number: '110'
+          negative_adjustment: 'true'
+          title: Operaciones no sujetas por reglas de localización o con inversión
+            del sujeto pasivo
+        box_112:
+          editable: 'true'
+          line_number: '112'
+          negative_adjustment: 'true'
+          title: Entregas de bienes objeto de instalación o montaje en otros Estados
+            miembros
+        box_190:
+          editable: 'true'
+          line_number: '190'
+          sub_title: IVA deducible en operaciones interiores de bienes y servicios
+          title: 'Operaciones interiores corrientes:'
+        box_190_tax_rate: 4%
+        box_191:
+          editable: 'true'
+          line_number: '191'
+          sub_title: IVA deducible en operaciones interiores de bienes y servicios
+          title: 'Operaciones interiores corrientes:'
+        box_196:
+          editable: 'true'
+          line_number: '196'
+          sub_title: IVA deducible en  operaciones interiores de bienes de inversión
+          title: 'Operaciones interiores de bienes de inversión:'
+        box_196_tax_rate: 4%
+        box_197:
+          editable: 'true'
+          line_number: '197'
+          sub_title: IVA deducible en  operaciones interiores de bienes de inversión
+          title: 'Operaciones interiores de bienes de inversión:'
+        box_1_tax_rate: 4%
+        box_2:
+          editable: 'true'
+          line_number: '2'
+          title: Régimen ordinario
+        box_202:
+          editable: 'true'
+          line_number: '202'
+          sub_title: IVA deducible en importaciones de bienes corrientes
+          title: 'Importaciones y adquisiciones intracomunitarias de bienes y servicios:'
+        box_202_tax_rate: 4%
+        box_203:
+          editable: 'true'
+          line_number: '203'
+          sub_title: IVA deducible en importaciones de bienes corrientes
+          title: 'Importaciones y adquisiciones intracomunitarias de bienes y servicios:'
+        box_208:
+          editable: 'true'
+          line_number: '208'
+          title: IVA deducible en importaciones de bienes de inversión
+        box_208_tax_rate: 4%
+        box_209:
+          editable: 'true'
+          line_number: '209'
+          title: IVA deducible en importaciones de bienes de inversión
+        box_21:
+          editable: 'true'
+          line_number: '21'
+          title: Adquisiciones intracomunitarias de bienes
+        box_214:
+          editable: 'true'
+          line_number: '214'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes corrientes
+        box_214_tax_rate: 4%
+        box_215:
+          editable: 'true'
+          line_number: '215'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes corrientes
+        box_21_tax_rate: 4%
+        box_22:
+          editable: 'true'
+          line_number: '22'
+          title: Adquisiciones intracomunitarias de bienes
+        box_220:
+          editable: 'true'
+          line_number: '220'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes de inversión
+        box_220_tax_rate: 4%
+        box_221:
+          editable: 'true'
+          line_number: '221'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes de inversión
+        box_23:
+          editable: 'true'
+          line_number: '23'
+          title: Adquisiciones intracomunitarias de bienes
+        box_230:
+          editable: 'true'
+          line_number: '230'
+          negative_adjustment: 'true'
+          title: Adquisiciones interiores exentas
+        box_231:
+          editable: 'true'
+          line_number: '231'
+          negative_adjustment: 'true'
+          title: Importaciones exentas
+        box_23_tax_rate: 10%
+        box_24:
+          editable: 'true'
+          line_number: '24'
+          title: Adquisiciones intracomunitarias de bienes
+        box_25:
+          editable: 'true'
+          line_number: '25'
+          title: Adquisiciones intracomunitarias de bienes
+        box_25_tax_rate: 21%
+        box_26:
+          editable: 'true'
+          line_number: '26'
+          title: Adquisiciones intracomunitarias de bienes
+        box_27:
+          editable: 'true'
+          line_number: '27'
+          title: IVA devengado en otros supuestos de inversión del sujeto
+        box_28:
+          editable: 'true'
+          line_number: '28'
+          title: IVA devengado en otros supuestos de inversión del sujeto
+        box_29:
+          editable: 'true'
+          line_number: '29'
+          negative_adjustment: 'true'
+          title: Modificación de bases y cuotas
+        box_3:
+          editable: 'true'
+          line_number: '3'
+          title: Régimen ordinario
+        box_30:
+          editable: 'true'
+          line_number: '30'
+          negative_adjustment: 'true'
+          title: Modificación de bases y cuotas
+        box_31:
+          editable: 'true'
+          line_number: '31'
+          negative_adjustment: 'true'
+          title: Modificación de bases y cuotas por auto de declaración de concurso
+            de acreedores
+        box_32:
+          editable: 'true'
+          line_number: '32'
+          negative_adjustment: 'true'
+          title: Modificación de bases y cuotas por auto de declaración de concurso
+            de acreedores
+        box_33:
+          line_number: '33'
+          subsection_header: 'true'
+          title: Total cuota devengada
+        box_34:
+          line_number: '34'
+          subsection_header: 'true'
+          title: Total cuota devengada
+        box_35:
+          editable: 'true'
+          line_number: '35'
+          title: Recargo de equivalencia
+        box_35_tax_rate: 0,5%
+        box_36:
+          editable: 'true'
+          line_number: '36'
+          title: Recargo de equivalencia
+        box_3_tax_rate: 10%
+        box_4:
+          editable: 'true'
+          line_number: '4'
+          title: Régimen ordinario
+        box_41:
+          editable: 'true'
+          line_number: '41'
+          title: Recargo de equivalencia
+        box_41_tax_rate: 1,75%
+        box_42:
+          editable: 'true'
+          line_number: '42'
+          title: Recargo de equivalencia
+        box_43:
+          editable: 'true'
+          line_number: '43'
+          negative_adjustment: 'true'
+          title: Modificación recargo equivalencia
+        box_44:
+          editable: 'true'
+          line_number: '44'
+          negative_adjustment: 'true'
+          title: Modificación recargo equivalencia
+        box_47:
+          line_number: '47'
+          title: Total cuotas IVA y recargo de equivalencia
+        box_48:
+          line_number: '48'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en operaciones interiores
+            de bienes y servicios corrientes
+        box_49:
+          line_number: '49'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en operaciones interiores
+            de bienes y servicios corrientes
+        box_5:
+          editable: 'true'
+          line_number: '5'
+          title: Régimen ordinario
+        box_50:
+          line_number: '50'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en operaciones interiores
+            de bienes de inversión
+        box_51:
+          line_number: '51'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en operaciones interiores
+            de bienes de inversión
+        box_52:
+          line_number: '52'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en importaciones de bienes
+            corrientes
+        box_523:
+          editable: 'true'
+          line_number: '523'
+          negative_adjustment: 'true'
+          title: Servicios localizados en el territorio de aplicación del impuesto
+            por inversión del sujeto pasivo
+        box_53:
+          line_number: '53'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en importaciones de bienes
+            corrientes
+        box_54:
+          line_number: '54'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en importaciones de bienes
+            de inversión
+        box_545:
+          editable: 'true'
+          line_number: '545'
+          title: Adquisiciones intracomunitarias de servicios
+        box_545_tax_rate: 4%
+        box_546:
+          editable: 'true'
+          line_number: '546'
+          title: Adquisiciones intracomunitarias de servicios
+        box_547:
+          editable: 'true'
+          line_number: '547'
+          title: Adquisiciones intracomunitarias de servicios
+        box_547_tax_rate: 10%
+        box_548:
+          editable: 'true'
+          line_number: '548'
+          title: Adquisiciones intracomunitarias de servicios
+        box_55:
+          line_number: '55'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en importaciones de bienes
+            de inversión
+        box_551:
+          editable: 'true'
+          line_number: '551'
+          title: Adquisiciones intracomunitarias de servicios
+        box_551_tax_rate: 21%
+        box_552:
+          editable: 'true'
+          line_number: '552'
+          title: Adquisiciones intracomunitarias de servicios
+        box_56:
+          line_number: '56'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en adquisiciones intracomunitarias
+            de bienes corrientes
+        box_57:
+          line_number: '57'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en adquisiciones intracomunitarias
+            de bienes corrientes
+        box_58:
+          line_number: '58'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en adquisiciones intracomunitarias
+            de bienes de inversión
+        box_587:
+          editable: 'true'
+          line_number: '587'
+          title: IVA deducible en adquisiciones intracomunitarias de servicios
+        box_587_tax_rate: 4%
+        box_588:
+          editable: 'true'
+          line_number: '588'
+          title: IVA deducible en adquisiciones intracomunitarias de servicios
+        box_59:
+          line_number: '59'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en adquisiciones intracomunitarias
+            de bienes de inversión
+        box_597:
+          line_number: '597'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en adquisiciones intracomunitarias
+            de servicios
+        box_598:
+          line_number: '598'
+          subsection_header: 'true'
+          title: Total bases imponibles y cuotas deducibles en adquisiciones intracomunitarias
+            de servicios
+        box_599:
+          editable: 'true'
+          line_number: '599'
+          title: Recargo de equivalencia
+        box_599_tax_rate: 1,4%
+        box_5_tax_rate: 21%
+        box_6:
+          editable: 'true'
+          line_number: '6'
+          title: Régimen ordinario
+        box_600:
+          editable: 'true'
+          line_number: '600'
+          title: Recargo de equivalencia
+        box_601:
+          editable: 'true'
+          line_number: '601'
+          title: Recargo de equivalencia
+        box_601_tax_rate: 5,2%
+        box_602:
+          editable: 'true'
+          line_number: '602'
+          title: Recargo de equivalencia
+        box_603:
+          editable: 'true'
+          line_number: '603'
+          sub_title: IVA deducible en operaciones interiores de bienes y servicios
+          title: 'Operaciones interiores corrientes:'
+        box_603_tax_rate: 10%
+        box_604:
+          editable: 'true'
+          line_number: '604'
+          sub_title: IVA deducible en operaciones interiores de bienes y servicios
+          title: 'Operaciones interiores corrientes:'
+        box_605:
+          editable: 'true'
+          line_number: '605'
+          sub_title: IVA deducible en operaciones interiores de bienes y servicios
+          title: 'Operaciones interiores corrientes:'
+        box_605_tax_rate: 21%
+        box_606:
+          editable: 'true'
+          line_number: '606'
+          sub_title: IVA deducible en operaciones interiores de bienes y servicios
+          title: 'Operaciones interiores corrientes:'
+        box_611:
+          editable: 'true'
+          line_number: '611'
+          sub_title: IVA deducible en operaciones interiores de bienes de inversión
+          title: 'Operaciones interiores de bienes de inversión:'
+        box_611_tax_rate: 10%
+        box_612:
+          editable: 'true'
+          line_number: '612'
+          sub_title: IVA deducible en operaciones interiores de bienes de inversión
+          title: 'Operaciones interiores de bienes de inversión:'
+        box_613:
+          editable: 'true'
+          line_number: '613'
+          sub_title: IVA deducible en operaciones interiores de bienes de inversión
+          title: 'Operaciones interiores de bienes de inversión:'
+        box_613_tax_rate: 21%
+        box_614:
+          editable: 'true'
+          line_number: '614'
+          sub_title: IVA deducible en operaciones interiores de bienes de inversión
+          title: 'Operaciones interiores de bienes de inversión:'
+        box_619:
+          editable: 'true'
+          line_number: '619'
+          sub_title: IVA deducible en importaciones de bienes corrientes
+          title: 'Importaciones y adquisiciones intracomunitarias de bienes y servicios:'
+        box_619_tax_rate: 10%
+        box_62:
+          editable: 'true'
+          line_number: '62'
+          negative_adjustment: 'true'
+          title: Rectificación de deducciones
+        box_620:
+          editable: 'true'
+          line_number: '620'
+          sub_title: IVA deducible en importaciones de bienes corrientes
+          title: 'Importaciones y adquisiciones intracomunitarias de bienes y servicios:'
+        box_621:
+          editable: 'true'
+          line_number: '621'
+          sub_title: IVA deducible en importaciones de bienes corrientes
+          title: 'Importaciones y adquisiciones intracomunitarias de bienes y servicios:'
+        box_621_tax_rate: 21%
+        box_622:
+          editable: 'true'
+          line_number: '622'
+          sub_title: IVA deducible en importaciones de bienes corrientes
+          title: 'Importaciones y adquisiciones intracomunitarias de bienes y servicios:'
+        box_623:
+          editable: 'true'
+          line_number: '623'
+          title: IVA deducible en importaciones de bienes de inversión
+        box_623_tax_rate: 10%
+        box_624:
+          editable: 'true'
+          line_number: '624'
+          title: IVA deducible en importaciones de bienes de inversión
+        box_625:
+          editable: 'true'
+          line_number: '625'
+          title: IVA deducible en importaciones de bienes de inversión
+        box_625_tax_rate: 21%
+        box_626:
+          editable: 'true'
+          line_number: '626'
+          title: IVA deducible en importaciones de bienes de inversión
+        box_627:
+          editable: 'true'
+          line_number: '627'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes corrientes
+        box_627_tax_rate: 10%
+        box_628:
+          editable: 'true'
+          line_number: '628'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes corrientes
+        box_629:
+          editable: 'true'
+          line_number: '629'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes corrientes
+        box_629_tax_rate: 21%
+        box_630:
+          editable: 'true'
+          line_number: '630'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes corrientes
+        box_631:
+          editable: 'true'
+          line_number: '631'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes de inversión
+        box_631_tax_rate: 10%
+        box_632:
+          editable: 'true'
+          line_number: '632'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes de inversión
+        box_633:
+          editable: 'true'
+          line_number: '633'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes de inversión
+        box_633_tax_rate: 21%
+        box_634:
+          editable: 'true'
+          line_number: '634'
+          title: IVA deducible en adquisiciones intracomunitarias de bienes de inversión
+        box_635:
+          editable: 'true'
+          line_number: '635'
+          title: IVA deducible en adquisiciones intracomunitarias de servicios
+        box_635_tax_rate: 10%
+        box_636:
+          editable: 'true'
+          line_number: '636'
+          title: IVA deducible en adquisiciones intracomunitarias de servicios
+        box_637:
+          editable: 'true'
+          line_number: '637'
+          title: IVA deducible en adquisiciones intracomunitarias de servicios
+        box_637_tax_rate: 21%
+        box_638:
+          editable: 'true'
+          line_number: '638'
+          title: IVA deducible en adquisiciones intracomunitarias de servicios
+        box_639:
+          editable: 'true'
+          line_number: '639'
+          negative_adjustment: 'true'
+          title: Rectificación de deducciones
+        box_64:
+          line_number: '64'
+          title: Suma de deducciones
+        box_65:
+          line_number: '65'
+          title: Resultado régimen general
+        box_659:
+          editable: 'true'
+          line_number: '659'
+          title: IVA a la importación liquidado por la Aduana (sólo sujetos pasivos
+            con opción de diferimiento)
+        box_660:
+          editable: 'true'
+          line_number: '660'
+          negative_adjustment: 'true'
+          title: Cuotas deducibles en virtud de resolución administrativa o sentencia
+            firmes con tipos no vigentes
+        box_661:
+          editable: 'true'
+          line_number: '661'
+          negative_adjustment: 'true'
+          title: Cuotas deducibles en virtud de resolución administrativa o sentencia
+            firmes con tipos no vigentes
+        box_662:
+          editable: 'true'
+          line_number: '662'
+          title: Cuotas pendientes de compensación al término del ejercicio
+        box_84:
+          line_number: '84'
+          title: Suma de resultados
+        box_85:
+          editable: 'true'
+          line_number: '85'
+          title: Compensación de cuotas del ejercicio anterior
+        box_86:
+          line_number: '86'
+          title: Resultado de la liquidación
+        box_95:
+          editable: 'true'
+          line_number: '95'
+          title: Total resultados a ingresar en las autoliquidaciones de IVA del ejercicio
+        box_97:
+          editable: 'true'
+          line_number: '97'
+          title: Si el resultado de la autoliquidación del último periodo es a compensar
+            o a devolver
+        box_98:
+          editable: 'true'
+          line_number: '98'
+          title: Si el resultado de la autoliquidación del último periodo es a compensar
+            o a devolver
+        box_99:
+          editable: 'true'
+          line_number: '99'
+          negative_adjustment: 'true'
+          title: Operaciones en régimen general
+      sections:
+        empty_section:
+          default_message: Esta parte de la devolución no está soportada por Sage
+            One. Puedes incorporar esta información en la web de la <a href='http://www.agenciatributaria.es'>Agencia
+            Tributaria</a> si es requerida.
+        section1:
+          business_name:
+            row_description: Apellidos y Nombre o Razón social o denominación
+          description: 1. Sujeto Pasivo + 3. Datos Estadísticos
+          vat_number:
+            row_description: NIF
+        section10:
+          description: 10. Volumen de operaciones
+        section11:
+          description: 11. Operaciones específicas
+          subtitle:
+            title1: Operaciones realizadas en el ejercicio
+            title2: ''
+            title3: ''
+        section12:
+          description: 12. Prorrata
+        section13:
+          description: 13. Actividades con regímenes de deducción diferenciados
+        section3:
+          business_activity:
+            code: Clave
+            description: Descripción
+            option1: Actividades sujetas al IAE (Activ. Empresariales)
+            option2: Actividades sujetas al IAE (Activ. Profesionales y Artísticas)
+            option3: Arrendadores de Locales de Negocios y Garajes
+            option4: Actividades Agrícolas, Ganaderas o Pesqueras, no sujetas al IAE
+            option5: Sujetos pasivos que no hayan iniciado la realización de entregas
+              de bienes o prestaciones de servicios correspondientes a actividades
+              empresariales o profesionales y no estén dados de alta en el IAE
+            option6: Otras actividades no sujetas al IAE
+            row_description: Actividades a las que se refiere la declaración
+        section4:
+          description: 4. Datos del Representante y firma de la declaración
+          message: Si tu empresa necesita completar esta sección, estará disponible
+            en enero, a tiempo para que presentes tu Modelo 390 a fin de mes. Si deseas
+            enviarlo antes, puedes hacerlo a través de la autoridad tributaria o tu
+            asesor.
+        section5_1:
+          description: 5. Operaciones Realizadas en Régimen General
+          subtitle:
+            title1: IVA Devengado
+            title2: Base imponible
+            title3: Tipo %
+            title4: Cuota devengada
+        section5_2:
+          subtitle:
+            title1: IVA Deducible
+            title2: Base imponible
+            title3: Tipo %
+            title4: Cuota devengada
+        section6:
+          description: 6. Operaciones realizadas en régimen simplificado
+        section7:
+          description: 7. Resultado liquidación anual
+          subtitle:
+            title1: Liquidación anual
+            title2: ''
+            title3: ''
+        section8:
+          description: '8. Tributación por razón de territorio '
+        section9:
+          description: 9. Resultado de las liquidaciones
+          radio_button1:
+            label: A Compensar
+          radio_button2:
+            label: A Devolver
+          subtitle:
+            title1: Períodos que no tributan en Régimen especial del grupo de entidades
+            title2: ''
+            title3: ''
+      year_picker:
+        label: Ejercicio
+    paid_false: Not paid
+    paid_true: Paid
+    part_paid: Part paid
+    personal_representative:
+      address: Dirección
+      business_number: NIF
+      door_number: Prta.
+      floor: Piso
+      municipality: Municipio
+      name: Apellidos y Nombre o Razón social o denominación
+      postcode: Código Postal
+      province: Provincia
+      stairs: Esc.
+      street: Calle, Pza., Avda
+      street_name: Vía Pública
+      street_number: Número
+      telephone: Teléfono
+      title: Personas físicas
+    record_payment_dialog:
+      bank_placeholder_payment: Where did this money come from?
+      bank_placeholder_refund: Where will this money go to?
+      label:
+        amount: Amount
+        bank_payment: Bank from
+        bank_refund: Bank to
+        date_payment: Date of Payment
+        date_refund: Date of Refund
+        reference: Reference
+      title_payment: Record Payment of VAT Return
+      title_refund: Record Refund of VAT Return
+      validation_message:
+        lockdown_date: The payment date must be later than the lockdown date of %{date}
+    report:
+      detailed_report: Detailed Report
+      export: Export
+      summary_report: Summary Report
+    report_status:
+      draft: Draft Return
+      filed_not_paid: Submitted manually but not paid
+      filed_not_refunded: Submitted manually but not refunded
+      filed_paid: Submitted manually and paid
+      filed_part_paid: Submitted manually and %{amount} paid
+      filed_part_refunded: Submitted manually and %{amount} refunded
+      filed_refund_carryforward: Filed and refund to carry forward
+      filed_refunded: Submitted manually and refunded
+    settings_dialog:
+      label:
+        tax_frequency: How often do you submit tax returns?
+    step_2_content:
+      button:
+        download_tax_file: Download .Tax File
+      label:
+        final_return: This is my final return for this financial year
+        optional_reference: Optional Reference
+      message:
+        MODELO390: |
+          Para acelerar el proceso de enviar tu modelo 390, puedes descargar una copia en formato .txt.
+          Luego podrás enviársela a la <strong><a target="_blank" href="https://www.agenciatributaria.gob.es/">Agencia Tributaria</a></strong> y el modelo se rellenará automáticamente.
+
+          También puedes rellenar el modelo por otros medios y continuar sin descargártelo
+      title:
+        mark_as_submitted: Mark as Submitted
+    table_header:
+      action: Action
+      date: Date
+      from: From
+      income_tax_expense_contact: Supplier
+      income_tax_revenue_contact: Customer
+      invoice_number: Invoice Number
+      irpf_percentage: IRPF %
+      irpf_value: IRPF Value
+      net: Net
+      net_total: Total
+      nif: NIF
+      reference: Reference
+      return_amount: Return Amount (%{currency_symbol})
+      status: Status
+      tax_type: Tax Type
+      to: To
+      total: Total
+      transaction_no: Trx No
+      type: Type
+      year: Year
+      year_quarter: Settlement Period
+    tax_calculation_on_report:
+      cash: VAT has been calculated based on the payment date.
+      invoice: VAT has been calculated based on the date of invoices.
+      mixed: VAT has been calculated using a mixture of invoice and payment dates.
+    tax_settings:
+      button: Set Tax Settings
+      message: Set the tax rates you'll apply to sales and purchases, so we can do
+        the math for you.
+      title: How will you charge sales tax?
+    title:
+      MODELO390: Modelo390
+      calculate_tax: Calculate Tax
+      create_return: Create VAT Return
+      submit: Submit VAT Returns
+      tax_return_type:
+        MODELO390: Annual
+      tax_returns: Your VAT Returns
+    urls:
+      draft:
+        MODELO130: "/reports/income_tax_es/draft"
+        MODELO390: "/reports/modelo390/draft"
+      index:
+        MODELO130: "/reports/income_tax_es#MODELO130"
+        MODELO390: "/reports/modelo390#MODELO390"
+      new:
+        MODELO130: "/reports/income_tax_es/new?tax_return_type=MODELO130"
+        MODELO390: "/reports/modelo390/new?tax_return_type=MODELO390"
+      submit:
+        MODELO130: "/reports/income_tax_es/mark_as_submitted"
+        MODELO390: "/reports/modelo390/mark_as_submitted"
+    vat_adjustment_dialog:
+      header:
+        income: Ingresos
+        trimesters: Trimestrales
+      label:
+        first_trimester: 1er Trimestre
+        fourth_trimester: 4º Trimestre
+        second_trimester: 2º Trimestre
+        third_trimester: 3er Trimestre
+        total: Total
+      title:
+        MODELO390: Ajuste de IVA
+    warnings:
+      adjustment_clear_warn: 'Your dates have changed: Please calculate your tax return
+        again to reflect your changes. Please note that any adjustments will be cleared.'
+      corrective_return_warn: You have already created a VAT return for the selected
+        period, this return will be set as a corrective return.
+      date_changed_warn: 'Your dates have changed: Please calculate your tax return
+        again to reflect your changes.'
+    year_quarter_picker:
+      label: Settlement Period
+  time:
+    formats:
+      date_and_time: "%a %d %b %Y, %R"
+      date_only: "%d %b %Y"
+      short_full_month: "%d %B, %H:%M"
+      short_with_comma: "%d %b, %H:%M"
+      tax_return: "%-d %b %Y %-l:%M%P"
+      time_only: "%H:%M"
+  transaction_types:
+    prompt_all: All
+  two_factor_authentication:
+    error: We could not verify the validity of your entered PIN. Please try again.
+    subject: Authentication required
+    verify:
+      action: Verify
+      description: You are trying to access Sage Business Cloud Accounting from a
+        new device, please use the PIN we have just emailed to you to verify your
+        identity.
+      main_title: Two Step Verification
+      pin: PIN
+      title: Verify Your Identity
+  unknown: Unknown
+  unknown_country: an unknown country
+  updates:
+    updates_button: View updates
+    updates_title: New updates launched
+    view_updates: We have made more improvements to your service.
+  upgrades:
+    notification:
+      long_running:
+        slack_message: |-
+          An upgrade to Sage Business Cloud Accounting took longer than expected.
+
+          Business GUID - %{guid}
+          Business Name - %{name}
+          Migrating for - %{length}
+          Started At - %{started_at}
+          Finished At - %{finished_at}
+        slack_subject: Long Running Upgrade to Sage Business Cloud Accounting - %{business}
+    success:
+      available_anytime_you_need: " is available anytime you need."
+      enjoy_sage_one_accounting: Enjoy Sage Business Cloud Accounting!
+      help_and_support: Help and support
+      mission_complete_html: Mission <b>complete!</b>
+      start_using_sage_one_accounting: Start Using Accounting
+  user_admin:
+    auth_provider:
+      title: Auth Providers
+    chargeable_dates_updated: Chargeable Dates Updated
+    create_user:
+      title: Create User
+    customer_list:
+      title: Customer List
+    emails:
+      activation:
+        subject: Activate Your Account
+    handled_by: Handled by %{name}
+    is_owner: You are viewing the owner of the business.
+    login:
+      errors:
+        blocked: User access is disabled.
+    pending_activations_list:
+      title: Pending Activations
+    search:
+      search_down: There was a problem contacting our search instance. Please search
+        by full email address until this issue has been resolved.
+    service_actions:
+      confirm_message_html: Please insert this string <b>%{rand}</b>
+      restart:
+        button: Reset Service
+        confirm: Are you sure you wish to reset the service for the selected business?  This
+          action is irreversible and will cause data loss.
+        confirm_label: If you wish to reset the service for the selected business,
+          please submit the string. This action is irreversible and will cause data
+          loss.
+        dialog_title: Reset Service Confirmation
+        error: Could not reset service.
+        success: Service has been successfully reset.
+      terminate:
+        additional_businesses_remain: You are attempting to delete the lead business
+          whilst additional businesses remain. Please delete any additional businesses
+          first.
+        button: Terminate Business
+        confirm: Are you sure you wish to terminate this business? This action is
+          irreversible and will cause data loss.
+        confirm_label: If you wish to terminate this business, please submit the string.  This
+          action is irreversible and will cause data loss.
+        dialog_title: Terminate Business Confirmation
+        error: Could not terminate business.
+        success: Business has been successfully terminated.
+      title: Service Actions
+    service_provider:
+      direct:
+        name: N/A
+      reseller: "%{name} (Reseller)"
+    user_actions:
+      block:
+        button: Block User Access
+        prompt: Are you sure you wish to block user access?
+        success: User access has been blocked.
+      chargeable_date: "%{name}: Chargeable Date"
+      chargeable_date_fixed: Chargeable date is fixed in billing system.
+      delink:
+        button: Delink Account
+        prompt: Are you sure you wish to delink this account? This is NOT reversible.
+        success: Account delinked
+      login:
+        button: Login as User
+        prompt: |-
+          All user activity is logged to help us know who has done what.
+
+          Customer data is confidential.  You must have their express permission to sign in.
+
+          Do you have the customer's permission to sign in?
+      resend_email_verification: Resend Activation Email
+      title: Actions
+      unblock:
+        button: Allow User Access
+        prompt: Are you sure you wish to allow user access?
+        success: User access has been allowed.
+      view_activity: View User Activities
+    user_audit:
+      title: User Audit Trail
+    user_details:
+      business_summary: Business Summary
+      contact_details: Contact Details
+      title: User Details
+  validations:
+    country_must_be: Country must be %{value}
+    country_must_be_one_of: Country must be one of %{value}
+    decimal: Must be a decimal
+    digit_length: Must be %{value} digits
+    email: Please enter a valid email address
+    equal_or_larger_than: Must be equal or larger than %{value}
+    integer: Must be an integer
+    integer_length_range: Must be between %{min} and %{max} digits in length
+    invalid_format: Invalid Format
+    length: Must be %{value} characters in length
+    length_greater_or_less: Must be %{value} characters or less
+    length_greater_or_more: Must be %{value} characters or more
+    length_range: Must be between %{min} and %{max} characters in length
+    max_date_range: Choose dates that are less than %{max} days apart
+    postcode_for_country: invalid for the selected country
+    value_between: Must be a value between %{min} and %{max}
+    value_match: "'%{value}' does not match our records."
+  views:
+    fuji_core_accounting/tax_period:
+      show:
+        end_date_nil: To Present
+  warnings:
+    messages:
+      change_affactes_all_records: Changing a pricing label will affect all records.
+      did_you_mean: Did you mean...
+      dirty_artefact: This %{artefact} has unsaved changes.
+      dirty_form: This form contains unsaved data.
+      disable_tax_rate: Deleting this tax rate will make it immediately inaccessible.
+      duplicate_artefact_found_purchases: A similar transaction already exists for
+        this Supplier
+      duplicate_artefact_found_sales: A similar transaction already exists for this
+        Customer
+      has_changed: The value of this field has been changed.
+      high_tax_rate_percentage: This is an abnormally high rate.
+      older_than_start_date: Date selected is prior to your Accounts Start Date of
+        %{date}.
+      verification_failure: We couldn't verify this email address; you can correct
+        it or try sending anyway.
+      verification_failures: 'We couldn''t verify the following email addresses; you
+        can correct them or try sending anyway: %{email_addresses}'
+      zero_tax_rate_percentage: This rate percentage is currently set to 0%.
+    title: 'Warning:'
+  widgets:
+    accounting_type_label:
+      accrual: Accrual
+      cash_based: Cash Based
+      indicator: 'Your current accounting type is: '
+    advanced_filter:
+      refine: Refine
+  withholding_tax:
+    edit:
+      exclude_description: IRPF is not added to the invoice.
+      include_description: Tell us the percentage or value to be withheld.
+      percentage_to_apply: 'Percentage to apply:'
+      purchase_corrective_invoice:
+        exclude: Do not deduct IRPF
+        include: Deduct IRPF
+        title: IRPF to be withheld
+      purchase_invoice:
+        exclude: Do not deduct IRPF
+        include: Deduct IRPF
+        title: IRPF to be withheld
+      sales_corrective_invoice:
+        exclude: Do not include IRPF
+        include: Include IRPF
+        title: Amend IRPF
+      sales_invoice:
+        exclude: Do not include IRPF
+        include: Include IRPF
+        title: Amend IRPF
+      sales_quote:
+        exclude: Do not include IRPF
+        include: Include IRPF
+        title: Amend IRPF
+      value_equals: of **%{value}** equals
+    irpf_withheld: IRPF
+    label: IRPF
+    not_applicable: Not applicable
+  wizards:
+    fuji_banking/bank_reconciliation_wizard:
+      titles:
+        first_step: Define Reconciliation Details
+        second_step: Reconcile Entries
+    multi_page_wizard:
+      buttons:
+        back: Back
+        cancel: Cancel
+        next: Next
+        submit: Submit
+    multi_step_wizard:
+      buttons:
+        back: Back
+        next: Next
+        submit: Mark as Filed
+    sop_authentication/signup_wizard:
+      long_titles:
+        authentication: Sign in to create your account
+        user_details: Enter your user details
+      prompts:
+        financial_settings_tax_scheme: Please select a VAT scheme
+        financial_settings_tax_submission_frequency_type: Please select a Submission
+          frequency
+        user_country: Select a Country
+      titles:
+        authentication: Sign In Details
+        business_address: Business Address
+        business_details: Business Details
+        coa_template_selection: COA Template Selection
+        contact_information: Contact Information
+        identification: Identification
+        services: Services
+        tax_details: VAT details
+        user_details: Contact Details

--- a/spec/services/normalize_spec.rb
+++ b/spec/services/normalize_spec.rb
@@ -116,6 +116,28 @@ RSpec.describe YamlNormalizer::Services::Normalize do
         end
       end
     end
+
+    context 'Psych changes sanitization' do
+      let(:file) { 'real_life_sample.yml' }
+      let(:expected) { 'real_life_sample_normalized.yml' }
+
+      it 'filters out the strange whitespace changes introduced by Psych parser' do
+        Tempfile.open(file) do |yaml|
+          yaml.write(File.read(path + file))
+          yaml.rewind
+          expect do
+            stderr = $stderr
+            $stderr = StringIO.new
+            described_class.new(yaml.path).call
+            $stderr = stderr
+          end.to(
+            change { File.read(yaml.path) }
+            .from(File.read("#{path}#{file}"))
+            .to(File.read("#{path}#{expected}"))
+          )
+        end
+      end
+    end
   end
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
## What is the change
Small normalization method in Normalize Service + version bump 1.1.0 -> 1.1.1

## Why is the change
It has been noticed that Psych parses sometimes removes nusignificant whitespace from the YAML files generating mess and confusion in reviews. A recent example can be found here: . The normalization now filters out such unwanted changes.

## TODO
- [ ] Find a smaller example YAML file for specs
- [ ] Review the code

