### PR TITLE
[yaml_normalizer] Added terminal methods for more informative CLI access

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,3 +3,7 @@ require:
 
 AllCops:
   TargetRubyVersion: 2.5
+
+# Commonly used screens these days easily fit more than 80 characters.
+Metrics/LineLength:
+  Max: 120

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Removed
 
+## [1.2.0] - 2019-08-08
+### Added
+- Versioning and help messages for CLI
+
+### Changed
+- Extended allowed line length to 120
+- Change the mutant to only scan the latest commits 
+
 
 ## [1.1.0] - 2019-05-21
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,6 +44,20 @@ This is how you run them in your terminal:
     $ yaml_check my_yaml_file.yml
     $ yaml_normalize my_yaml_file.yml
 
+To check the current version of yaml_normalizer type:
+   $ yaml_check --version
+
+   or
+
+   $ yaml_normalize -v
+
+To see the help message for yaml_normalizer type:
+   $ yaml_check --help
+
+    or
+
+   $ yaml_normalize -h
+
 ### Include Yaml Normalizer rake tasks
 In your Gemfile, add
 

--- a/Rakefile
+++ b/Rakefile
@@ -66,6 +66,6 @@ FlogTask.new do |config|
 end
 
 desc 'Continuous integration test suite (DEFAULT)'
-task ci: %i[inch rubocop ci_flog ci_spec mutant]
+task ci: %i[inch rubocop ci_flog ci_spec]
 
 task default: :ci

--- a/Rakefile
+++ b/Rakefile
@@ -44,6 +44,7 @@ end
 desc 'Mutation testing to check mutation coverage of current RSpec test suite'
 task :mutant do
   mutant_sh = 'bundle exec mutant \
+    --since 18069a6bb8779c2381b361738c866ce4c35f7466 \
     --include lib \
     --require yaml_normalizer \
     --use rspec YamlNormalizer* 2>&1'
@@ -66,6 +67,6 @@ FlogTask.new do |config|
 end
 
 desc 'Continuous integration test suite (DEFAULT)'
-task ci: %i[inch rubocop ci_flog ci_spec]
+task ci: %i[inch rubocop ci_flog ci_spec mutant]
 
 task default: :ci

--- a/Rakefile
+++ b/Rakefile
@@ -44,7 +44,7 @@ end
 desc 'Mutation testing to check mutation coverage of current RSpec test suite'
 task :mutant do
   mutant_sh = 'bundle exec mutant \
-    --since v1.2.0 \
+    --since 0baa016e8a89b81b35e74ff988594dc11fbd48f5 \
     --include lib \
     --require yaml_normalizer \
     --use rspec YamlNormalizer* 2>&1'

--- a/Rakefile
+++ b/Rakefile
@@ -44,7 +44,7 @@ end
 desc 'Mutation testing to check mutation coverage of current RSpec test suite'
 task :mutant do
   mutant_sh = 'bundle exec mutant \
-    --since 18069a6bb8779c2381b361738c866ce4c35f7466 \
+    --since v1.2.0 \
     --include lib \
     --require yaml_normalizer \
     --use rspec YamlNormalizer* 2>&1'

--- a/lib/yaml_normalizer/ext/sort_by_key.rb
+++ b/lib/yaml_normalizer/ext/sort_by_key.rb
@@ -19,9 +19,7 @@ module YamlNormalizer
       def sort_by_key(recursive = true)
         keys.sort_by(&:to_s).each_with_object({}) do |key, seed|
           value = seed[key] = fetch(key)
-          if recursive && value.instance_of?(Hash)
-            seed[key] = value.extend(SortByKey).sort_by_key
-          end
+          seed[key] = value.extend(SortByKey).sort_by_key if recursive && value.instance_of?(Hash)
         end
       end
     end

--- a/lib/yaml_normalizer/helpers.rb
+++ b/lib/yaml_normalizer/helpers.rb
@@ -7,3 +7,4 @@ module YamlNormalizer
 end
 
 require 'yaml_normalizer/helpers/normalize'
+require 'yaml_normalizer/helpers/param_parser'

--- a/lib/yaml_normalizer/helpers/param_parser.rb
+++ b/lib/yaml_normalizer/helpers/param_parser.rb
@@ -16,11 +16,11 @@ module YamlNormalizer
           opts.banner = "Usage: #{program_name} [options] file1, file2..."
           opts.on('-v', '--version', 'Prints the yaml_normalizer version') do
             print_version
-            exit(0)
+            exit_success
           end
           opts.on('-h', '--help', 'Prints this help') do
             print(opts)
-            exit(0)
+            exit_success
           end
         end.parse(args)
       end
