### PR TITLE
[yaml_normalizer] Reimplement Ext::Nested to fix bug on subhashes

### DIFF
--- a/lib/yaml_normalizer/ext/nested.rb
+++ b/lib/yaml_normalizer/ext/nested.rb
@@ -17,21 +17,21 @@ module YamlNormalizer
       #   => {"a"=>{"b"=>{"c"=>1}}, "b"=>{"x"=>2, "y"=>{"ok"=>true}, "z"=>4}}
       # @return [Hash] tree-shaped Hash
       def nested
-        tree = Hash.new { |h, k| h[k] = Hash.new(&h.default_proc) }
-        each { |key, val| nest_key(tree, key.to_s, val) }
-        tree.default_proc = nil
+        tree = {}
+        each { |key, val| nest_key(tree, key, val) }
         tree
       end
 
       private
 
-      def nest_key(hash, key, val)
-        if key.include?('.')
-          keys = key.split('.')
-          hash.dig(*keys[0..-2])[keys.fetch(-1)] = val
-        else
-          hash[key] = val
+      def nest_key(hash, dotted_key, val)
+        keys = dotted_key.to_s.split('.')
+        last_key = keys.pop.to_s
+        sub_hash = hash
+        keys.each do |key|
+          sub_hash = (sub_hash[key] ||= {})
         end
+        sub_hash[last_key] = val
       end
     end
   end

--- a/spec/nested_spec.rb
+++ b/spec/nested_spec.rb
@@ -13,7 +13,9 @@ RSpec.describe YamlNormalizer::Ext::Nested do
         'b.y.two' => nil,
         'no_dot' => 'ok',
         3 => String,
-        sym: 'ok' }
+        sym: 'ok',
+        nil => 'nil',
+        '' => 'empty' }
     end
 
     it 'does not modify the original object' do
@@ -26,11 +28,16 @@ RSpec.describe YamlNormalizer::Ext::Nested do
                                       'y' => { 'one' => true, 'two' => nil } },
                              'no_dot' => 'ok',
                              '3' => String,
-                             'sym' => 'ok')
+                             'sym' => 'ok',
+                             '' => 'empty')
     end
 
     it 'resets the default_proc' do
       expect(subject[:unknown]).to be_nil
+    end
+
+    it 'does not create unknown keys on access' do
+      expect(subject.dig('a', 'unknown')).to be_nil
     end
   end
 


### PR DESCRIPTION
The nested stuff should return a hash with no special behaviour accessing the keys.
I think this was intended by `tree.default_proc = nil`. The problem is, that the default_proc was not removed for all the subhashes created while nesting, so I stumbled accross very funny bugs like:

```ruby
h = { 'a.b.c' = 'val' }.extend(YamlNormalizer::Ext::Nested).nested
=> { 'a' => { 'b' => { 'c' => 'val' } } }
h['a']['foo']
=> {}
h
=> { 'a' => { 'b' => { 'c' => 'val' } }, 'foo' => {} }
```
This breaks some ymls saved with the YML-Editor for example.
I had to reimplement the whole nested stuff to fix this bug.