@@ -35,6 +35,10 @@ module YamlNormalizer
 
       def program_name
         $PROGRAM_NAME.split('/').last
+      end
+
+      def exit_success
+        exit unless ENV['ENV'] == 'test'
       end
     end
   end

--- a/lib/yaml_normalizer/helpers/param_parser.rb
+++ b/lib/yaml_normalizer/helpers/param_parser.rb
@@ -6,29 +6,29 @@ module YamlNormalizer
   module Helpers
     # Methods handling passing of additional params from CLI
     module ParamParser
-      # rubocop:disable Metrics/MethodLength
-
       # Parse the params provided to the service
       # @param [Array] args - params passed to the service
       # @return nil
       def parse_params(*args)
         OptionParser.new do |opts|
           opts.banner = "Usage: #{program_name} [options] file1, file2..."
-          opts.on('-v', '--version', 'Prints the yaml_normalizer version') do
-            print_version
-            exit_success
-          end
-          opts.on('-h', '--help', 'Prints this help') do
-            print(opts)
-            exit_success
-          end
+          opts.on('-v', '--version', 'Prints the yaml_normalizer version') { print_version }
+          opts.on('-h', '--help', 'Prints this help') { print_help(opts) }
         end.parse(args)
       end
-      # rubocop:enable Metrics/MethodLength
 
       # Print current version of the tool
       def print_version
         print("#{YamlNormalizer::VERSION}\n")
+        exit_success
+      end
+
+      # Print current version of the tool
+      # @param [Option] opts - options of opt_parser object
+      # @return nil
+      def print_help(opts)
+        print(opts)
+        exit_success
       end
 
       private

--- a/lib/yaml_normalizer/helpers/param_parser.rb
+++ b/lib/yaml_normalizer/helpers/param_parser.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'optparse'
+
+module YamlNormalizer
+  module Helpers
+    # Methods handling passing of additional params from CLI
+    module ParamParser
+      # rubocop:disable Metrics/MethodLength
+
+      # Parse the params provided to the service
+      # @param [Array] args - params passed to the service
+      # @return nil
+      def parse_params(*args)
+        OptionParser.new do |opts|
+          opts.banner = "Usage: #{program_name} [options] file1, file2..."
+          opts.on('-v', '--version', 'Prints the yaml_normalizer version') do
+            print_version
+            exit(0)
+          end
+          opts.on('-h', '--help', 'Prints this help') do
+            print(opts)
+            exit(0)
+          end
+        end.parse(args)
+      end
+      # rubocop:enable Metrics/MethodLength
+
+      # Print current version of the tool
+      def print_version
+        print("#{YamlNormalizer::VERSION}\n")
+      end
+
+      private
+
+      def program_name
+        $PROGRAM_NAME.split('/').last
+      end
+    end
+  end
+end

--- a/lib/yaml_normalizer/services/check.rb
+++ b/lib/yaml_normalizer/services/check.rb
@@ -11,6 +11,7 @@ module YamlNormalizer
     #   result = check.call
     class Check < Base
       include Helpers::Normalize
+      include Helpers::ParamParser
 
       # files is a sorted array of file path Strings
       attr_reader :files
@@ -19,6 +20,7 @@ module YamlNormalizer
       # more Strings that are interpreted as file glob pattern.
       # @param *args [Array<String>] a list of file glob patterns
       def initialize(*args)
+        parse_params(*args)
         files = args.each_with_object([]) { |a, o| o << Dir[a.to_s] }
         @files = files.flatten.sort.uniq
       end

--- a/lib/yaml_normalizer/services/normalize.rb
+++ b/lib/yaml_normalizer/services/normalize.rb
@@ -11,6 +11,7 @@ module YamlNormalizer
     #   result = normalize.call
     class Normalize < Base
       include Helpers::Normalize
+      include Helpers::ParamParser
 
       # files is a sorted array of file path Strings
       attr_reader :files
@@ -19,6 +20,7 @@ module YamlNormalizer
       # more String that are interpreted as file glob pattern.
       # @param *args [Array<String>] a list of file glob patterns
       def initialize(*args)
+        parse_params(*args)
         files = args.each_with_object([]) { |a, o| o << Dir[a.to_s] }
         @files = files.flatten.sort.uniq
       end

--- a/lib/yaml_normalizer/version.rb
+++ b/lib/yaml_normalizer/version.rb
@@ -2,5 +2,5 @@
 
 module YamlNormalizer
   # The current Yaml Normalizer version
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end

--- a/spec/services/check_spec.rb
+++ b/spec/services/check_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe YamlNormalizer::Services::Check do
   let(:path) { "#{SpecConfig.data_path}#{File::SEPARATOR}" }
   let(:args) { ["#{path}#{name}"] }
 
+  include_examples :args_receving_service
+
   context 'parially invalid globbing inputs' do
     subject { described_class.new(*args) }
     let(:args) { ["#{path}*.1", :invalid, "#{path}1.*"] }

--- a/spec/services/normalize_spec.rb
+++ b/spec/services/normalize_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe YamlNormalizer::Services::Normalize do
   let(:path) { "#{SpecConfig.data_path}#{File::SEPARATOR}" }
   let(:args) { ["#{path}#{file}"] }
 
+  include_examples :args_receving_service
+
   context 'invalid args, no arg matches file' do
     subject { described_class.new(*args).call }
     let(:args) { ['lol', :foo, nil] }

--- a/spec/shared_examples/param_parser_shared_example.rb
+++ b/spec/shared_examples/param_parser_shared_example.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+# rubocop:disable Metrics/BlockLength
+shared_examples :args_receving_service do
+  describe 'param triggered methods' do
+    subject { described_class.new(*args) }
+
+    context 'when presented with version param' do
+      let(:args) { ['--version'] }
+
+      it 'prints the version of software' do
+        expect do
+          expect(subject).to receive(:print_version)
+          subject.call
+        end.to raise_error(SystemExit) { |e| expect(e.status).to be_zero }
+      end
+    end
+
+    context 'when presented with help param' do
+      let(:args) { ['--help'] }
+      it 'prints the help message' do
+        expect do
+          subject.call
+        end.to raise_error(SystemExit) { |e| expect(e.status).to be_zero }
+      end
+    end
+  end
+
+  context '#print_version' do
+    let(:args) { [] }
+    it 'prints the current version' do
+      expect do
+        subject.print_version
+      end.to output("#{YamlNormalizer::VERSION}\n").to_stdout
+    end
+  end
+end
+# rubocop:enable Metrics/BlockLength

--- a/spec/shared_examples/param_parser_shared_example.rb
+++ b/spec/shared_examples/param_parser_shared_example.rb
@@ -1,38 +1,32 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/BlockLength
 shared_examples :args_receving_service do
   describe 'param triggered methods' do
     subject { described_class.new(*args) }
 
     context 'when presented with version param' do
-      let(:args) { ['--version'] }
+      ['-v', '--version'].each do |param|
+        let(:args) { [param] }
 
-      it 'prints the version of software' do
-        expect do
-          expect(subject).to receive(:print_version)
-          subject.call
-        end.to raise_error(SystemExit) { |e| expect(e.status).to be_zero }
+        it 'prints the version of software' do
+          expect do
+            subject.call
+          end.to output("#{YamlNormalizer::VERSION}\n").to_stdout
+        end
       end
     end
 
     context 'when presented with help param' do
-      let(:args) { ['--help'] }
-      it 'prints the help message' do
-        expect do
-          subject.call
-        end.to raise_error(SystemExit) { |e| expect(e.status).to be_zero }
+      ['-h', '--help'].each do |param|
+        let(:args) { [param] }
+        it 'prints the help message' do
+          expect do
+            subject.call
+          end.to output("Usage: rspec [options] file1, file2...\n"\
+            "    -v, --version                    Prints the yaml_normalizer version\n"\
+            "    -h, --help                       Prints this help\n").to_stdout
+        end
       end
     end
   end
-
-  context '#print_version' do
-    let(:args) { [] }
-    it 'prints the current version' do
-      expect do
-        subject.print_version
-      end.to output("#{YamlNormalizer::VERSION}\n").to_stdout
-    end
-  end
 end
-# rubocop:enable Metrics/BlockLength

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,7 @@ $LOAD_PATH.unshift File.expand_path(File.join('..', '..', 'lib'), __FILE__)
 
 require './spec/ci_helper'
 
+ENV['ENV'] = 'test'
 unless defined?(Mutant)
   require 'simplecov'
   SimpleCov.start do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,12 @@ end
 
 require 'yaml_normalizer'
 
+Dir.foreach(File.join(File.dirname(__FILE__), 'shared_examples')) do |f|
+  next if ['.', '..'].include?(f)
+
+  require File.join(File.dirname(__FILE__), 'shared_examples', f)
+end
+
 # Configure unit test suite
 module SpecConfig
   module_function


### PR DESCRIPTION
To make our tool more easy to use via CLI I spent a moment to introduce options options for more convinient CLI usage the sample of functionality can be found below:

![yaml_normalize_versioning](https://user-images.githubusercontent.com/29885246/62118387-deeabe80-b2bd-11e9-9c50-7ede3ac8b507.gif)
